### PR TITLE
interp_partials.c: Clip partial magnitudes

### DIFF
--- a/src/interp_partials.c
+++ b/src/interp_partials.c
@@ -61,7 +61,7 @@ float _logfreq_of_midi_cents(float midi_cents) {
 }
 
 float _env_lin_of_db(float db) {
-    float lin =  powf(10.f, (db - 100) / 20.f) - 0.001;
+    float lin =  powf(10.f, MIN(20.f, (db - 100.f)) / 20.f) - 0.001;
     if (lin < 0)  return 0;
     return lin;
 }


### PR DESCRIPTION
@drepetto reported that notes below around A0 on synth patch 256 (dpwe piano) blew up quite unpleasantly.  This is because the lowest note in the harmonics table is C1, so notes below that are being extrapolated from the difference between C1 and Eb1, which apparently led to some extreme growth for some time points of some harmonics.

I avoided the worst of this behavior by clipping the dB magnitudes of the harmonic envelopes to 120 dB (where 0 is the floor).  These super low notes are still weird, but at least they don't drive the output into wrap-around clip.