### PR TITLE
Sequence deltas, not full `event`s 

### DIFF
--- a/src/amy-example.c
+++ b/src/amy-example.c
@@ -22,7 +22,11 @@ uint8_t render(uint16_t osc, SAMPLE * buf, uint16_t len) {
 int main(int argc, char ** argv) {
     char *output_filename = NULL;
     //fprintf(stderr, "main init. pcm is %p pcm_map is %p\n",  pcm, pcm_map);
-
+    fprintf(stderr, "sizeof synthinfo %d event %d delta %d\n",
+	sizeof(struct synthinfo),
+	sizeof(struct event),
+	sizeof(struct delta)
+	);
     int opt;
     while((opt = getopt(argc, argv, ":d:o:lh")) != -1) 
     { 

--- a/src/amy.h
+++ b/src/amy.h
@@ -404,7 +404,9 @@ extern uint8_t amy_transfer_flag ;
 
 struct event amy_default_event();
 void amy_add_event(struct event e);
+void add_delta_to_queue(struct delta d, void*user_data);
 void amy_add_event_internal(struct event e, uint16_t base_osc);
+void amy_parse_event_to_deltas(struct event e, uint16_t base_osc, void (*callback)(struct delta d, void*user_data), void*user_data );
 int16_t * amy_simple_fill_buffer() ;
 int web_audio_buffer(float *samples, int length);
 void amy_render(uint16_t start, uint16_t end, uint8_t core);
@@ -516,7 +518,7 @@ extern void partials_note_off(uint16_t osc);
 extern void interp_partials_note_on(uint16_t osc);
 extern void interp_partials_note_off(uint16_t osc);
 extern void patches_load_patch(struct event e); 
-extern void patches_event_has_voices(struct event e);
+extern void patches_event_has_voices(struct event e, void (*callback)(struct delta d, void*user_data), void*user_data );
 extern void patches_reset();
 extern void patches_debug();
 extern void patches_store_patch(char * message);

--- a/src/patches.c
+++ b/src/patches.c
@@ -101,7 +101,7 @@ extern int parse_list_uint16_t(char *message, uint16_t *vals, int max_num_vals, 
 
 // This is called when i get an event with voices in it, BUT NOT with a load_patch 
 // So i know that the patch / voice alloc already exists and the patch has already been set!
-void patches_event_has_voices(struct event e) {
+void patches_event_has_voices(struct event e, void (*callback)(struct delta d, void*user_data), void*user_data ) {
     uint16_t voices[MAX_VOICES];
     uint8_t num_voices = parse_list_uint16_t(e.voices, voices, MAX_VOICES, 0);
     // clear out the voices and patch now from the event. If we didn't, we'd keep calling this over and over
@@ -111,7 +111,7 @@ void patches_event_has_voices(struct event e) {
     for(uint8_t i=0;i<num_voices;i++) {
         if(AMY_IS_SET(voice_to_base_osc[voices[i]])) {
             uint16_t target_osc = voice_to_base_osc[voices[i]];
-            amy_add_event_internal(e, target_osc);
+            amy_parse_event_to_deltas(e, target_osc, callback, user_data);
         }
     }
 }


### PR DESCRIPTION
This makes it so the sequencer stores / sequences deltas instead of full events. With full events, it was a big memory user (see #74 )

This also adds a new `callback` arg to the methods that parse events into deltas, so we can choose where to send them. 

Tested on tulip web's sequencer use cases

