### PR TITLE
Hpf bpf upper limit

### DIFF
--- a/amy/test.py
+++ b/amy/test.py
@@ -903,21 +903,17 @@ class TestParamsInPatchCmd(AmyTest):
     amy.send(time=400, synth=1, note=60, vel=0)
     amy.send(time=400, synth=1, note=63, vel=0)
 
-class TestHPFBPFHighBaseFreq(AmyTest):
+class TestHPFHighBaseFreq(AmyTest):
   def run(self):
-    amy.send(time=0, synth=1, patch=0, num_voices=4, filter_type=amy.FILTER_HPF, filter_freq=1200)
-    amy.send(time=50, synth=1, note=48, vel=1)
-    amy.send(time=150, synth=1, note=60, vel=1)
-    amy.send(time=250, synth=1, note=63, vel=1)
-    #
-    amy.send(time=300, synth=1, patch=0, num_voices=4, filter_type=amy.FILTER_BPF, filter_freq=1200)
-    amy.send(time=350, synth=1, note=48, vel=1)
-    amy.send(time=450, synth=1, note=60, vel=1)
-    amy.send(time=550, synth=1, note=63, vel=1)
-    # notes off
-    amy.send(time=700, synth=1, note=48, vel=0)
-    amy.send(time=700, synth=1, note=60, vel=0)
-    amy.send(time=700, synth=1, note=63, vel=0)
+    amy.send(time=0, synth=1, patch=0, num_voices=4)
+    amy.send(time=10, synth=1, filter_type=amy.FILTER_HPF, filter_freq=1000)
+    amy.send(time=50, synth=1, note=48, vel=10)
+    amy.send(time=150, synth=1, note=60, vel=10)
+    amy.send(time=250, synth=1, note=63, vel=10)
+    # notes off 
+    amy.send(time=400, synth=1, note=48, vel=0)
+    amy.send(time=400, synth=1, note=60, vel=0)
+    amy.send(time=400, synth=1, note=63, vel=0)
 
 
 def main(argv):

--- a/src/filters.c
+++ b/src/filters.c
@@ -89,6 +89,9 @@ int8_t dsps_biquad_gen_hpf_f32(SAMPLE *coeffs, float f, float qFactor)
     if (qFactor <= 0.0001) {
         qFactor = 0.0001;
     }
+    if (f > 0.45) {
+        f = 0.45;
+    }
     float Fs = 1;
 
     float w0 = 2 * M_PI * f / Fs;
@@ -115,6 +118,9 @@ int8_t dsps_biquad_gen_bpf_f32(SAMPLE *coeffs, float f, float qFactor)
 {
     if (qFactor <= 0.0001) {
         qFactor = 0.0001;
+    }
+    if (f > 0.45) {
+        f = 0.45;
     }
     float Fs = 1;
 


### PR DESCRIPTION
Puts a hard limit on the break frequency for HPF and BPF at 0.45 f_nyq (i.e. 19.8 kHz).  Fixes #516 