### PR TITLE
MIDI program changes remain with the current block of 128.

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,8 @@ amy.send(synth=0, note=70, vel=1)
 amy.send(synth=0, note=70, vel=0)
 # .. or we can send note-offs to all the currently-active synth voices by not specifying a note
 amy.send(synth=0, vel=0)
+# Once a synth has been initialized and associated with a set of voices, you can use it alone with load_patch
+amy.send(synth=0, load_patch=13)  # Load a different Juno patch, will remain 4-voice.
 ```
 
-(Note: Although `note` can take on real values -- e.g. `note=60.5` for 50 cents above C4 -- the voice management tracks voices by integer note numbers (i.e., midi notes) so it rounds note values to the nearest integer when deciding which note-off goes with which note-on.)
+(Note: Although `note` can take on real values -- e.g. `note=60.5` for 50 cents above C4 -- the voice management tracks voices by integer note numbers (i.e., midi notes) so it rounds note values to the nearest integer when deciding which note-off goes with which note-on.  Note also that note-on events that also set the `patch` parameter (e.g. to select PCM samples) will fold the patch number into the note integer used as the key for note-on, note-off matching.)

--- a/src/amy.h
+++ b/src/amy.h
@@ -730,11 +730,12 @@ extern void patches_reset();
 extern void all_notes_off();
 extern void patches_debug();
 extern void patches_store_patch(char * message);
-extern void instrument_add_new(int instrument_number, int num_voices, uint16_t *amy_voices);
+extern void instrument_add_new(int instrument_number, int num_voices, uint16_t *amy_voices, uint16_t patch_number);
 #define _INSTRUMENT_NO_VOICE (255)
 extern uint16_t instrument_voice_for_note_event(int instrument_number, int note, bool is_note_off);
 extern int instrument_get_voices(int instrument_number, uint16_t *amy_voices);
 extern int instrument_all_notes_off(int instrument_number, uint16_t *amy_voices);
+extern int instrument_get_patch_number(int instrument_number);
 
 extern SAMPLE render_partials(SAMPLE *buf, uint16_t osc);
 extern SAMPLE render_custom(SAMPLE *buf, uint16_t osc) ;

--- a/src/midi.c
+++ b/src/midi.c
@@ -165,7 +165,8 @@ void amy_received_program_change(uint8_t channel, uint8_t program, uint32_t time
     e.time = time;
     e.instrument = channel;
     e.source = EVENT_MIDI;
-    e.load_patch = program;
+    // The MIDI patch number is within the block-of-256 of existing patch numbers, so DX7 patches will remain DX7.
+    e.load_patch = program + (instrument_get_patch_number(e.instrument) & 0xFF80);
     if (channel != AMY_MIDI_CHANNEL_DRUMS) {  // What would that even mean?
         amy_add_event(&e);
     }

--- a/src/patches.c
+++ b/src/patches.c
@@ -163,7 +163,7 @@ void patches_event_has_voices(struct event *e, void (*callback)(struct delta *d,
                 voices[0] = instrument_voice_for_note_event(e->instrument, note, is_note_off);
                 if (voices[0] == _INSTRUMENT_NO_VOICE) {
                     // For now, I think this can only happen with a note-off that has no matching note-on.
-                    fprintf(stderr, "synth %d did not find a voice, dropping message.", e->instrument);
+                    fprintf(stderr, "synth %d did not find a voice, dropping message.\n", e->instrument);
                     return;
                 }
                 num_voices = 1;
@@ -293,6 +293,6 @@ void patches_load_patch(struct event *e) {
     }
     // Finally, store as an instrument if instrument number is specified.
     if (AMY_IS_SET(e->instrument)) {
-        instrument_add_new(e->instrument, num_voices, voices);
+        instrument_add_new(e->instrument, num_voices, voices, e->load_patch);
     }
 }


### PR DESCRIPTION
Previously, MIDI program changes resulted in a `load_patch` in the range 0-127 (the juno patches).  But if you had initialized that instrument to a DX7 patch (`load_patch` 128-255), a program change would change you to a juno.

This change keeps track of the current `patch_number` associated with an instrument, then the MIDI program change only modifies the lowest 7 bits of this value.  Thus, a program change sent to an instrument playing a DX7 patch will select a different DX7 patch.
