### PR TITLE
Mechanism to wake up oscs if amplitude changes

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -906,7 +906,6 @@ void play_event(struct delta d) {
     //if(trig) synth[d.osc].note_on_clock = total_samples;
 
     if ( PARAM_IS_COMBO_COEF(d.param, AMP) ||
-         PARAM_IS_COMBO_COEF(d.param, FILTER_FREQ) ||
          PARAM_IS_BP_COEF(d.param)) {
         // Changes to Amp/filter/EGs can potentially make a silence-suspended note come back.
         // Revive the note if it hasn't seen a note_off since the last note_on.
@@ -1248,7 +1247,8 @@ void amy_render(uint16_t start, uint16_t end, uint8_t core) {
             SAMPLE max_val = render_osc_wave(osc, core, per_osc_fb[core]);
             // check it's not off, just in case. todo, why do i care?
             // apply filter to osc if set
-            if(synth[osc].filter_type != FILTER_NONE) max_val = filter_process(per_osc_fb[core], osc, max_val);
+            if(synth[osc].filter_type != FILTER_NONE)
+                max_val = filter_process(per_osc_fb[core], osc, max_val);
             uint8_t handled = 0;
             if(amy_external_render_hook!=NULL) {
                 handled = amy_external_render_hook(osc, per_osc_fb[core], AMY_BLOCK_SIZE);

--- a/src/amy.h
+++ b/src/amy.h
@@ -94,9 +94,10 @@ enum coefs{
 #define SCHEDULED 1
 #define PLAYED 2
 #define AUDIBLE 3
-#define IS_MOD_SOURCE 4
-#define IS_ALGO_SOURCE 5
-#define STATUS_OFF 6
+#define AUDIBLE_SUSPENDED 4
+#define IS_MOD_SOURCE 5
+#define IS_ALGO_SOURCE 6
+#define STATUS_OFF 7
 
 // Envelope generator types (for synth[osc].env_type[eg]).
 #define ENVELOPE_NORMAL 0


### PR DESCRIPTION
In #164 we noted that once the noise osc within a Juno voice has hit zero amplitude, subsequent changes to its level will not introduce noise, because the `zero_amp_clock` mechanism has already taken that osc out of `AUDIBLE` status.

This change introduces a new `AUDIBLE_SUSPENDED` status for oscillators that have reached zero amplitude.  Then, if there are later events that modify the amplitude or envelope generator parameters for that osc, and provided it has not seen a note-off since the last note-on, those changes return it from `AUDIBLE_SUSPENDED` to `AUDIBLE`.  If, in fact, those parameter changes still leave the output at zero, the `max_val` check in `render_osc_wave()` will return it to `AUDIBLE_SUSPENDED` within a few frames.