### PR TITLE
sequencer.c: Handle us in 64 bit.

### DIFF
--- a/amy.py
+++ b/amy.py
@@ -305,7 +305,6 @@ def restart():
     libamy.restart()
 
 def inject_midi(a, b, c, d=None):
-    import libamy
     if d is None:
         libamy.inject_midi(a, b, c)
     else:

--- a/src/amy.c
+++ b/src/amy.c
@@ -1435,6 +1435,7 @@ void amy_render(uint16_t start, uint16_t end, uint8_t core) {
 
 // on all platforms, sysclock is based on total samples played, using audio out (i2s or etc) as system clock
 uint32_t amy_sysclock() {
+    // Time is returned in integer microseconds.  uint32_t rollover is 49.7 days.
     return (uint32_t)((amy_global.total_blocks * AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE) * 1000);
 }
 

--- a/src/patches.c
+++ b/src/patches.c
@@ -142,7 +142,7 @@ void patches_event_has_voices(struct event *e, void (*callback)(struct delta *d,
             num_voices = instrument_get_voices(e->instrument, voices);
         } else {
             // velocity is present, this is a note-on/note-off.
-            if (! (AMY_IS_SET(e->midi_note) && e->midi_note != 0) ) {
+            if (! (AMY_IS_SET(e->midi_note) && e->midi_note != 0) && AMY_IS_UNSET(e->patch)) {
                 // velocity without a note number (or for midi_note=0).  This is valid for velocity==0 => all-notes-off.
                 if (e->velocity != 0) {
                     // Attempted a note-on to all voices, suppress.
@@ -153,7 +153,9 @@ void patches_event_has_voices(struct event *e, void (*callback)(struct delta *d,
                 num_voices = instrument_all_notes_off(e->instrument, voices);
             } else {
                 // It's a note-on or note-off event, so the instrument mechanism chooses which single voice to use.
-                uint16_t note = (uint8_t)roundf(e->midi_note);
+                uint16_t note = 0;
+                if (AMY_IS_SET(e->midi_note))  // midi note can be unset if patch is set.
+                    note = (uint8_t)roundf(e->midi_note);
 		if (AMY_IS_SET(e->patch)) {
 		    // This event includes a note *and* a patch, so it's like a drum sample note on.
 		    // Wrap the patch number into the note, so we don't allocate the same pitch for different drums to the same voice.


### PR DESCRIPTION
Make sure amy_millis() doesn't overflow at 1.1 h when promoting to microseconds.

[unrelated] Allows wave=PATCH note-ons to omit note number for synth/instrument note-ons.