### PR TITLE
AMY_MIDI_Synth.ino: Make features.default_synths=1 explicit.

### DIFF
--- a/examples/AMY_MIDI_Synth/AMY_MIDI_Synth.ino
+++ b/examples/AMY_MIDI_Synth/AMY_MIDI_Synth.ino
@@ -54,6 +54,8 @@ void test_audio_in() {
 void setup() {
   amy_config_t amy_config = amy_default_config();
   amy_config.features.startup_bleep = 1;
+  // Install the default_synths on synths (MIDI chans) 1, 2, and 10 (this is the default).
+  amy_config.features.default_synths = 1;
 
   // If you want MIDI over UART (5-pin or 3-pin serial MIDI)
   amy_config.midi = AMY_MIDI_IS_UART;


### PR DESCRIPTION
Some people are surprised that their library starts up with so much specific state.  This at least leaves a little reminder.