### PR TITLE
Add to_synth option to change the synth number (hence MIDI channel) f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Here's the full list:
 | `i`    | `synth`  | 0-31  | Define a set of voices for voice management. |
 | `if`   | `synth_flags` | uint | Flags for synth creation: 1 = Use MIDI drum note->patch translation; 2 = Drop note-off events. |
 | `ip`   | `pedal` | int | Non-zero means pedal is down (i.e., sustain).  Must be used with `synth`. |
+| `it`   | `to_synth` | 0-31 | New synth number, when changing the number (MIDI channel for n=1..16) of an entire synth. |
 | `iv`   | `num_voices` | int | The number of voices to allocate when defining a synth, alternative to directly specifying voice numbers with `voices=`.  Only valid with `instrument=X, load_patch=Y`. |
 | `I`    | `ratio`  | float | For ALGO types, ratio of modulator frequency to  base note frequency / For the PARTIALS base note, ratio controls the speed of the playback |
 | `j`    | `tempo`  | float | The tempo (BPM, quarter notes) of the sequencer. Defaults to 108.0. |

--- a/amy.py
+++ b/amy.py
@@ -157,7 +157,7 @@ def message(**kwargs):
               'eq': 'xL', 'filter_type': 'GI', 'ratio': 'IF', 'latency_ms': 'NI', 'algo_source': 'OL', 'load_sample': 'zL',
               'chorus': 'kL', 'reverb': 'hL', 'echo': 'ML', 'load_patch': 'KI', 'store_patch': 'uS', 'voices': 'rL',
               'external_channel': 'WI', 'portamento': 'mI', 'sequence': 'HL', 'tempo': 'jF',
-              'synth': 'iI', 'pedal': 'ipI', 'synth_flags': 'ifI', 'num_voices': 'ivI', # 'i' is prefix for some two-letter synth-level codes.
+              'synth': 'iI', 'pedal': 'ipI', 'synth_flags': 'ifI', 'num_voices': 'ivI', 'to_synth': 'itI', # 'i' is prefix for some two-letter synth-level codes.
               'patch': 'pI', 'num_partials': 'pI', # Note alaising.
               'algorithm': 'oI',
               }

--- a/src/amy.c
+++ b/src/amy.c
@@ -437,6 +437,7 @@ struct event amy_default_event() {
     e.voices[0] = 0;
     AMY_UNSET(e.instrument);
     AMY_UNSET(e.instrument_flags);
+    AMY_UNSET(e.to_instrument);
     AMY_UNSET(e.pedal);
     AMY_UNSET(e.num_voices);
     return e;

--- a/src/amy.h
+++ b/src/amy.h
@@ -417,6 +417,7 @@ struct event {
     // Instrument-layer values.
     uint8_t instrument;
     uint32_t instrument_flags;  // Special flags to set when defining instruments.
+    uint8_t to_instrument;  // For moving setup between synth numbers.
     uint8_t pedal;  // MIDI pedal value.
     uint16_t num_voices;
     //
@@ -744,6 +745,7 @@ extern void patches_store_patch(char * message);
 #define _INSTRUMENT_FLAGS_IGNORE_NOTE_OFFS (0x02)
 #define _INSTRUMENT_FLAGS_NEGATE_PEDAL (0x04)
 extern void instrument_add_new(int instrument_number, int num_voices, uint16_t *amy_voices, uint16_t patch_number, uint32_t flags);
+extern void instrument_change_number(int old_instrument_number, int new_instrument_number);
 #define _INSTRUMENT_NO_VOICE (255)
 extern uint16_t instrument_voice_for_note_event(int instrument_number, int note, bool is_note_off);
 extern int instrument_get_voices(int instrument_number, uint16_t *amy_voices);

--- a/src/instrument.c
+++ b/src/instrument.c
@@ -221,6 +221,15 @@ void instrument_add_new(int instrument_number, int num_voices, uint16_t *amy_voi
     instruments[instrument_number] = instrument_init(num_voices, amy_voices, patch_number, flags);
 }
 
+void instrument_change_number(int old_instrument_number, int new_instrument_number) {
+    if (instruments[new_instrument_number]) {
+        instrument_free(instruments[new_instrument_number]);
+    }
+    instruments[new_instrument_number] = instruments[old_instrument_number];
+    instruments[old_instrument_number] = NULL;
+}
+
+
 int instrument_get_voices(int instrument_number, uint16_t *amy_voices) {
     int num_voices = 0;
     struct instrument_info *instrument = instruments[instrument_number];

--- a/src/parse.c
+++ b/src/parse.c
@@ -210,6 +210,7 @@ void amy_parse_synth_layer_message(char *message, struct event *e) {
     if (cmd == 'p')  e->pedal = atoi(message);
     else if (cmd == 'f')  e->instrument_flags = atoi(message);
     else if (cmd == 'v')  e->num_voices = atoi(message);
+    else if (cmd == 't')  e->to_instrument = atoi(message);
     else fprintf(stderr, "Unrecognized synth-level command '%s'\n", message - 1);
 }
 
@@ -259,11 +260,11 @@ void amy_parse_message(char * message, struct event *e) {
         cmd = message[pos];
         char *arg = message + pos + 1;
         //if(cmd == '_' && pos==0) sync_response = 1;
-        if( ((cmd >= 'a' && cmd <= 'z') || (cmd >= 'A' && cmd <= 'Z')) || cmd == 0) {  // new mode or end
+        if( isalpha(cmd) || cmd == 0) {  // new cmd or end
             if(cmd == 't') {
                 e->time=atol(arg);
             } else {
-                if(cmd >= 'A' && cmd <= 'z') {
+                if(isalpha(cmd)) {
                     switch(cmd) {
                         case 'a': parse_coef_message(arg, e->amp_coefs);break;
                         case 'A': copy_param_list_substring(e->bp0, arg); e->bp_is_set[0] = 1; break;

--- a/src/patches.c
+++ b/src/patches.c
@@ -232,8 +232,15 @@ void patches_event_has_voices(struct event *e, void (*callback)(struct delta *d,
                     e->instrument, e->voices);
         }
         flags = instrument_get_flags(e->instrument);
-        // Pedal events are a special case
+        if (AMY_IS_SET(e->to_instrument)) {
+            // This involves moving the instrument number.
+            instrument_change_number(e->instrument, e->to_instrument);
+            e->instrument = e->to_instrument;
+            AMY_UNSET(e->to_instrument);
+            // Then continue handling any other args.
+        }
         if (AMY_IS_SET(e->pedal)) {
+            // Pedal events are a special case
             bool sustain = (e->pedal != 0);
             if (flags & _INSTRUMENT_FLAGS_NEGATE_PEDAL) {
                 sustain = !sustain;  // Some MIDI pedals report backwards.


### PR DESCRIPTION
Add to_synth option to change the synth number (hence MIDI channel) for an existing instrument.

This is sometimes useful.  It's needs by the tulip front end to make setting up python synths easier.