### PR TITLE
Added wave=BYO_PARTIALS for cleaner BYO_PARTIALS syntax.

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -903,7 +903,7 @@ void osc_note_on(uint16_t osc, float initial_freq) {
     if(synth[osc].wave==NOISE) noise_note_on(osc);
     if(AMY_HAS_PARTIALS == 1) {
         //if(synth[osc].wave==PARTIAL)  partial_note_on(osc);
-        if(synth[osc].wave==PARTIALS) partials_note_on(osc);
+        if(synth[osc].wave==PARTIALS || synth[osc].wave==BYO_PARTIALS) partials_note_on(osc);
     }
     if(AMY_HAS_CUSTOM == 1) {
         if(synth[osc].wave==CUSTOM) custom_note_on(osc, initial_freq);
@@ -957,7 +957,8 @@ void play_event(struct delta d) {
         }
     }
     if(d.param == PHASE) { synth[d.osc].phase = *(PHASOR *)&d.data;  synth[d.osc].trigger_phase = *(PHASOR*)&d.data; } // PHASOR
-    if(d.param == PATCH) synth[d.osc].patch = *(uint16_t *)&d.data;
+    // For now, if the wave type is BYO_PARTIALS, negate the patch number (which is also num_partials) and treat like regular PARTIALS - partials_note_on knows what to do.
+    if(d.param == PATCH) synth[d.osc].patch = ((synth[d.osc].wave == BYO_PARTIALS) ? -1 : 1) * *(uint16_t *)&d.data;
     if(d.param == FEEDBACK) synth[d.osc].feedback = *(float *)&d.data;
 
     if(PARAM_IS_COMBO_COEF(d.param, AMP)) {
@@ -1106,7 +1107,7 @@ void play_event(struct delta d) {
                 //synth[d.osc].note_off_clock = total_samples;
                 //partial_note_off(d.osc);
                 #endif
-            } else if(synth[d.osc].wave==PARTIALS) {
+            } else if(synth[d.osc].wave==PARTIALS || synth[d.osc].wave==BYO_PARTIALS) {
                 #if AMY_HAS_PARTIALS == 1
                 AMY_UNSET(synth[d.osc].note_on_clock);
                 synth[d.osc].note_off_clock = total_samples;
@@ -1291,7 +1292,7 @@ SAMPLE render_osc_wave(uint16_t osc, uint8_t core, SAMPLE* buf) {
             if(synth[osc].wave == ALGO) max_val = render_algo(buf, osc, core);
             if(AMY_HAS_PARTIALS == 1) {
                 //if(synth[osc].wave == PARTIAL) max_val = render_partial(buf, osc);
-                if(synth[osc].wave == PARTIALS) max_val = render_partials(buf, osc);
+                if(synth[osc].wave == PARTIALS || synth[osc].wave == BYO_PARTIALS) max_val = render_partials(buf, osc);
             }
         }
         if(AMY_HAS_CUSTOM == 1) {

--- a/src/amy.h
+++ b/src/amy.h
@@ -86,8 +86,9 @@ enum coefs{
 #define ALGO 8
 #define PARTIAL 9
 #define PARTIALS 10
-#define CUSTOM 11
-#define WAVE_OFF 12
+#define BYO_PARTIALS 11
+#define CUSTOM 12
+#define WAVE_OFF 13
 
 // synth[].status values
 #define EMPTY 0

--- a/test.py
+++ b/test.py
@@ -179,7 +179,7 @@ class TestBuildYourOwnPartials(AmyTest):
     num_partials = 16
     base_freq = 261.63
     base_osc = 0
-    amy.send(time=0, osc=base_osc, wave=amy.PARTIALS, patch=-num_partials)
+    amy.send(time=0, osc=base_osc, wave=amy.BYO_PARTIALS, num_partials=num_partials)
     for i in range(1, num_partials + 1):
       # Set up each partial as the corresponding harmonic of the base_freq, with an amplitude of 1/N, 50ms attack, and a decay of 1 sec / N
       amy.send(osc=base_osc + i, wave=amy.PARTIAL, freq=base_freq * i, bp0='50,%.2f,%d,0,0,0' % ((1.0 / i), 1000 // i))
@@ -191,7 +191,7 @@ class TestBYOPVoices(AmyTest):
   def run(self):
     # Does build-your-own-partials work with the voices mechanism?
     num_partials = 4
-    s = '1024,v0w%dp%dZ' % (amy.PARTIALS, -num_partials) + ''.join(['v%dw%dZ' % (i + 1, amy.PARTIAL) for i in range(num_partials)])
+    s = '1024,v0w%dp%dZ' % (amy.BYO_PARTIALS, num_partials) + ''.join(['v%dw%dZ' % (i + 1, amy.PARTIAL) for i in range(num_partials)])
     amy.send(store_patch=s)
     amy.send(time=0, voices='0,1,2,3', load_patch=1024)
     for i in range(num_partials):
@@ -206,7 +206,7 @@ class TestBYOPNoteOff(AmyTest):
   def run(self):
     # Partials were not seeing note-offs.
     num_partials = 8
-    s = '1024,v0w%dp%dZ' % (amy.PARTIALS, -num_partials) + ''.join(['v%dw%dZ' % (i + 1, amy.PARTIAL) for i in range(num_partials)])
+    s = '1024,v0w%dp%dZ' % (amy.BYO_PARTIALS, num_partials) + ''.join(['v%dw%dZ' % (i + 1, amy.PARTIAL) for i in range(num_partials)])
     amy.send(store_patch=s)
     amy.send(time=0, voices='0,1', load_patch=1024)
     for i in range(num_partials):


### PR DESCRIPTION
The old hack of using a negative patch number with wave=PARTIALS still works, and indeed BYO_PARTIALS num_partials=... uses the same wire-code letter as patch, and the message decoder simply flips the sign of it for BYO.  Thereafter PARTIALS and BYO_PARTIALS are treated the same. 

TODO: Cleanup the distinction between PARTIALS and BYO_PARTIALS in the code, which is currently mediated by looking for a negative patch value in the individual PARTIAL oscs, even though they don't need or care about patch number for anything else.