### PR TITLE
fix reset_osc logic; extend MAX_VOICES and MAX_VOICES_PER_INSTRUMENT.

### DIFF
--- a/src/instrument.c
+++ b/src/instrument.c
@@ -9,7 +9,7 @@
 
 #include "amy.h"
 #include <inttypes.h>
-#define MAX_VOICES_PER_INSTRUMENT 16
+#define MAX_VOICES_PER_INSTRUMENT 32
 
 #define INSTRUMENT_RAM_CAPS SYNTH_RAM_CAPS
 
@@ -131,6 +131,10 @@ void instrument_debug(struct instrument_info *instrument) {
 
 struct instrument_info *instrument_init(int num_voices, uint16_t* amy_voices, uint16_t patch_number, uint32_t flags) {
     struct instrument_info *instrument = (struct instrument_info *)malloc_caps(sizeof(struct instrument_info), amy_global.config.ram_caps_synth);
+    if (num_voices > MAX_VOICES_PER_INSTRUMENT) {
+        fprintf(stderr, "num_voices %d > MAX_VOICES_PER_INSTRUMENT %d\n", num_voices, MAX_VOICES_PER_INSTRUMENT);
+        return NULL;
+    }
     instrument->num_voices = num_voices;
     instrument->patch_number = patch_number;
     instrument->flags = flags;

--- a/src/parse.c
+++ b/src/parse.c
@@ -330,21 +330,21 @@ void amy_parse_message(char * message, amy_event *e) {
             case 'S':
                 e->reset_osc = atoi(arg);
                 // if we're resetting all of AMY, do it now
-                if(e->reset_osc & RESET_AMY) {
-                    amy_stop();
-                    amy_start(amy_global.config);
-                }
-                // if we're resetting timebase, do it NOW
-                if(e->reset_osc & RESET_TIMEBASE) {
-                    amy_reset_sysclock();
-                    AMY_UNSET(e->reset_osc);
-                }
-                if(e->reset_osc & RESET_EVENTS) {
-                    amy_deltas_reset();
-                    AMY_UNSET(e->reset_osc);
-                }
-                if(e->reset_osc & RESET_SYNTHS) {
-                    amy_reset_oscs();
+                if (e->reset_osc & (RESET_AMY | RESET_TIMEBASE | RESET_EVENTS | RESET_SYNTHS)) {
+                    if(e->reset_osc & RESET_AMY) {
+                        amy_stop();
+                        amy_start(amy_global.config);
+                    }
+                    // if we're resetting timebase, do it NOW
+                    if(e->reset_osc & RESET_TIMEBASE) {
+                        amy_reset_sysclock();
+                    }
+                    if(e->reset_osc & RESET_EVENTS) {
+                        amy_deltas_reset();
+                    }
+                    if(e->reset_osc & RESET_SYNTHS) {
+                        amy_reset_oscs();
+                    }
                     AMY_UNSET(e->reset_osc);
                 }
                 break;

--- a/src/patches.c
+++ b/src/patches.c
@@ -21,7 +21,7 @@ if you get a osc and a voice, you add the osc to the base_osc lookup and send th
 
 #define _PATCHES_FIRST_USER_PATCH 1024
 
-#define MAX_VOICES 32
+#define MAX_VOICES 64
 #define MEMORY_PATCHES 32
 char * memory_patch[MEMORY_PATCHES];
 uint16_t next_user_patch_index = 0;
@@ -395,6 +395,7 @@ void patches_load_patch(amy_event *e) {
                 }
                 if (v == MAX_VOICES)  {
                     fprintf(stderr, "ran out of voices allocating %d voices to synth %d for patch %d, ignoring.", e->num_voices, e->synth, patch_number);
+                    patches_debug();
                     return;
                 }
                 voices[i] = v;


### PR DESCRIPTION
xanadu.py needs 35 voices total, 18 of them in a single instrument.