### PR TITLE
Synth flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Here's the full list:
 | `n`    | `note` | float, but typ. uint 0-127 | Midi note, sets frequency.  Fractional Midi notes are allowed |
 | `N`    | `latency_ms` | uint | Sets latency in ms. default 0 (see LATENCY) |
 | `o`    | `algorithm` | uint 1-32 | DX7 FM algorithm to use for ALGO type |
+| `o`    | `synth_flags` | uint | Flags for synth creation: 1 = Use MIDI drum note->patch translation; 2 = Drop note-off events.  (Note alias with `algorithm` code). |
 | `O`    | `algo_source` | string | Which oscillators to use for the FM algorithm. list of six (starting with op 6), use empty for not used, e.g 0,1,2 or 0,1,2,,, |
 | `p`    | `patch` | int | Which predefined PCM or Partials patch to use, or number of partials if < 0. (Juno/DX7 patches are different - see `load_patch`). |
 | `P`    | `phase` | float 0-1 | Where in the oscillator's cycle to begin the waveform (also works on the PCM buffer). default 0 |
@@ -724,6 +725,10 @@ amy.send(synth=0, note=70, vel=0)
 amy.send(synth=0, vel=0)
 # Once a synth has been initialized and associated with a set of voices, you can use it alone with load_patch
 amy.send(synth=0, load_patch=13)  # Load a different Juno patch, will remain 4-voice.
+# As a special case, you can set up a MIDI drum synth that will translate note events into PCM presets.
+amy.send(store_patch='1024,w7f0')
+amy.send(synth=10, voices='3,4,5', load_patch=1024, synth_flags=3)
+amy.send(synth=10, note=40, vel=1)  # MIDI drums 'electric snare'
 ```
 
 (Note: Although `note` can take on real values -- e.g. `note=60.5` for 50 cents above C4 -- the voice management tracks voices by integer note numbers (i.e., midi notes) so it rounds note values to the nearest integer when deciding which note-off goes with which note-on.  Note also that note-on events that also set the `patch` parameter (e.g. to select PCM samples) will fold the patch number into the note integer used as the key for note-on, note-off matching.)

--- a/amy.py
+++ b/amy.py
@@ -154,10 +154,11 @@ def message(**kwargs):
     kw_map = {'osc': 'vI', 'wave': 'wI', 'note': 'nF', 'vel': 'lF', 'amp': 'aC', 'freq': 'fC', 'duty': 'dC', 'feedback': 'bF', 'time': 'tI',
               'reset': 'SI', 'phase': 'PF', 'pan': 'QC', 'client': 'gI', 'volume': 'VF', 'pitch_bend': 'sF', 'filter_freq': 'FC', 'resonance': 'RF',
               'bp0': 'AL', 'bp1': 'BL', 'eg0_type': 'TI', 'eg1_type': 'XI', 'debug': 'DI', 'chained_osc': 'cI', 'mod_source': 'LI', 
-              'eq': 'xL', 'filter_type': 'GI', 'algorithm': 'oI', 'ratio': 'IF', 'latency_ms': 'NI', 'algo_source': 'OL', 'load_sample': 'zL',
+              'eq': 'xL', 'filter_type': 'GI', 'ratio': 'IF', 'latency_ms': 'NI', 'algo_source': 'OL', 'load_sample': 'zL',
               'chorus': 'kL', 'reverb': 'hL', 'echo': 'ML', 'load_patch': 'KI', 'store_patch': 'uS', 'voices': 'rL',
               'external_channel': 'WI', 'portamento': 'mI', 'sequence': 'HL', 'tempo': 'jF', 'synth': 'iI',
               'patch': 'pI', 'num_partials': 'pI', # Note alaising.
+              'algorithm': 'oI', 'synth_flags': 'oI', # Note aliasing.
               }
     arg_handlers = {
         'I': str, 'F': trunc, 'S': str, 'L': str, 'C': parse_ctrl_coefs,

--- a/src/patches.c
+++ b/src/patches.c
@@ -399,6 +399,11 @@ void patches_load_patch(struct event *e) {
     // Finally, store as an instrument if instrument number is specified.
     if (AMY_IS_SET(e->instrument)) {
         uint32_t flags = 0;
+        if (AMY_IS_SET(e->algorithm) && !AMY_IS_SET(e->instrument_flags)) {
+            // algorithm is used as an alias for synth_flags when defining instruments.
+            e->instrument_flags = e->algorithm;
+            AMY_UNSET(e->algorithm);
+        }
         if (AMY_IS_SET(e->instrument_flags)) flags = e->instrument_flags;
         instrument_add_new(e->instrument, num_voices, voices, e->load_patch, flags);
     }

--- a/test.py
+++ b/test.py
@@ -677,12 +677,26 @@ class TestSynthDrums(AmyTest):
     self.config_default = True
   
   def run(self):
-    # inject_midi args are (time, midi_event_chan, midi_note, midi_vel)
     amy.send(time=100, synth=10, note=35, vel=100/127)  # bass
     amy.send(time=400, synth=10, note=35, vel=100/127)  # bass
     amy.send(time=400, synth=10, note=37, vel=100/127)  # snare
     amy.send(time=700, synth=10, note=37, vel=100/127)  # snare
     amy.send(time=900, synth=10, note=37, vel=0)  # snare note off - ignored with current setup.
+
+
+class TestSynthFlags(AmyTest):
+  """Test setting up MIDI drums using synth_flags (alias).  Slightly different waveform than TestSynthDrums because chorus is off."""
+
+  def run(self):
+    # The default config is NOT set, set up MIDI drums on instrument 1 here.
+    amy.send(store_patch='1024,w7f0');
+    # synth_flags=3 means do MIDI drums note translation and ignore note-offs.
+    amy.send(synth=1, synth_flags=3, voices='0,1,2,3', load_patch=1024)
+    amy.send(time=100, synth=1, note=35, vel=100/127)  # bass
+    amy.send(time=400, synth=1, note=35, vel=100/127)  # bass
+    amy.send(time=400, synth=1, note=37, vel=100/127)  # snare
+    amy.send(time=700, synth=1, note=37, vel=100/127)  # snare
+    amy.send(time=900, synth=1, note=37, vel=0)  # snare note off - ignored with current setup.
 
 
 class TestDoubleNoteOff(AmyTest):


### PR DESCRIPTION
`e->instrument_flags` was introduced in #329.  This change makes it controllable via the Python API and adds a test.

I used an alias of wire code 'o' (algorithm) on the thought they're unlikely to be used together.