### PR TITLE
reset sequencer ticks to 0 (and recompute sequencer) on timebase reset

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -1932,6 +1932,8 @@ struct event amy_parse_message(char * message) {
 
 void amy_reset_sysclock() {
     total_samples = 0;
+    sequencer_tick_count = 0;
+    sequencer_recompute();
 }
 
 // given a string play / schedule the event directly


### PR DESCRIPTION
The sequencer was not getting its ticks set to 0 on RESET_TIMEBASE. This does that.

