### PR TITLE
Check for NULL return allocating echo & chorus delay lines.

### DIFF
--- a/examples/AMY_MIDI_Synth/AMY_MIDI_Synth.ino
+++ b/examples/AMY_MIDI_Synth/AMY_MIDI_Synth.ino
@@ -3,11 +3,11 @@
 // Simple AMY synth setup that just sets up the default MIDI synth.
 // Plug a MIDI keyboard into the MIDI in port and play notes, send program changes, etc
 // We've tested this with the following boards:
-// 
+//
 // esp32s3 [n32r8]
 // rp2040 (Pi Pico) -- use 250Mhz and -O3 for 6 note juno polyphony and turn off serial debug if you have it on
 // rp2350 (Pi Pico)
-// teensy4 
+// teensy4
 // Please see https://github.com/shorepine/amy/issues/354 for the full list
 
 
@@ -52,6 +52,7 @@ void test_audio_in() {
 }
 
 void setup() {
+  delay(2000);
   amy_config_t amy_config = amy_default_config();
   amy_config.features.startup_bleep = 1;
 
@@ -76,14 +77,14 @@ void setup() {
   amy_start(amy_config);
   amy_live_start();
 
-  test_polyphony();
+  //test_polyphony();
   //test_sequencer();
-  //test_audio_in();
+  test_audio_in();
 }
 
 void loop() {
   // Your loop() must contain this call to amy:
-  amy_update(); 
+  amy_update();
 
   // put your main code here, to run repeatedly:
 }

--- a/src/api.c
+++ b/src/api.c
@@ -48,7 +48,7 @@ amy_config_t amy_default_config() {
     c.max_memory_patches = 32;
 
     // caps
-    #if (defined TULIP) || (defined AMYBOARD)
+#if defined(TULIP) || defined(AMYBOARD) // || defined(ESP_PLATFORM)
     c.ram_caps_events = MALLOC_CAP_SPIRAM;
     c.ram_caps_synth = MALLOC_CAP_SPIRAM;
     c.ram_caps_block = MALLOC_CAP_DEFAULT;

--- a/src/delay.c
+++ b/src/delay.c
@@ -62,7 +62,11 @@ delay_line_t *new_delay_line(int len, int fixed_delay, int ram_type) {
         fprintf(stderr, "delay line len must be power of 2, not %d\n", len);
         abort();
     }
-    delay_line_t *delay_line = (delay_line_t*)malloc_caps(sizeof(delay_line_t) + len * sizeof(SAMPLE), ram_type); 
+    delay_line_t *delay_line = (delay_line_t*)malloc_caps(sizeof(delay_line_t) + len * sizeof(SAMPLE), ram_type);
+    if (delay_line == NULL) {
+	fprintf(stderr, "unable to alloc delay line of %d samples\n", len);
+	return NULL;
+    }
     delay_line->samples = (SAMPLE*)(((uint8_t*)delay_line) + sizeof(delay_line_t));
     delay_line->len = len;
     delay_line->log_2_len = log_2_len;


### PR DESCRIPTION
Print an error message and return rather than accessing the null pointer.