### PR TITLE
src/amy.c: Remove redundant setting of filter_logfreq_coefs[0]

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -437,7 +437,6 @@ void amy_add_event_internal(struct event e, uint16_t base_osc) {
         }
     }
 
-    if(AMY_IS_SET(e.filter_freq_coefs[COEF_CONST])) { float filter_logfreq = logfreq_of_freq(e.filter_freq_coefs[COEF_CONST]); d.param=FILTER_FREQ; d.data = *(uint32_t *)&filter_logfreq; add_delta_to_queue(d); }
     for (int i = 0; i < NUM_COMBO_COEFS; ++i) {
         if(AMY_IS_SET(e.filter_freq_coefs[i])) {
             float freq_coef = e.filter_freq_coefs[i];


### PR DESCRIPTION
Setting `filter_logfreq_coefs[COEF_CONST]` in amy_add_event_internal() is a special case because the specified value is in Hz which must be converted to logfreq units before storing.  However, this special case was implemented twice.  This change removes one of them.