### PR TITLE
pyamy.c: miniaudio can be playback-only; api.c: Default AUDIO_IS_NONE.

### DIFF
--- a/src/amy-example.c
+++ b/src/amy-example.c
@@ -58,7 +58,6 @@ int main(int argc, char ** argv) {
 
     amy_config_t amy_config = amy_default_config();
     amy_config.audio = AMY_AUDIO_IS_MINIAUDIO;
-    amy_config.features.audio_in = 1;  // We need audio_in for miniaudio to run??
     amy_config.playback_device_id = playback_device_id;
     fprintf(stderr, "playback_device_id=%d\n", playback_device_id);
     amy_config.capture_device_id = capture_device_id;

--- a/src/amy-message.c
+++ b/src/amy-message.c
@@ -46,7 +46,7 @@ int main(int argc, char ** argv) {
 
     amy_config_t amy_config = amy_default_config();
     amy_config.audio = AMY_AUDIO_IS_MINIAUDIO;
-    amy_config.features.audio_in = 1;  // We need audio_in for miniaudio to run??
+    amy_config.features.audio_in = 1;  // Run with audio in.
     amy_config.features.default_synths = 0;
     amy_config.playback_device_id = playback_device_id;
     amy_config.capture_device_id = capture_device_id;

--- a/src/amy-piano.c
+++ b/src/amy-piano.c
@@ -16,7 +16,6 @@ int main(int argc, char ** argv) {
     amy_config.audio = AMY_AUDIO_IS_MINIAUDIO;
     //amy_config.playback_device_id = -1;
     //amy_config.capture_device_id = -1;
-    amy_config.features.audio_in = 1; // Needed to make libminiaudio work?
     amy_config.features.default_synths = 0;
     amy_start(amy_config);
 

--- a/src/api.c
+++ b/src/api.c
@@ -50,11 +50,7 @@ amy_config_t amy_default_config() {
     c.write_samples_fn = NULL;
 
     c.midi = AMY_MIDI_IS_NONE;
-    #ifndef AMY_MCU
-    c.audio = AMY_AUDIO_IS_MINIAUDIO;
-    #else
-    c.audio = AMY_AUDIO_IS_I2S;
-    #endif
+    c.audio = AMY_AUDIO_IS_NONE;
     c.ks_oscs = 1;
 
     c.max_oscs = 180;
@@ -348,13 +344,15 @@ void amy_start(amy_config_t c) {
             amy_bleep(0);  // bleep using raw oscs.
     }
 #if !defined(ESP_PLATFORM) && !defined(PICO_ON_DEVICE) && !defined(ARDUINO) && !defined(__EMSCRIPTEN__)
-    miniaudio_start();
+    if (amy_global.config.audio == AMY_AUDIO_IS_MINIAUDIO)
+        miniaudio_start();
 #endif
 }
 
 void amy_stop() {
 #if !defined(ESP_PLATFORM) && !defined(PICO_ON_DEVICE) && !defined(ARDUINO)
-    miniaudio_stop();
+    if (amy_global.config.audio == AMY_AUDIO_IS_MINIAUDIO)
+        miniaudio_stop();
 #endif
     oscs_deinit();
 }


### PR DESCRIPTION
With the merger of amy_live into amy_start, we need to be able to start Amy *without* automatic live sound output, so the default value for amy_config.audio (in api.c) is AMY_AUDIO_IS_NONE; you have to explicitly ask for something else.

After Brian fixed miniaudio to run even without sound input, we no longer need to always set features.audio_in when selecting miniaudio.  The pyamy live() command now will select playback only if it's passed only one arg (the playback device) (but it runs with audio_in if there are 2 args (capture device) or 0 args (defaults for both playback and capture).
