### PR TITLE
parse_message finds ends of embedded wire strings directly; 

### DIFF
--- a/src/amy.h
+++ b/src/amy.h
@@ -811,7 +811,7 @@ uint32_t ms_to_samples(uint32_t ms) ;
 // API
 void amy_add_message(char *message);
 void amy_add_event(amy_event *e);
-void amy_parse_message(char * message, int length, amy_event *e);
+int amy_parse_message(char * message, int length, amy_event *e);
 void amy_start(amy_config_t);
 void amy_stop();
 

--- a/src/filters.c
+++ b/src/filters.c
@@ -225,7 +225,7 @@ static inline SAMPLE ABS(SAMPLE a) {
 static inline int headroom(SAMPLE a) {
     // How many bits bigger can this value get before overflow?
 #ifdef AMY_USE_FIXEDPOINT
-    return __builtin_clz(ABS(a)) - 1;  // -1 for sign bit.
+    return __builtin_clz(ABS(a) | 1) - 1;  // -1 for sign bit.
 #else  // !AMY_USE_FIXEDPOINT
     // How many bits can you shift before this max overflows?
     int bits = 0;
@@ -240,7 +240,7 @@ static inline int headroom(SAMPLE a) {
 static inline int nheadroom16(SAMPLE a) {
     // Headroom with MAX(0, 16 - headroom(a)) precomputed.
 #ifdef AMY_USE_FIXEDPOINT
-    return MAX(0, 16 - (__builtin_clz(ABS(a)) - 1));  // -1 for sign bit.
+    return MAX(0, 16 - (__builtin_clz(ABS(a) | 1) - 1));  // -1 for sign bit.
 #else  // !AMY_USE_FIXEDPOINT
     // How many bits can you shift before this max overflows?
     int bits = 0;

--- a/src/miniaudio.h
+++ b/src/miniaudio.h
@@ -28083,7 +28083,7 @@ static ma_result ma_device_stop__alsa(ma_device* pDevice)
     resultPoll = poll((struct pollfd*)pDevice->alsa.pPollDescriptorsCapture, 1, 0);
     if (resultPoll > 0) {
         ma_uint64 t;
-        read(((struct pollfd*)pDevice->alsa.pPollDescriptorsCapture)[0].fd, &t, sizeof(t));
+        (void)!read(((struct pollfd*)pDevice->alsa.pPollDescriptorsCapture)[0].fd, &t, sizeof(t));
     }
     }
 
@@ -28104,7 +28104,7 @@ static ma_result ma_device_stop__alsa(ma_device* pDevice)
     resultPoll = poll((struct pollfd*)pDevice->alsa.pPollDescriptorsPlayback, 1, 0);
     if (resultPoll > 0) {
         ma_uint64 t;
-        read(((struct pollfd*)pDevice->alsa.pPollDescriptorsPlayback)[0].fd, &t, sizeof(t));
+        (void)!read(((struct pollfd*)pDevice->alsa.pPollDescriptorsPlayback)[0].fd, &t, sizeof(t));
     }
 
     }
@@ -57321,7 +57321,7 @@ MA_API ma_result ma_data_source_read_pcm_frames(ma_data_source* pDataSource, voi
 
     /* Keep reading until we've read as many frames as possible. */
     while (totalFramesProcessed < frameCount) {
-        ma_uint64 framesProcessed;
+        ma_uint64 framesProcessed = 0;
         ma_uint64 framesRemaining = frameCount - totalFramesProcessed;
 
         /* We need to resolve the data source that we'll actually be reading from. */

--- a/src/parse.c
+++ b/src/parse.c
@@ -443,7 +443,7 @@ int _next_alpha(char *s) {
 
 
 // given a string return a parsed event
-void amy_parse_message(char * message, int length, amy_event *e) {
+int amy_parse_message(char * message, int length, amy_event *e) {
     peek_stack("parse_message");
     char cmd = '\0';
     uint16_t pos = 0;
@@ -452,7 +452,7 @@ void amy_parse_message(char * message, int length, amy_event *e) {
     if (amy_global.transfer_flag == AMY_TRANSFER_TYPE_FILE || amy_global.transfer_flag == AMY_TRANSFER_TYPE_AUDIO) {
         parse_transfer_message(message, length);
         e->status = EVENT_TRANSFER_DATA;
-        return;
+        return length;
     }
 
     while(pos < length) {
@@ -568,7 +568,8 @@ void amy_parse_message(char * message, int length, amy_event *e) {
             /* Y,y available */
             /* Z used for end of message */
             case 'Z':
-                break;
+	      ++pos;
+	      goto end;
             default:
                 break;
             }
@@ -578,4 +579,7 @@ void amy_parse_message(char * message, int length, amy_event *e) {
         if (pos > length) fprintf(stderr, "parse string overrun %d %d %s\n", pos, length, message);
         pos += _next_alpha(message + pos);  // Skip over any non-alpha argument to the current command.
     }
+ end:
+    // Return exactly how many characters we used.
+    return pos;
 }


### PR DESCRIPTION
amy_parse_message used to overshoot the end when consuming wire messages.

also make sure clz doesn't see zeros.