### PR TITLE
Fm mod osc

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -1109,6 +1109,7 @@ void play_delta(struct delta *d) {
         synth[d->osc]->mod_source = mod_osc;
         // NOTE: These are delta-only side effects.  A purist would strive to remove them.
         // When an oscillator is named as a modulator, we change its state.
+        ensure_osc_allocd(mod_osc, NULL);
         synth[mod_osc]->status = SYNTH_IS_MOD_SOURCE;
         // No longer record this osc in note_off state.
         AMY_UNSET(synth[mod_osc]->note_off_clock);

--- a/src/amy.h
+++ b/src/amy.h
@@ -749,7 +749,7 @@ void amy_live_stop();
 int16_t * amy_simple_fill_buffer() ;
 void amy_update();
 int16_t *amy_render_audio();
-void amy_pass_to_i2s(int16_t *block);
+void amy_pass_to_i2s(const int16_t *block);
 amy_config_t amy_default_config();
 void amy_clear_event(amy_event *e);
 amy_event amy_default_event();

--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -7,7 +7,7 @@
 #endif
 
 #if (defined ARDUINO_ARCH_RP2040) || (defined ARDUINO_ARCH_RP2350)
-#define TUD_USB_GADGET
+//#define TUD_USB_GADGET
 #include "tusb.h"
 #include "class/midi/midi.h"
 #include "class/midi/midi_device.h"

--- a/src/i2s.c
+++ b/src/i2s.c
@@ -266,16 +266,21 @@ void amy_poll_tasks() {
 
 int16_t *amy_render_audio() {
     //if (ap->free_list != NULL) {
+//#define USE_SECOND_CORE
+#ifdef USE_SECOND_CORE
     int32_t res;
     queue_entry_t entry = {render_other_core, AMY_OK};
     queue_add_blocking(&call_queue, &entry);
     amy_render(0, AMY_OSCS/2, 0);
     queue_remove_blocking(&results_queue, &res);
+#else
+    amy_render(0, AMY_OSCS, 0);
+#endif
     int16_t *block = amy_fill_buffer();
     return block;
 }
 
-void amy_pass_to_i2s(int16_t *block) {
+void amy_pass_to_i2s_old(const int16_t *block) {
     size_t written = 0;
     struct audio_buffer *buffer = take_audio_buffer(ap, true);
     int16_t *samples = (int16_t *) buffer->buffer->bytes;
@@ -340,7 +345,7 @@ void core1_main() {
 }
 
 
-amy_err_t i2s_amy_init() {
+amy_err_t i2s_amy_init_old() {
     queue_init(&call_queue, sizeof(queue_entry_t), 2);
     queue_init(&results_queue, sizeof(int32_t), 2);
     uint32_t * core1_separate_stack_address = (uint32_t*)malloc(0x2000);
@@ -350,7 +355,16 @@ amy_err_t i2s_amy_init() {
     return AMY_OK;
 }
 
+extern void i2s_read_write_buffer(int16_t *in_samples, const int16_t *out_samples, int nframes);
 
+void amy_pass_to_i2s(const int16_t *block) {
+    // len is the number of int16 sample frames.
+    i2s_read_write_buffer(amy_in_block, block, AMY_BLOCK_SIZE);
+}
+
+amy_err_t i2s_amy_init() {
+    return AMY_OK;
+}
 
 
 #elif defined __IMXRT1062__

--- a/src/i2s.c
+++ b/src/i2s.c
@@ -266,7 +266,7 @@ void amy_poll_tasks() {
 
 int16_t *amy_render_audio() {
     //if (ap->free_list != NULL) {
-//#define USE_SECOND_CORE
+#define USE_SECOND_CORE
 #ifdef USE_SECOND_CORE
     int32_t res;
     queue_entry_t entry = {render_other_core, AMY_OK};
@@ -363,6 +363,13 @@ void amy_pass_to_i2s(const int16_t *block) {
 }
 
 amy_err_t i2s_amy_init() {
+#ifdef USE_SECOND_CORE
+    queue_init(&call_queue, sizeof(queue_entry_t), 2);
+    queue_init(&results_queue, sizeof(int32_t), 2);
+    uint32_t * core1_separate_stack_address = (uint32_t*)malloc(0x2000);
+    multicore_launch_core1_with_stack(core1_main, core1_separate_stack_address, 0x2000);
+    sleep_ms(500);
+#endif
     return AMY_OK;
 }
 

--- a/src/pico_support.cpp
+++ b/src/pico_support.cpp
@@ -3,8 +3,9 @@
 //#include <Arduino.h>
 //#include <Adafruit_TinyUSB.h>
 //#include <MIDI.h>
+#ifdef USE_TUSB
 #include <Adafruit_TinyUSB.h>
-
+#endif
 
 
 
@@ -12,20 +13,24 @@ extern "C" {
 	void check_tusb_midi();
 	
 	void pico_setup_midi() {
-		if (!TinyUSBDevice.isInitialized()) {
+#ifdef USE_TUSB
+            if (!TinyUSBDevice.isInitialized()) {
 			TinyUSBDevice.begin(0);
 		}
 		//usb_midi.setStringDescriptor("AMY Synthesizer");
 
+#endif
 	}
 
 	void pico_process_midi() {
-		#ifdef TINYUSB_NEED_POLLING_TASK
+
+#ifdef USE_TUSB
+#ifdef TINYUSB_NEED_POLLING_TASK
 			// Manual call tud_task since it isn't called by Core's background
 			TinyUSBDevice.task();
 		#endif
 		check_tusb_midi();
+#endif
 	}
-
 }
 #endif


### PR DESCRIPTION
Setting the `mod_osc` directly modifies the status of that osc, but it was possible for the osc not to be allocated.