### PR TITLE
doing audio in as runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ EMSCRIPTEN_OPTIONS = -s WASM=1 \
 -s ALLOW_MEMORY_GROWTH=1 \
 -sMODULARIZE -s 'EXPORT_NAME="amyModule"' \
 -s EXPORTED_RUNTIME_METHODS="['cwrap','ccall']" \
--s EXPORTED_FUNCTIONS="['_amy_play_message', '_amy_reset_sysclock', '_amy_live_start', '_amy_start', '_sequencer_ticks', '_malloc', '_free']"
+-s EXPORTED_FUNCTIONS="['_amy_play_message', '_amy_reset_sysclock', '_amy_live_stop', '_amy_live_start', '_amy_start', '_sequencer_ticks', '_malloc', '_free']"
 
 PYTHON = python3
 
@@ -59,7 +59,7 @@ src/patches.h: $(PYTHONS) $(HEADERS_BUILD)
 	${PYTHON} amy_headers.py
 
 %.o: %.c $(HEADERS) src/patches.h
-	$(CC) $(CFLAGS) -DAMY_HAS_AUDIO_IN -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 %.o: %.mm $(HEADERS)
 	clang $(CFLAGS) -c $< -o $@
@@ -89,7 +89,7 @@ docs/amy.js: $(TARGET)
 	 emcc $(SOURCES) $(EMSCRIPTEN_OPTIONS) -O3 -o $@
 
 docs/amy-audioin.js: $(TARGET)
-	 emcc $(SOURCES) $(EMSCRIPTEN_OPTIONS) -DAMY_HAS_AUDIO_IN -O3 -o $@
+	 emcc $(SOURCES) $(EMSCRIPTEN_OPTIONS) -O3 -o $@
 
 clean:
 	-rm -f src/*.o

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ void bleep() {
 
 void main() {
     amy_start(/* cores= */ 1, /* reverb= */ 0, /* chorus= */ 0,  /* echo */ 1); // initializes amy 
-    amy_live_start(); // render live audio
+    amy_live_start(1); // render live audio
     bleep();
 }
 ```
@@ -141,7 +141,7 @@ Or in C, sending the wire protocol directly:
 
 void main() {
     amy_start(/* cores= */ 1, /* reverb= */ 0, /* chorus= */ 0, /* echo */ 1);
-    amy_live_start();
+    amy_live_start(1);
     amy_play_message("v0n50l1K130r0Z");
 }
 ```

--- a/src/amy-example.c
+++ b/src/amy-example.c
@@ -83,7 +83,7 @@ int main(int argc, char ** argv) {
             exit (1) ;
         }
     } else {
-        amy_live_start();
+        amy_live_start(1);
     }
 
     /*

--- a/src/amy-message.c
+++ b/src/amy-message.c
@@ -45,7 +45,7 @@ int main(int argc, char ** argv) {
 
 
     amy_start(/* cores= */ 1, /* reverb= */ 1, /* chorus= */ 1, /* echo= */1);
-    amy_live_start();
+    amy_live_start(1);
     amy_reset_oscs();
 
     while (1) {

--- a/src/amy.h
+++ b/src/amy.h
@@ -483,7 +483,7 @@ struct event amy_parse_message(char * message);
 void amy_restart();
 void amy_start(uint8_t cores, uint8_t reverb, uint8_t chorus, uint8_t echo);
 void amy_stop();
-void amy_live_start();
+void amy_live_start(uint8_t audio_in);
 void amy_live_stop();
 void amy_reset_oscs();
 void amy_print_devices();

--- a/src/libminiaudio-audio.h
+++ b/src/libminiaudio-audio.h
@@ -11,6 +11,6 @@ extern int16_t amy_capture_device_id;
 extern uint8_t amy_running;
 
 void amy_print_devices();
-void amy_live_start();
+void amy_live_start(uint8_t audio_in);
 void amy_live_stop();
 #endif

--- a/src/pyamy.c
+++ b/src/pyamy.c
@@ -26,7 +26,7 @@ static PyObject * live_wrapper(PyObject *self, PyObject *args) {
         amy_playback_device_id = arg1;
         amy_capture_device_id = arg2;
     }
-    amy_live_start();
+    amy_live_start(1);
     return Py_None;
 }
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -16,7 +16,7 @@ if os.uname()[4] == 'armv7l' or os.uname()[4] == 'armv6l':
 	link_args += ['-latomic', '-ldl']
 
 extension_mod = Extension("libamy", sources=sources, \
-	extra_compile_args=["-I/opt/homebrew/include", "-DAMY_DEBUG", "-DAMY_HAS_AUDIO_IN"], \
+	extra_compile_args=["-I/opt/homebrew/include", "-DAMY_DEBUG"], \
 	extra_link_args=link_args)
 
 setup(name = "libamy", 


### PR DESCRIPTION
This sets audio in support at runtime (when you call amy_live_start) instead of a compile flag. 
