### PR TITLE
Fix error when echo delay lines array is empty or partially initialized

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -209,7 +209,9 @@ void config_echo(float level, float delay_ms, float max_delay_ms, float feedback
 	    }
 	    if (!success) {
 		fprintf(stderr, "unable to alloc echo of %d ms\n", (int)max_delay_ms);
-		echo_delay_lines[0] = echo_delay_lines[1] = NULL;
+		for (int c = 0; c < AMY_NCHANS; ++c) {
+		    echo_delay_lines[c] = NULL;
+		}
 		return;
 	    }
             amy_global.echo.max_delay_samples = max_delay_samples;
@@ -218,7 +220,9 @@ void config_echo(float level, float delay_ms, float max_delay_ms, float feedback
         // Apply delay.  We have to stay 1 sample less than delay line length for FIR EQ delay.
         if (delay_samples > amy_global.echo.max_delay_samples - 1) delay_samples = amy_global.echo.max_delay_samples - 1;
         for (int c = 0; c < AMY_NCHANS; ++c) {
-            echo_delay_lines[c]->fixed_delay = delay_samples;
+			if (echo_delay_lines[c] != NULL) {
+                echo_delay_lines[c]->fixed_delay = delay_samples;
+			}
         }
     }
     amy_global.echo.level = F2S(level);


### PR DESCRIPTION
The config_echo function is checking only echo_delay_lines[0] to determine if initialization is needed, but then unconditionally dereferences all channels in the array when setting fixed_delay. This causes en error when the array is partially initialized or contains NULL entries for some channels.