### PR TITLE
Sequencer in AMY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,12 @@ all: default
 
 SOURCES = src/algorithms.c src/amy.c src/envelope.c src/examples.c \
 	src/filters.c src/oscillators.c src/pcm.c src/partials.c src/custom.c \
-	src/delay.c src/log2_exp2.c src/patches.c src/transfer.c
+	src/delay.c src/log2_exp2.c src/patches.c src/transfer.c src/sequencer.c
 
 OBJECTS = $(patsubst %.c, %.o, src/algorithms.c src/amy.c src/envelope.c \
 	src/delay.c src/partials.c src/custom.c src/patches.c \
 	src/examples.c src/filters.c src/oscillators.c src/pcm.c src/log2_exp2.c \
-	src/libminiaudio-audio.c src/transfer.c)
+	src/libminiaudio-audio.c src/transfer.c src/sequencer.c)
  
 HEADERS = $(wildcard src/*.h) src/amy_config.h
 HEADERS_BUILD := $(filter-out src/patches.h,$(HEADERS))

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Here's the full list:
 | `f`    | `freq`   |  float[,float...]      | Frequency of oscillator, set of ControlCoefficients.  Default is 0,1,0,0,0,0,1 (from `note` pitch plus `pitch_bend`) |
 | `F`    | `filter_freq` | float[,float...]  | Center/break frequency for variable filter, set of ControlCoefficients |
 | `G`    | `filter_type` | 0-4 | Filter type: 0 = none (default.) 1 = lowpass, 2 = bandpass, 3 = highpass, 4 = double-order lowpass. |
+| `H`    | `sequence` | int,int,int | Tick number, divider number, tag number for sequencing | 
 | `h`    | `reverb` | float[,float,float,float] | Reverb parameters -- level, liveness, damping, xover: Level is for output mix; liveness controls decay time, 1 = longest, default 0.85; damping is extra decay of high frequencies, default 0.5; xover is damping crossover frequency, default 3000 Hz. |
 | `I`    | `ratio`  | float | For ALGO types, ratio of modulator frequency to  base note frequency / For the PARTIALS base note, ratio controls the speed of the playback |
 | `k`    | `chorus` | float[,float,float,float] | Chorus parameters -- level, delay, freq, depth: Level is for output mix (0 to turn off); delay is max in samples (320); freq is LFO rate in Hz (0.5); depth is proportion of max delay (0.5). |

--- a/amy.py
+++ b/amy.py
@@ -160,7 +160,7 @@ def message(**kwargs):
               'bp0': 'AL', 'bp1': 'BL', 'eg0_type': 'TI', 'eg1_type': 'XI', 'debug': 'DI', 'chained_osc': 'cI', 'mod_source': 'LI', 
               'eq': 'xL', 'filter_type': 'GI', 'algorithm': 'oI', 'ratio': 'IF', 'latency_ms': 'NI', 'algo_source': 'OL', 'load_sample': 'zL',
               'chorus': 'kL', 'reverb': 'hL', 'echo': 'ML', 'load_patch': 'KI', 'store_patch': 'uS', 'voices': 'rL',
-              'external_channel': 'WI', 'portamento': 'mI',
+              'external_channel': 'WI', 'portamento': 'mI', 'sequence': 'HL', 
               'patch': 'pI', 'num_partials': 'pI', # Note alaising.
               }
     arg_handlers = {

--- a/amy.py
+++ b/amy.py
@@ -160,7 +160,7 @@ def message(**kwargs):
               'bp0': 'AL', 'bp1': 'BL', 'eg0_type': 'TI', 'eg1_type': 'XI', 'debug': 'DI', 'chained_osc': 'cI', 'mod_source': 'LI', 
               'eq': 'xL', 'filter_type': 'GI', 'algorithm': 'oI', 'ratio': 'IF', 'latency_ms': 'NI', 'algo_source': 'OL', 'load_sample': 'zL',
               'chorus': 'kL', 'reverb': 'hL', 'echo': 'ML', 'load_patch': 'KI', 'store_patch': 'uS', 'voices': 'rL',
-              'external_channel': 'WI', 'portamento': 'mI', 'sequence': 'HL', 
+              'external_channel': 'WI', 'portamento': 'mI', 'sequence': 'HL', 'tempo': 'jF',
               'patch': 'pI', 'num_partials': 'pI', # Note alaising.
               }
     arg_handlers = {

--- a/src/amy.c
+++ b/src/amy.c
@@ -313,6 +313,7 @@ int8_t global_init() {
     amy_global.volume = 1.0f;
     amy_global.pitch_bend = 0;
     amy_global.latency_ms = 0;
+    amy_global.tempo = 108.0; 
     amy_global.eq[0] = F2S(1.0f);
     amy_global.eq[1] = F2S(1.0f);
     amy_global.eq[2] = F2S(1.0f);
@@ -371,6 +372,7 @@ struct event amy_default_event() {
     AMY_UNSET(e.midi_note);
     AMY_UNSET(e.volume);
     AMY_UNSET(e.pitch_bend);
+    AMY_UNSET(e.tempo);
     AMY_UNSET(e.latency_ms);
     AMY_UNSET(e.ratio);
     for (int i = 0; i < NUM_COMBO_COEFS; ++i) {
@@ -519,6 +521,7 @@ void amy_add_event_internal(struct event e, uint16_t base_osc) {
     if(AMY_IS_SET(e.volume)) { d.param=VOLUME; d.data = *(uint32_t *)&e.volume; add_delta_to_queue(d); }
     if(AMY_IS_SET(e.pitch_bend)) { d.param=PITCH_BEND; d.data = *(uint32_t *)&e.pitch_bend; add_delta_to_queue(d); }
     if(AMY_IS_SET(e.latency_ms)) { d.param=LATENCY; d.data = *(uint32_t *)&e.latency_ms; add_delta_to_queue(d); }
+    if(AMY_IS_SET(e.tempo)) { d.param=TEMPO; d.data = *(uint32_t *)&e.tempo; add_delta_to_queue(d); }
     if(AMY_IS_SET(e.ratio)) { float logratio = log2f(e.ratio); d.param=RATIO; d.data = *(uint32_t *)&logratio; add_delta_to_queue(d); }
     if(AMY_IS_SET(e.resonance)) { d.param=RESONANCE; d.data = *(uint32_t *)&e.resonance; add_delta_to_queue(d); }
     if(AMY_IS_SET(e.portamento_ms)) { d.param=PORTAMENTO; d.data = *(uint32_t *)&e.portamento_ms; add_delta_to_queue(d); }
@@ -1021,6 +1024,7 @@ void play_event(struct delta d) {
     if(d.param == VOLUME) amy_global.volume = *(float *)&d.data;
     if(d.param == PITCH_BEND) amy_global.pitch_bend = *(float *)&d.data;
     if(d.param == LATENCY) { amy_global.latency_ms = *(uint16_t *)&d.data; }
+    if(d.param == TEMPO) { amy_global.tempo = *(float *)&d.data; sequencer_recompute(); }
     if(d.param == EQ_L) amy_global.eq[0] = F2S(powf(10, *(float *)&d.data / 20.0));
     if(d.param == EQ_M) amy_global.eq[1] = F2S(powf(10, *(float *)&d.data / 20.0));
     if(d.param == EQ_H) amy_global.eq[2] = F2S(powf(10, *(float *)&d.data / 20.0));
@@ -1582,85 +1586,63 @@ float atoff(const char *s) {
     return whole + frac;
 }
 
-int parse_float_list_message(char *message, float *vals, int max_num_vals, float skipped_val) {
-    // Return the number of values extracted from message.
-    uint16_t c = 0, last_c;
-    uint16_t stop = strspn(message, " -0123456789,.");  // Note: space AND period.
-    int num_vals_received = 0;
-    while(c < stop && num_vals_received < max_num_vals) {
-        *vals = atoff(message + c);
-        // Skip spaces in front of number.
-        while (message[c] == ' ') ++c;
-        // Figure length of number string.
-        last_c = c;
-        c += strspn(message + c, "-0123456789.");  // No space, just minus, digits, and decimal point.
-        if (last_c == c)  // Zero-length number.
-            *vals = skipped_val;  // Rewrite with special value for skips.
-        while(message[c] != ',' && message[c] != 0 && c < MAX_MESSAGE_LEN) c++;
-        ++c;  // Step over the comma (if that's where we landed).
-        ++vals;  // Move to next output.
-        ++num_vals_received;
-    }
-    if (c < stop) {
-        fprintf(stderr, "WARNING: parse_float_list: More than %d values in \"%s\"\n",
-                max_num_vals, message);
-    }
-    return num_vals_received;
-}
 
-int parse_int_list_message32(char *message, int32_t *vals, int max_num_vals, int32_t skipped_val) {
-    // Return the number of values extracted from message.
-    uint16_t c = 0, last_c;
-    uint16_t stop = strspn(message, " -0123456789,");  // Space, no period.
-    int num_vals_received = 0;
-    while(c < stop && num_vals_received < max_num_vals) {
-        *vals = atoi(message + c);
-        // Skip spaces in front of number.
-        while (message[c] == ' ') ++c;
-        // Figure length of number string.
-        last_c = c;
-        c += strspn(message + c, "-0123456789");  // No space, just minus and digits.
-        if (last_c == c)  // Zero-length number.
-            *vals = skipped_val;  // Rewrite with special value for skips.
-        // Step through (spaces?) to next comma, or end of string or region.
-        while (message[c] != ',' && message[c] != 0 && c < MAX_MESSAGE_LEN) c++;
-        ++c;  // Step over the comma (if that's where we landed).
-        ++vals;  // Move to next output.
-        ++num_vals_received;
-    }
-    if (c < stop) {
-        fprintf(stderr, "WARNING: parse_int_list: More than %d values in \"%s\"\n",
-                max_num_vals, message);
-    }
-    return num_vals_received;
-}
+#define PARSE_LIST_STRSPN1(var) _Generic((var), \
+    float:    " -0123456789,.", \
+    uint32_t: " 0123456789,", \
+    uint16_t: " 0123456789,", \
+    int16_t:  " -0123456789,", \
+    int32_t:  " -0123456789," \
+)
 
-int parse_int_list_message16(char *message, int16_t *vals, int max_num_vals, int16_t skipped_val) {
-    // Return the number of values extracted from message.
-    uint16_t c = 0, last_c;
-    uint16_t stop = strspn(message, " -0123456789,");  // Space, no period.
-    int num_vals_received = 0;
-    while(c < stop && num_vals_received < max_num_vals) {
-        *vals = atoi(message + c);
-        // Skip spaces in front of number.
-        while (message[c] == ' ') ++c;
-        // Figure length of number string.
-        last_c = c;
-        c += strspn(message + c, "-0123456789");  // No space, just minus and digits.
-        if (last_c == c)  // Zero-length number.
-            *vals = skipped_val;  // Rewrite with special value for skips.
-        // Step through (spaces?) to next comma, or end of string or region.
-        while (message[c] != ',' && message[c] != 0 && c < MAX_MESSAGE_LEN) c++;
-        ++c;  // Step over the comma (if that's where we landed).
-        ++vals;  // Move to next output.
-        ++num_vals_received;
+#define PARSE_LIST_STRSPN2(var) _Generic((var), \
+    float:    "-0123456789.", \
+    uint32_t: "0123456789", \
+    uint16_t: "0123456789", \
+    int16_t:  "-0123456789", \
+    int32_t:  "-0123456789" \
+)
+
+#define PARSE_LIST_ATO(var) _Generic((var), \
+    float:    atoff, \
+    uint32_t: atoi, \
+    uint16_t: atoi, \
+    int32_t:  atoi, \
+    int16_t:  atoi \
+)
+
+#define PARSE_LIST(type) \
+    int parse_list_##type(char *message, type *vals, int max_num_vals, type skipped_val) { \
+        uint16_t c = 0, last_c; \
+        uint16_t stop = strspn(message, PARSE_LIST_STRSPN1(skipped_val)); \
+        int num_vals_received = 0; \
+        while(c < stop && num_vals_received < max_num_vals) { \
+            *vals = PARSE_LIST_ATO(skipped_val)(message + c); \
+            while (message[c] == ' ') ++c; \
+            last_c = c; \
+            c += strspn(message + c, PARSE_LIST_STRSPN2(skipped_val));  \
+            if (last_c == c)  \
+                *vals = skipped_val;  \
+            while (message[c] != ',' && message[c] != 0 && c < MAX_MESSAGE_LEN) c++; \
+            ++c; \
+            ++vals; \
+            ++num_vals_received; \
+        } \
+        if (c < stop) { \
+            fprintf(stderr, "WARNING: parse__list_##type: More than %d values in \"%s\"\n", \
+                max_num_vals, message); \
+        } \
+        return num_vals_received; \
     }
-    if (c < stop) {
-        fprintf(stderr, "WARNING: parse_int_list: More than %d values in \"%s\"\n",
-                max_num_vals, message);
-    }
-    return num_vals_received;
-}
+
+
+PARSE_LIST(float)
+PARSE_LIST(uint32_t)
+PARSE_LIST(uint16_t)
+PARSE_LIST(int32_t)
+PARSE_LIST(int16_t)
+
+
 
 void copy_param_list_substring(char *dest, const char *src) {
     // Copy wire command string up to next parameter char.
@@ -1675,7 +1657,7 @@ void copy_param_list_substring(char *dest, const char *src) {
 
 // helper to parse the list of source voices for an algorithm
 void parse_algorithm_source(struct synthinfo * t, char *message) {
-    int num_parsed = parse_int_list_message16(message, t->algo_source, MAX_ALGO_OPS,
+    int num_parsed = parse_list_int16_t(message, t->algo_source, MAX_ALGO_OPS,
                                             AMY_UNSET_VALUE(t->algo_source[0]));
     // Clear unspecified values.
     for (int i = num_parsed; i < MAX_ALGO_OPS; ++i) {
@@ -1687,7 +1669,7 @@ void parse_algorithm_source(struct synthinfo * t, char *message) {
 int parse_breakpoint(struct synthinfo * e, char* message, uint8_t which_bpset) {
     float vals[2 * MAX_BREAKPOINTS];
     // Read all the values as floats.
-    int num_vals = parse_float_list_message(message, vals, 2 * MAX_BREAKPOINTS,
+    int num_vals = parse_list_float(message, vals, 2 * MAX_BREAKPOINTS,
                                             AMY_UNSET_VALUE(vals[0]));
     // Distribute out to times and vals, casting times to ints.
     for (int i = 0; i < num_vals; ++i) {
@@ -1711,7 +1693,7 @@ int parse_breakpoint(struct synthinfo * e, char* message, uint8_t which_bpset) {
 }
 
 void parse_coef_message(char *message, float *coefs) {
-    int num_coefs = parse_float_list_message(message, coefs, NUM_COMBO_COEFS,
+    int num_coefs = parse_list_float(message, coefs, NUM_COMBO_COEFS,
                                              AMY_UNSET_VALUE(coefs[0]));
     // Clear the unspecified coefs to unset.
     for (int i = num_coefs; i < NUM_COMBO_COEFS; ++i)
@@ -1779,7 +1761,7 @@ struct event amy_parse_message(char * message) {
                         case 'h': if (AMY_HAS_REVERB) {
                             float reverb_params[4] = {AMY_UNSET_VALUE(reverb.liveness), AMY_UNSET_VALUE(reverb.liveness),
                                                       AMY_UNSET_VALUE(reverb.liveness), AMY_UNSET_VALUE(reverb.liveness)};
-                            parse_float_list_message(message + start, reverb_params, 4, AMY_UNSET_VALUE(reverb.liveness));
+                            parse_list_float(message + start, reverb_params, 4, AMY_UNSET_VALUE(reverb.liveness));
                             // config_reverb doesn't understand UNSET, so copy in the current values.
                             if (AMY_IS_UNSET(reverb_params[0])) reverb_params[0] = S2F(reverb.level);
                             if (AMY_IS_UNSET(reverb_params[1])) reverb_params[1] = reverb.liveness;
@@ -1790,11 +1772,12 @@ struct event amy_parse_message(char * message) {
                         break;
                         /* i is used by alles for sync index -- but only for sync messages -- ok to use here but test */
                         case 'I': e.ratio = atoff(message + start); break;
+                        case 'j': e.tempo = atof(message+start); break;
                         /* j, J available */
                         // chorus.level 
                         case 'k': if(AMY_HAS_CHORUS) {
                             float chorus_params[4] = {AMY_UNSET_FLOAT, AMY_UNSET_FLOAT, AMY_UNSET_FLOAT, AMY_UNSET_FLOAT};
-                            parse_float_list_message(message + start, chorus_params, 4, AMY_UNSET_FLOAT);
+                            parse_list_float(message + start, chorus_params, 4, AMY_UNSET_FLOAT);
                             // config_chorus doesn't understand UNSET, copy existing values.
                             if (AMY_IS_UNSET(chorus_params[0])) chorus_params[0] = S2F(chorus.level);
                             if (AMY_IS_UNSET(chorus_params[1])) chorus_params[1] = (float)chorus.max_delay;
@@ -1809,7 +1792,7 @@ struct event amy_parse_message(char * message) {
                         case 'm': e.portamento_ms=atoi(message + start); break;
                         case 'M': if (AMY_HAS_ECHO) {
                             float echo_params[5] = {AMY_UNSET_FLOAT, AMY_UNSET_FLOAT, AMY_UNSET_FLOAT, AMY_UNSET_FLOAT, AMY_UNSET_FLOAT};
-                            parse_float_list_message(message + start, echo_params, 5, AMY_UNSET_FLOAT);
+                            parse_list_float(message + start, echo_params, 5, AMY_UNSET_FLOAT);
                             if (AMY_IS_UNSET(echo_params[0])) echo_params[0] = S2F(echo.level);
                             if (AMY_IS_UNSET(echo_params[1])) echo_params[1] = (float)echo.delay_samples * 1000.f / AMY_SAMPLE_RATE;
                             if (AMY_IS_UNSET(echo_params[2])) echo_params[2] = (float)echo.max_delay_samples * 1000.f / AMY_SAMPLE_RATE;
@@ -1841,15 +1824,15 @@ struct event amy_parse_message(char * message) {
                         case 'X': e.eg_type[1] = atoi(message + start); break;
                         case 'x': {
                               float eq[3] = {AMY_UNSET_VALUE(e.eq_l), AMY_UNSET_VALUE(e.eq_m), AMY_UNSET_VALUE(e.eq_h)};
-                              parse_float_list_message(message + start, eq, 3, AMY_UNSET_VALUE(e.eq_l));
+                              parse_list_float(message + start, eq, 3, AMY_UNSET_VALUE(e.eq_l));
                               e.eq_l = eq[0];
                               e.eq_m = eq[1];
                               e.eq_h = eq[2];
                             }
                             break;
                         case 'z': {
-                            int32_t sm[6]; // patch, length, SR, midinote, loopstart, loopend
-                            parse_int_list_message32(message+start, sm, 6, 0);
+                            uint32_t sm[6]; // patch, length, SR, midinote, loopstart, loopend
+                            parse_list_uint32_t(message+start, sm, 6, 0);
                             if(sm[1]==0) { // remove patch
                                 pcm_unload_patch(sm[0]);
                             } else {
@@ -1872,11 +1855,11 @@ struct event amy_parse_message(char * message) {
     }
     AMY_PROFILE_STOP(AMY_PARSE_MESSAGE)
 
-    if(sequence_message) {
-        sequencer_add_event(e, tick, divider, tag);
-    } else {
-        // Only do this if we got some data
-        if(length >0) {
+    if(length>0) { // only do this if we got some data 
+        if(sequence_message) {
+            uint8_t added = sequencer_add_event(e, tick, divider, tag);
+            (void)added; // we don't need to do anything with this info at this time
+        } else {
             // if time is set, play then
             // if time and latency is set, play in time + latency
             // if time is not set, play now
@@ -1920,8 +1903,8 @@ void amy_start(uint8_t cores, uint8_t reverb, uint8_t chorus, uint8_t echo) {
         pthread_mutex_init(&amy_queue_lock, NULL);
     #endif
     amy_profiles_init();
-    sequencer_init();
     global_init();
+    sequencer_init();
     amy_global.cores = cores;
     amy_global.has_chorus = chorus;
     amy_global.has_reverb = reverb;

--- a/src/amy.h
+++ b/src/amy.h
@@ -161,7 +161,7 @@ enum params{
     RESONANCE, PORTAMENTO, CHAINED_OSC,  // 45, 46, 47
     MOD_SOURCE, FILTER_TYPE,             // 48, 49
     EQ_L, EQ_M, EQ_H,                    // 50, 51, 52
-    ALGORITHM, LATENCY,                  // 53, 54
+    ALGORITHM, LATENCY, TEMPO,           // 53, 54, 55
     ALGO_SOURCE_START=100,               // 100..105
     ALGO_SOURCE_END=100+MAX_ALGO_OPS,    // 106
     BP_START=ALGO_SOURCE_END + 1,        // 107..138
@@ -285,6 +285,7 @@ struct event {
     float detune;
     float volume;
     float pitch_bend;
+    float tempo;
     uint16_t latency_ms;
     float ratio;
     float resonance;
@@ -439,6 +440,7 @@ struct state {
     int16_t next_event_write;
     struct delta * event_start; // start of the sorted list
     int16_t latency_ms;
+    float tempo;
 };
 
 // custom oscillator

--- a/src/amy.h
+++ b/src/amy.h
@@ -105,7 +105,7 @@ enum coefs{
 #define EVENT_EMPTY 0
 #define EVENT_SCHEDULED 1
 #define EVENT_TRANSFER_DATA 2
-
+#define EVENT_SEQUENCE 3
 
 // Envelope generator types (for synth[osc].env_type[eg]).
 #define ENVELOPE_NORMAL 0

--- a/src/patches.c
+++ b/src/patches.c
@@ -96,11 +96,14 @@ void patches_store_patch(char * message) {
     //fprintf(stderr, "store_patch: patch %d n_osc %d patch %s\n", patch_number, max_osc, patch);
 }
 
+extern int parse_list_uint16_t(char *message, uint16_t *vals, int max_num_vals, uint16_t skipped_val);
+
+
 // This is called when i get an event with voices in it, BUT NOT with a load_patch 
 // So i know that the patch / voice alloc already exists and the patch has already been set!
 void patches_event_has_voices(struct event e) {
-    int16_t voices[MAX_VOICES];
-    uint8_t num_voices = parse_int_list_message16(e.voices, voices, MAX_VOICES, 0);
+    uint16_t voices[MAX_VOICES];
+    uint8_t num_voices = parse_list_uint16_t(e.voices, voices, MAX_VOICES, 0);
     // clear out the voices and patch now from the event. If we didn't, we'd keep calling this over and over
     e.voices[0] = 0;
     AMY_UNSET(e.load_patch);
@@ -119,8 +122,8 @@ void patches_event_has_voices(struct event e) {
 void patches_load_patch(struct event e) {
     char sub_message[255];
     
-    int16_t voices[MAX_VOICES];
-    uint8_t num_voices = parse_int_list_message16(e.voices, voices, MAX_VOICES, 0);
+    uint16_t voices[MAX_VOICES];
+    uint8_t num_voices = parse_list_uint16_t(e.voices, voices, MAX_VOICES, 0);
     char *message;
     uint16_t patch_osc = 0;
     if(e.load_patch > 1023) {

--- a/src/sequencer.c
+++ b/src/sequencer.c
@@ -144,8 +144,8 @@ static void sequencer_check_and_fill() {
     }
 }
 
-// Desktop: called from a thread
-#ifndef ESP_PLATFORM
+// posix: called from a thread
+#if defined _POSIX_THREADS
 void * run_sequencer(void *vargs) {
     // Loop forever, checking for time and sleeping
     while(1) {
@@ -156,7 +156,7 @@ void * run_sequencer(void *vargs) {
 }
 
 // ESP: do it with hardware timer
-#else
+#elif defined ESP_PLATFORM
 static void sequencer_timer_callback(void* arg) {
     sequencer_check_and_fill();
 }

--- a/src/sequencer.h
+++ b/src/sequencer.h
@@ -3,8 +3,6 @@
 #define __SEQUENCERH
 
 #include "amy.h"
-// Things that MP can change
-extern float sequencer_bpm ;
 
 // Our internal accounting
 extern uint32_t sequencer_tick_count ;
@@ -15,7 +13,8 @@ extern uint32_t us_per_tick ;
 void sequencer_init();
 void sequencer_recompute();
 void parse_tick_and_tag(char * message, uint32_t *tick, uint16_t *divider, uint32_t *tag);
-void sequencer_add_event(struct event e, uint32_t tick, uint16_t divider, uint32_t tag);
+uint8_t sequencer_add_event(struct event e, uint32_t tick, uint16_t divider, uint32_t tag);
+extern void (*amy_external_sequencer_hook)(uint32_t);
 
 #define AMY_SEQUENCER_PPQ 48
 

--- a/src/sequencer.h
+++ b/src/sequencer.h
@@ -1,0 +1,22 @@
+//  sequencer.h
+#ifndef __SEQUENCERH
+#define __SEQUENCERH
+
+#include "amy.h"
+// Things that MP can change
+extern float sequencer_bpm ;
+
+// Our internal accounting
+extern uint32_t sequencer_tick_count ;
+extern uint64_t next_amy_tick_us ;
+extern uint32_t us_per_tick ;
+
+
+void sequencer_init();
+void sequencer_recompute();
+void parse_tick_and_tag(char * message, uint32_t *tick, uint16_t *divider, uint32_t *tag);
+void sequencer_add_event(struct event e, uint32_t tick, uint16_t divider, uint32_t tag);
+
+#define AMY_SEQUENCER_PPQ 48
+
+#endif

--- a/src/setup.py
+++ b/src/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup, Extension
 import glob
 import os
 # the c++ extension module
-sources = ['algorithms.c', 'amy.c', 'delay.c', 'envelope.c', 'filters.c', 'transfer.c', 'custom.c', 'patches.c', 'libminiaudio-audio.c', 'oscillators.c', 'partials.c', 'pcm.c', 'pyamy.c', 'log2_exp2.c']
+sources = ['algorithms.c', 'amy.c', 'delay.c', 'envelope.c', 'filters.c', 'sequencer.c', 'transfer.c', 'custom.c', 'patches.c', 'libminiaudio-audio.c', 'oscillators.c', 'partials.c', 'pcm.c', 'pyamy.c', 'log2_exp2.c']
 os.environ["CC"] = "gcc"
 os.environ["CXX"] = "g++"
 


### PR DESCRIPTION
This PR adds the sequencer to AMY. We have new `sequence` and `tempo` commands. 

This allows anyone to have a Tulip-style clock sequencer running directly in AMY. 

README.md has the API for it and some examples. 

This gets us closer to fixing up https://github.com/shorepine/tulipcc/issues/340
