### PR TITLE
A minor documentation fix, and addition of a missing file in pico's cmakelists

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ amy_start(/* cores= */ 2, /* reverb= */ 1, /* chorus= */ 1, /* echo */ 1);
 ...
 ... {
     // For each sample block:
-    amy_prepare(); // prepare to render this block
+    amy_prepare_buffer(); // prepare to render this block
     amy_render(0, OSCS/2, 0); // render oscillators 0 - OSCS/2 on core 0
     // on the other core... 
     amy_render(OSCS/2, OSCS, 1); // render oscillators OSCS/2-OSCS on core 1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ if (TARGET tinyusb_device)
             amy-example-rp2040.c
             algorithms.c
             amy.c
+            transfer.c
             delay.c
             envelope.c
             custom.c


### PR DESCRIPTION
Note that I have not tested the pico `CMakeLists.txt` change, I used those files to make my own `CMakeLists.txt` for my own project (non-pico), and noticed that the code wouldn't compile if I didn't add the `transfer.c` file.