### PR TITLE
src/amy.c: Naming an oscillator as a mod_source clears its amp[VEL].

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -909,8 +909,15 @@ void play_event(struct delta d) {
     }
     if(d.param == CLONE_OSC) { clone_osc(d.osc, *(int16_t *)&d.data); }
     if(d.param == RESET_OSC) { if(*(int16_t *)&d.data>(AMY_OSCS+1)) { amy_reset_oscs(); } else { reset_osc(*(int16_t *)&d.data); } }
-    // todo: event-only side effect, remove
-    if(d.param == MOD_SOURCE) { synth[d.osc].mod_source = *(uint16_t *)&d.data; synth[*(uint16_t *)&d.data].status = IS_MOD_SOURCE; }
+    if(d.param == MOD_SOURCE) {
+        uint16_t mod_osc = *(uint16_t *)&d.data;
+        synth[d.osc].mod_source = mod_osc;
+        // NOTE: These are event-only side effects.  A purist would strive to remove them.
+        // When an oscillator is named as a modulator, we change its state.
+        synth[mod_osc].status = IS_MOD_SOURCE;
+        // Remove default amplitude dependence on velocity when an oscillator is made a modulator.
+        synth[mod_osc].amp_coefs[COEF_VEL] = 0;
+    }
 
     if(d.param == RATIO) synth[d.osc].logratio = *(float *)&d.data;
 


### PR DESCRIPTION
We hit a problem where setting up an oscillator as an LFO using C led to a zero-amplitude modulator unless you explicitly cleared `amp_coef[COEF_VEL]`, the incorporation of the oscillator note velocity into its overall amplitude, which is set to 1.0 by default. 

However, modulation oscillators never have a nonzero velocity (that would lead to them being audible), so this dependence is unwanted.

With this change, `amp_coef[COEF_VEL]` is automatically cleared for a modulator oscillator when it is set as the `mod_source` for another oscillator.  This increases the undesirable magic side effects of `amy:play_event()`, but I am comfortable with this solution.

If you really wanted the modulating oscillator to depend on velocity, you could rewrite its amp coefficients *after* naming it as the `mod_source` for the dependent oscillator.