### PR TITLE
reset_osc with RESET_TIMEBASE resets time clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Here's the full list:
 | `r`    | `voices` | int[,int] | Comma separated list of voices to send message to, or load patch into. |
 | `R`    | `resonance` | float | Q factor of variable filter, 0.5-16.0. default 0.7 |
 | `s`    | `pitch_bend` | float | Sets the global pitch bend, by default modifying all note frequencies by (fractional) octaves up or down |
-| `S`    | `reset`  | uint | Resets given oscillator. set to > OSCS to reset all oscillators, gain and EQ. |
+| `S`    | `reset_osc`  | uint | Resets given oscillator. set to RESET_ALL_OSCS to reset all oscillators, gain and EQ. RESET_TIMEBASE resets the clock. RESET_AMY restarts AMY.|
 | `t`    | `time` | uint | Request playback time relative to some fixed start point on your host, in ms. Allows precise future scheduling. |
 | `T`    | `eg0_type` | uint 0-3 | Type for Envelope Generator 0 - 0: Normal (RC-like) / 1: Linear / 2: DX7-style / 3: True exponential. |
 | `u`    | `store_patch` | number,string | Store up to 32 patches in RAM with ID number (1024-1055) and AMY message after a comma. Must be sent alone |

--- a/amy.py
+++ b/amy.py
@@ -8,6 +8,7 @@ MAX_QUEUE = 400
 SINE, PULSE, SAW_DOWN, SAW_UP, TRIANGLE, NOISE, KS, PCM, ALGO, PARTIAL, PARTIALS, BYO_PARTIALS, CUSTOM, OFF = range(14)
 FILTER_NONE, FILTER_LPF, FILTER_BPF, FILTER_HPF, FILTER_LPF24 = range(5)
 ENVELOPE_NORMAL, ENVELOPE_LINEAR, ENVELOPE_DX7, ENVELOPE_TRUE_EXPONENTIAL = range(4)
+RESET_ALL_OSCS, RESET_TIMEBASE, RESET_AMY = (8192, 16384, 32768)
 AMY_LATENCY_MS = 0
 AMY_MAX_DRIFT_MS = 20000
 
@@ -318,7 +319,7 @@ def reset(osc=None, **kwargs):
     if(osc is not None):
         send(reset=osc, **kwargs)
     else:
-        send(reset=1000, **kwargs) # reset > AMY_OSCS resets all oscs
+        send(reset=RESET_ALL_OSCS, **kwargs) 
 
 def volume(volume, client = None):
     send(client=client, volume=volume)

--- a/amy.py
+++ b/amy.py
@@ -318,7 +318,7 @@ def reset(osc=None, **kwargs):
     if(osc is not None):
         send(reset=osc, **kwargs)
     else:
-        send(reset=10000, **kwargs) # reset > AMY_OSCS resets all oscs
+        send(reset=1000, **kwargs) # reset > AMY_OSCS resets all oscs
 
 def volume(volume, client = None):
     send(client=client, volume=volume)

--- a/src/amy.c
+++ b/src/amy.c
@@ -1007,16 +1007,17 @@ void play_event(struct delta d) {
     }
     if(d.param == CLONE_OSC) { clone_osc(d.osc, *(int16_t *)&d.data); }
     if(d.param == RESET_OSC) { 
-        // If reset_osc > 9999, also reset time base
-        // In the future, we want to use this as a "hard reset" that e.g. resets the chip this is running on, or resets the audio driver.
-        if(*(int16_t *)&d.data>9999) {
+        if(*(int16_t *)&d.data & RESET_AMY) {
+            amy_stop();
+            amy_start(amy_global.cores, amy_global.has_chorus, amy_global.has_reverb, amy_global.has_echo);
+        }
+        if(*(int16_t *)&d.data & RESET_TIMEBASE) {
             amy_reset_sysclock();
-            amy_reset_oscs();
-        // If reset_osc > AMY_OSCS but < 10000, then just reset oscs
-        } else if(*(int16_t *)&d.data>(AMY_OSCS+1)) { 
+        }
+        if(*(int16_t *)&d.data & RESET_ALL_OSCS) { 
             amy_reset_oscs(); 
-        // Else, just reset the given osc.
-        } else { 
+        }
+        if(*(int16_t *)&d.data < AMY_OSCS+1) { 
             reset_osc(*(int16_t *)&d.data); 
         } 
     }

--- a/src/amy.c
+++ b/src/amy.c
@@ -1006,7 +1006,20 @@ void play_event(struct delta d) {
             AMY_UNSET(synth[d.osc].chained_osc);
     }
     if(d.param == CLONE_OSC) { clone_osc(d.osc, *(int16_t *)&d.data); }
-    if(d.param == RESET_OSC) { if(*(int16_t *)&d.data>(AMY_OSCS+1)) { amy_reset_oscs(); } else { reset_osc(*(int16_t *)&d.data); } }
+    if(d.param == RESET_OSC) { 
+        // If reset_osc > 9999, also reset time base
+        // In the future, we want to use this as a "hard reset" that e.g. resets the chip this is running on, or resets the audio driver.
+        if(*(int16_t *)&d.data>9999) {
+            amy_reset_sysclock();
+            amy_reset_oscs();
+        // If reset_osc > AMY_OSCS but < 10000, then just reset oscs
+        } else if(*(int16_t *)&d.data>(AMY_OSCS+1)) { 
+            amy_reset_oscs(); 
+        // Else, just reset the given osc.
+        } else { 
+            reset_osc(*(int16_t *)&d.data); 
+        } 
+    }
     if(d.param == MOD_SOURCE) {
         uint16_t mod_osc = *(uint16_t *)&d.data;
         synth[d.osc].mod_source = mod_osc;

--- a/src/amy.h
+++ b/src/amy.h
@@ -106,6 +106,11 @@ enum coefs{
 #define ENVELOPE_DX7 2
 #define ENVELOPE_TRUE_EXPONENTIAL 3
 
+// Reset masks
+#define RESET_ALL_OSCS 8192
+#define RESET_TIMEBASE 16384
+#define RESET_AMY 32768
+
 
 #define true 1
 #define false 0

--- a/src/examples.c
+++ b/src/examples.c
@@ -9,7 +9,7 @@ extern void delay_ms(uint32_t ms);
 void example_reset(uint32_t start) {
     struct event e = amy_default_event();
     e.osc = 0;
-    e.reset_osc = 1000;
+    e.reset_osc = RESET_ALL_OSCS;
     e.time = start;
     amy_add_event(e);
 }

--- a/test.py
+++ b/test.py
@@ -33,7 +33,6 @@ class AmyTest:
 
   def __init__(self):
     amy.restart()
-    amy.send(time=0)  # Defeat "computed_delta" offset.
 
   def test(self):
 


### PR DESCRIPTION
For _reasons_ (Amy chip, and amy-web) I would like to be able to send AMY a message to reset its time base to 0, so that future calls with time=x start from 0. 

I _personally_ see this as a form of “reset”. We already have the notion that reset_osc set to > AMY_OSCS (120) resets all of the oscs. 

What I posit to you is what if we had an even bigger reset, like reset_osc = 10000 , that also restarted audio (including the audio clock?) 

