### PR TITLE
fixing RESET_TIMEBASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Here's the full list:
 | `r`    | `voices` | int[,int] | Comma separated list of voices to send message to, or load patch into. |
 | `R`    | `resonance` | float | Q factor of variable filter, 0.5-16.0. default 0.7 |
 | `s`    | `pitch_bend` | float | Sets the global pitch bend, by default modifying all note frequencies by (fractional) octaves up or down |
-| `S`    | `reset`  | uint | Resets given oscillator. set to RESET_ALL_OSCS to reset all oscillators, gain and EQ. RESET_TIMEBASE resets the clock. RESET_AMY restarts AMY. RESET_SEQUENCER clears the sequencer.|
+| `S`    | `reset`  | uint | Resets given oscillator. set to RESET_ALL_OSCS to reset all oscillators, gain and EQ. RESET_TIMEBASE resets the clock (immediately, ignoring `time`). RESET_AMY restarts AMY. RESET_SEQUENCER clears the sequencer.|
 | `t`    | `time` | uint | Request playback time relative to some fixed start point on your host, in ms. Allows precise future scheduling. |
 | `T`    | `eg0_type` | uint 0-3 | Type for Envelope Generator 0 - 0: Normal (RC-like) / 1: Linear / 2: DX7-style / 3: True exponential. |
 | `u`    | `store_patch` | number,string | Store up to 32 patches in RAM with ID number (1024-1055) and AMY message after a comma. Must be sent alone |
@@ -266,7 +266,7 @@ Both `amy.send()`s will return immediately, but you'll hear the second note play
 
 ### The sequencer
 
-On supported platforms (right now any unix device with pthreads, and the ESP32 or related chip), AMY starts a sequencer that works on `ticks` from startup. You can reset the `ticks` to 0 with an `amy.send(reset=amy.RESET_TIMEBASE)`. 
+On supported platforms (right now any unix device with pthreads, and the ESP32 or related chip), AMY starts a sequencer that works on `ticks` from startup. You can reset the `ticks` to 0 with an `amy.send(reset=amy.RESET_TIMEBASE)`. Note this will happen immediately, ignoring any `time` or `sequence`.
 
 Ticks run at 48 PPQ at the set tempo. The tempo defaults to 108 BPM. This means there are 108 quarter notes a minute, and `48 * 108 = 5184` ticks a minute, 86 ticks a second. The tempo can be changed with `amy.send(tempo=120)`.
 

--- a/src/amy.c
+++ b/src/amy.c
@@ -975,12 +975,10 @@ void play_event(struct delta d) {
             AMY_UNSET(synth[d.osc].chained_osc);
     }
     if(d.param == RESET_OSC) { 
+        // Remember that RESET_TIMEBASE happens immediately in the parse, so we don't deal with it here.
         if(*(int16_t *)&d.data & RESET_AMY) {
             amy_stop();
             amy_start(amy_global.cores, amy_global.has_chorus, amy_global.has_reverb, amy_global.has_echo);
-        }
-        if(*(int16_t *)&d.data & RESET_TIMEBASE) {
-            amy_reset_sysclock();
         }
         if(*(int16_t *)&d.data & RESET_ALL_OSCS) { 
             amy_reset_oscs(); 
@@ -1812,7 +1810,13 @@ struct event amy_parse_message(char * message) {
                         case 'Q': parse_coef_message(message + start, e.pan_coefs); break;
                         case 'R': e.resonance=atoff(message + start); break;
                         case 'r': copy_param_list_substring(e.voices, message+start); break; 
-                        case 'S': e.reset_osc = atoi(message + start); break;
+                        case 'S': 
+                            e.reset_osc = atoi(message + start);
+                            // if we're resetting timebase, do it NOW
+                            if(e.reset_osc & RESET_TIMEBASE) {
+                                amy_reset_sysclock();
+                            }
+                            break;
                         case 's': e.pitch_bend = atoff(message + start); break;
                         /* t used for time */
                         case 'T': e.eg_type[0] = atoi(message + start); break;


### PR DESCRIPTION
RESET_TIMEBASE was being scheduled, which meant a call like 
```
amy.send(reset=amy.RESET_TIMEBASE)
amy.send(osc=0,freq=440,vel=1,time=0)
amy.send(osc=0,freq=220,vel=1,time=100)
```
Would not actually work properly, as the TIMEBASE was not reset until after the scheduling of the freq messages.
In this PR we reset timebase immediately on parsing. We updated the docs.

