### PR TITLE
removing incorrect python req

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,4 @@ name = "amy"
 version = "0.1.0"
 description = "AMY synthesizer"
 readme = "README.md"
-requires-python = ">=3.11"
 dependencies = ['numpy', 'scipy']


### PR DESCRIPTION
I had committed a pyproject.toml, which is fine, but it had an incorrect requirement set by uv, which was not. this removes that.

