### PR TITLE
amy.py: Tolerate amy.send(time=None).

### DIFF
--- a/amy.py
+++ b/amy.py
@@ -184,9 +184,12 @@ def message(**kwargs):
     m = ""
     for key, arg in kwargs.items():
         if arg is None:
-            raise ValueError
-        wire_code, type_code = kw_map[key]
-        m += wire_code + arg_handlers[type_code](arg)
+            if key != 'time':
+                raise ValueError('No arg for key ' + key)
+            # Just ignore time=None
+        else:
+            wire_code, type_code = kw_map[key]
+            m += wire_code + arg_handlers[type_code](arg)
     #print("message:", m)
     return m + 'Z'
 


### PR DESCRIPTION
I made Amy.send() raise a ValueError if args were passed with value None, but it turns out we do this with time= a lot.