### PR TITLE
Remove clone_osc from AMY

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,6 @@ Here's the full list:
 | `b`    | `feedback` | float 0-1 | Use for the ALGO synthesis type in FM or for karplus-strong, or to indicate PCM looping (0 off, >0, on) |
 | `B`    | `bp1`    | string      | Breakpoints for Envelope Generator 1. See bp0 |
 | `c`    | `chained_osc` |  uint 0 to OSCS-1 | Chained oscillator.  Note/velocity events to this oscillator will propagate to chained oscillators.  VCF is run only for first osc in chain, but applies to all oscs in chain. |
-| `C`    | `clone_osc` | uint 0 to OSCS-1 | Clone oscillator.  Most parameters from the named other oscillator are copied into this one. |
 | `d`    | `duty`   |  float[,float...] | Duty cycle for pulse wave, ControlCoefficients, defaults to 0.5 |
 | `D`    | `debug`  |  uint, 2-4  | 2 shows queue sample, 3 shows oscillator data, 4 shows modified oscillator. Will interrupt audio! |
 | `f`    | `freq`   |  float[,float...]      | Frequency of oscillator, set of ControlCoefficients.  Default is 0,1,0,0,0,0,1 (from `note` pitch plus `pitch_bend`) |

--- a/amy.py
+++ b/amy.py
@@ -157,7 +157,7 @@ def message(**kwargs):
     # I=int, F=float, S=str, L=list, C=ctrl_coefs
     kw_map = {'osc': 'vI', 'wave': 'wI', 'note': 'nF', 'vel': 'lF', 'amp': 'aC', 'freq': 'fC', 'duty': 'dC', 'feedback': 'bF', 'time': 'tI',
               'reset': 'SI', 'phase': 'PF', 'pan': 'QC', 'client': 'cI', 'volume': 'vF', 'pitch_bend': 'sF', 'filter_freq': 'FC', 'resonance': 'RF',
-              'bp0': 'AL', 'bp1': 'BL', 'eg0_type': 'TI', 'eg1_type': 'XI', 'debug': 'DI', 'chained_osc': 'cI', 'mod_source': 'LI', 'clone_osc': 'CI',
+              'bp0': 'AL', 'bp1': 'BL', 'eg0_type': 'TI', 'eg1_type': 'XI', 'debug': 'DI', 'chained_osc': 'cI', 'mod_source': 'LI', 
               'eq': 'xL', 'filter_type': 'GI', 'algorithm': 'oI', 'ratio': 'IF', 'latency_ms': 'NI', 'algo_source': 'OL',
               'chorus': 'kL', 'reverb': 'hL', 'echo': 'ML', 'load_patch': 'KI', 'store_patch': 'uS', 'voices': 'rL',
               'external_channel': 'WI', 'portamento': 'mI',

--- a/src/amy.c
+++ b/src/amy.c
@@ -381,7 +381,6 @@ struct event amy_default_event() {
     AMY_UNSET(e.portamento_ms);
     AMY_UNSET(e.filter_type);
     AMY_UNSET(e.chained_osc);
-    AMY_UNSET(e.clone_osc);
     AMY_UNSET(e.mod_source);
     AMY_UNSET(e.eq_l);
     AMY_UNSET(e.eq_m);
@@ -521,7 +520,6 @@ void amy_add_event_internal(struct event e, uint16_t base_osc) {
     if(AMY_IS_SET(e.resonance)) { d.param=RESONANCE; d.data = *(uint32_t *)&e.resonance; add_delta_to_queue(d); }
     if(AMY_IS_SET(e.portamento_ms)) { d.param=PORTAMENTO; d.data = *(uint32_t *)&e.portamento_ms; add_delta_to_queue(d); }
     if(AMY_IS_SET(e.chained_osc)) { e.chained_osc += base_osc; d.param=CHAINED_OSC; d.data = *(uint32_t *)&e.chained_osc; add_delta_to_queue(d); }
-    if(AMY_IS_SET(e.clone_osc)) { e.clone_osc += base_osc; d.param=CLONE_OSC; d.data = *(uint32_t *)&e.clone_osc; add_delta_to_queue(d); }
     if(AMY_IS_SET(e.reset_osc)) { e.reset_osc += base_osc; d.param=RESET_OSC; d.data = *(uint32_t *)&e.reset_osc; add_delta_to_queue(d); }
     if(AMY_IS_SET(e.mod_source)) { e.mod_source += base_osc; d.param=MOD_SOURCE; d.data = *(uint32_t *)&e.mod_source; add_delta_to_queue(d); }
     if(AMY_IS_SET(e.filter_type)) { d.param=FILTER_TYPE; d.data = *(uint32_t *)&e.filter_type; add_delta_to_queue(d); }
@@ -580,63 +578,7 @@ end:
 }
 
 
-void clone_osc(uint16_t i, uint16_t f) {
-    // Set all the synth state to the values from another osc.
-    //fprintf(stderr, "cloning osc %d from %d\n", i, f);
-    //reset_osc(i);  // Causes current voices to stop on param change...
-    synth[i].wave = synth[f].wave;
-    synth[i].patch = synth[f].patch;
-    //synth[i].midi_note = synth[f].midi_note;
-    for (int j = 0; j < NUM_COMBO_COEFS; ++j)
-        synth[i].amp_coefs[j] = synth[f].amp_coefs[j];
-    for (int j = 0; j < NUM_COMBO_COEFS; ++j)
-        synth[i].logfreq_coefs[j] = synth[f].logfreq_coefs[j];
-    for (int j = 0; j < NUM_COMBO_COEFS; ++j)
-        synth[i].filter_logfreq_coefs[j] = synth[f].filter_logfreq_coefs[j];
-    for (int j = 0; j < NUM_COMBO_COEFS; ++j)
-        synth[i].duty_coefs[j] = synth[f].duty_coefs[j];
-    for (int j = 0; j < NUM_COMBO_COEFS; ++j)
-        synth[i].pan_coefs[j] = synth[f].pan_coefs[j];
-    synth[i].feedback = synth[f].feedback;
-    //synth[i].phase = synth[f].phase;
-    //synth[i].volume = synth[f].volume;
-    synth[i].eq_l = synth[f].eq_l;
-    synth[i].eq_m = synth[f].eq_m;
-    synth[i].eq_h = synth[f].eq_h;
-    synth[i].logratio = synth[f].logratio;
-    synth[i].resonance = synth[f].resonance;
-    synth[i].portamento_alpha = synth[f].portamento_alpha;
-    //synth[i].velocity = synth[f].velocity;
-    //synth[i].step = synth[f].step;
-    //synth[i].sample = synth[f].sample;
-    //synth[i].mod_value = synth[f].mod_value;
-    //synth[i].substep = synth[f].substep;
-    //synth[i].status = synth[f].status;
-    //synth[i].chained_osc = synth[f].chained_osc + (f - i);  // Can't do this because we don't have a way to unset it afterwards.  Have to manually set chained_osc after clone.
-    AMY_UNSET(synth[i].chained_osc);
-    synth[i].mod_source = synth[f].mod_source;    // It's OK to have multiple oscs with the same mod source.  But if we set it, then clone other params, we overwrite it.
-    //synth[i].note_on_clock = synth[f].note_on_clock;
-    //synth[i].note_off_clock = synth[f].note_off_clock;
-    //synth[i].zero_amp_clock = synth[f].zero_amp_clock;
-    //synth[i].mod_value_clock = synth[f].mod_value_clock;
-    synth[i].filter_type = synth[f].filter_type;
-    //synth[i].hpf_state[0] = synth[f].hpf_state[0];
-    //synth[i].hpf_state[1] = synth[f].hpf_state[1];
-    //synth[i].dc_offset = synth[f].dc_offset;
-    synth[i].algorithm = synth[f].algorithm;
-    //for(uint8_t j=0;j<MAX_ALGO_OPS;j++) synth[i].algo_source[j] = synth[f].algo_source[j];  // RISKY - end up allocating secondary oscs to multiple mains.
-    for(uint8_t j=0;j<MAX_BREAKPOINT_SETS;j++) {
-        for(uint8_t k=0;k<MAX_BREAKPOINTS;k++) {
-            synth[i].breakpoint_times[j][k] = synth[f].breakpoint_times[j][k];
-            synth[i].breakpoint_values[j][k] = synth[f].breakpoint_values[j][k];
-        }
-        synth[i].eg_type[j] = synth[f].eg_type[j];
-    }
-    //for(uint8_t j=0;j<MAX_BREAKPOINT_SETS;j++) { synth[i].last_scale[j] = synth[f].last_scale[j]; }
-    //synth[i].last_two[0] = synth[f].last_two[0];
-    //synth[i].last_two[1] = synth[f].last_two[1];
-    //synth[i].lut = synth[f].lut;
-}
+
 
 void reset_osc(uint16_t i ) {
     // set all the synth state to defaults
@@ -1005,7 +947,6 @@ void play_event(struct delta d) {
         else
             AMY_UNSET(synth[d.osc].chained_osc);
     }
-    if(d.param == CLONE_OSC) { clone_osc(d.osc, *(int16_t *)&d.data); }
     if(d.param == RESET_OSC) { if(*(int16_t *)&d.data>(AMY_OSCS+1)) { amy_reset_oscs(); } else { reset_osc(*(int16_t *)&d.data); } }
     if(d.param == MOD_SOURCE) {
         uint16_t mod_osc = *(uint16_t *)&d.data;
@@ -1752,7 +1693,7 @@ struct event amy_parse_message(char * message) {
                         case 'B': copy_param_list_substring(e.bp1, message + start); e.bp_is_set[1] = 1; break;
                         case 'b': e.feedback = atoff(message+start); break;
                         case 'c': e.chained_osc = atoi(message + start); break;
-                        case 'C': e.clone_osc = atoi(message + start); break;
+                        /* C available */
                         case 'd': parse_coef_message(message + start, e.duty_coefs);break;
                         case 'D': show_debug(atoi(message + start)); break;
                         case 'f': parse_coef_message(message + start, e.freq_coefs);break;

--- a/src/amy.h
+++ b/src/amy.h
@@ -289,7 +289,6 @@ struct event {
     char bp1[MAX_PARAM_LEN];
     uint8_t eg_type[MAX_BREAKPOINT_SETS];
     char voices[MAX_PARAM_LEN];
-    uint16_t clone_osc;  // Only used as a flag.
     uint16_t reset_osc;
     uint8_t status;
 };

--- a/test.py
+++ b/test.py
@@ -443,12 +443,11 @@ class TestFlutesEq(AmyTest):
 
   def run(self):
     amy.send(time=0, eq="-15,8,8")
-    amy.send(time=0, osc=0, wave=amy.SAW_UP, filter_type=amy.FILTER_LPF24, resonance=1.75,
-             bp0='200,1,9800,0,100,0',
-             bp1='200,1,9800,0,100,0',
-             filter_freq='242,0.323'),
-    amy.send(time=0, osc=1, clone_osc=0)
-    amy.send(time=0, osc=2, clone_osc=0)
+    osc_args = {'time':0, 'wave':amy.SAW_UP, 'filter_type':amy.FILTER_LPF24, 'resonance':1.75, 
+        'bp0':'200,1,9800,0,100,0', 'bp1':'200,1,9800,0,100,0', 'filter_freq':'242,0.323'}
+    amy.send(osc=0, **osc_args)
+    amy.send(osc=1, **osc_args)
+    amy.send(osc=2, **osc_args)
     amy.send(time=100, osc=0, note=48, vel=0.5)
     amy.send(time=200, osc=1, note=52, vel=0.5)
     amy.send(time=300, osc=2, note=55, vel=0.5)

--- a/timing.py
+++ b/timing.py
@@ -287,12 +287,13 @@ class TestTiming(AmyTest):
   """Run LPF24 to see how it times."""
 
   def run(self):
-    amy.send(time=0, osc=0, wave=amy.SAW_UP, filter_freq='16,0,0,0,10', resonance=0.75, filter_type=amy.FILTER_LPF24,
-             bp1='3,1,200,0.5,200,0')
-    amy.send(time=0, osc=1, clone_osc=0)
-    amy.send(time=0, osc=2, clone_osc=0)
-    amy.send(time=0, osc=3, clone_osc=0)
-    amy.send(time=0, osc=4, clone_osc=0)
+    osc_args = {"time":0, 'wave':amy.SAW_UP, 'filter_freq':'16,0,0,0,10', 'resonance':0.75, 'filter_type':amy.FILTER_LPF24,
+        'bp1':'3,1,200,0.5,200,0'}
+    amy.send(osc=0, **osc_args)
+    amy.send(osc=1, **osc_args)
+    amy.send(osc=2, **osc_args)
+    amy.send(osc=3, **osc_args)
+    amy.send(osc=4, **osc_args)
     amy.send(time=50, osc=0, note=48, vel=1)
     amy.send(time=100, osc=1, note=51, vel=1)
     amy.send(time=150, osc=2, note=54, vel=1)


### PR DESCRIPTION
clone_osc was used early on in juno development, but subsumed by `voices`. It's no longer used anywhere except for two tests, so I rewrote those and removed clone_osc (which was mostly commented out code anyway.) 

