### PR TITLE
README.md: Fix the FM example to clear amp[VEL].

### DIFF
--- a/src/examples.c
+++ b/src/examples.c
@@ -296,44 +296,44 @@ void example_fm(uint32_t start) {
     // Direct construction of an FM tone, as in the documentation.
     struct event e;
 
-    // Output oscillator (op 1)
-    e = amy_default_event();
-    e.time = start;
-    e.osc = 7;
-    e.wave = SINE;
-    e.ratio = 0.2f;
-    e.amp_coefs[COEF_CONST] = 0.1f;
-    e.amp_coefs[COEF_VEL] = 0;
-    e.amp_coefs[COEF_EG0] = 1.0f;
-    strcpy(e.bp0, "0,1,1000,0,0,0");
-    amy_add_event(e);
-
     // Modulating oscillator (op 2)
     e = amy_default_event();
     e.time = start;
-    e.osc = 8;
+    e.osc = 9;
     e.wave = SINE;
     e.ratio = 1.0f;
     e.amp_coefs[COEF_CONST] = 1.0f;
     e.amp_coefs[COEF_VEL] = 0;
     e.amp_coefs[COEF_EG0] = 0;
     amy_add_event(e);
-  
+
+    // Output oscillator (op 1)
+    e = amy_default_event();
+    e.time = start;
+    e.osc = 8;
+    e.wave = SINE;
+    e.ratio = 0.2f;
+    e.amp_coefs[COEF_CONST] = 1.0f;
+    e.amp_coefs[COEF_VEL] = 0;
+    e.amp_coefs[COEF_EG0] = 1.0f;
+    strcpy(e.bp0, "0,1,1000,0,0,0");
+    amy_add_event(e);
+
     // ALGO control oscillator
     e = amy_default_event();
     e.time = start;
-    e.osc = 9;
+    e.osc = 7;
     e.wave = ALGO;
     e.algorithm = 1;  // algo 1 has op 2 driving op 1 driving output (plus a second chain for ops 6,5,4,3).
-    strcpy(e.algo_source, ",,,,8,7");
+    strcpy(e.algo_source, ",,,,9,8");
     amy_add_event(e);
 
     // Add a note on event.
     e = amy_default_event();
     e.time = start + 100;
-    e.osc = 9;
+    e.osc = 7;
     e.midi_note = 60;
-    e.velocity = 25.0f; // this is very quiet as constructed -- just two ops
+    e.velocity = 1.0f;
     amy_add_event(e);
 }
 


### PR DESCRIPTION
The example that plays a couple of FM tone by directly configuring the individual sine oscillators had been broken since we made the change that unspecified ControlCoefficients are left unchanged (rather than being cleared to zero).  Because FM component oscs do not see the velocity of their parent note, it's important to include `amp={'vel': 0}` (to clear the default weight of 1), otherwise the operator oscs will always have zero output, because they see a velocity of zero.

Doing this, I realize that `ratio` is really just a special case of ControlCoefficients.  Instead of `ratio=0.2` (and the associated explanation), that's really just `freq={'const':  52.326, 'note': 1}`, i.e. it follows the note frequency, but relative to 0.2 x the default frequency (of 261.63 Hz).  We could change that.  Would it make things easier to understand?