### PR TITLE
Move external hooks into amy_config

### DIFF
--- a/src/amy-example.c
+++ b/src/amy-example.c
@@ -68,9 +68,8 @@ int main(int argc, char ** argv) {
                 break; 
         } 
     }
-    amy_external_render_hook = render;
-
     amy_config_t amy_config = amy_default_config();
+    amy_config.amy_external_render_hook = render;
     amy_config.audio = AMY_AUDIO_IS_MINIAUDIO;
     amy_config.playback_device_id = playback_device_id;
     fprintf(stderr, "playback_device_id=%d\n", playback_device_id);

--- a/src/amy.c
+++ b/src/amy.c
@@ -1346,9 +1346,9 @@ void hold_and_modify(uint16_t osc) {
     ctrl_inputs[COEF_EG1] = S2F(compute_breakpoint_scale(osc, 1, 0));
     ctrl_inputs[COEF_MOD] = S2F(compute_mod_scale(osc));
     ctrl_inputs[COEF_BEND] = amy_global.pitch_bend;
-    if(amy_external_coef_hook != NULL) {
-        ctrl_inputs[COEF_EXT0] = amy_external_coef_hook(0);
-        ctrl_inputs[COEF_EXT1] = amy_external_coef_hook(1);
+    if(amy_global.config.amy_external_coef_hook != NULL) {
+        ctrl_inputs[COEF_EXT0] = amy_global.config.amy_external_coef_hook(0);
+        ctrl_inputs[COEF_EXT1] = amy_global.config.amy_external_coef_hook(1);
     } else {
         #ifdef __EMSCRIPTEN__
         ctrl_inputs[COEF_EXT0] = amy_web_cv_1;
@@ -1551,8 +1551,8 @@ void amy_render(uint16_t start, uint16_t end, uint8_t core) {
                 max_val = filter_process(per_osc_fb[core], osc, max_val);
 	        }
             uint8_t handled = 0;
-            if(amy_external_render_hook!=NULL) {
-                handled = amy_external_render_hook(osc, per_osc_fb[core], AMY_BLOCK_SIZE);
+            if(amy_global.config.amy_external_render_hook != NULL) {
+                handled = amy_global.config.amy_external_render_hook(osc, per_osc_fb[core], AMY_BLOCK_SIZE);
             } else {
                 #ifdef __EMSCRIPTEN__
                 // TODO -- pass the buffer to a JS shim using the new bytes support, we could use this to visualize CV output
@@ -1641,8 +1641,8 @@ void amy_block_processed(void) {
         }
     });
 #else
-    if(amy_external_block_done_hook != NULL) {
-        amy_external_block_done_hook();
+    if(amy_global.config.amy_external_block_done_hook != NULL) {
+        amy_global.config.amy_external_block_done_hook();
     }
 #endif
 }

--- a/src/amy.h
+++ b/src/amy.h
@@ -652,6 +652,19 @@ typedef struct  {
     // alternative audio output function
     size_t (*write_samples_fn)(const uint8_t *buffer, size_t buffer_size);
 
+    // Optional hooks for host/platform integration.
+    uint8_t (*amy_external_render_hook)(uint16_t osc, SAMPLE *, uint16_t len);
+    float (*amy_external_coef_hook)(uint16_t channel);
+    void (*amy_external_block_done_hook)(void);
+    void (*amy_external_midi_input_hook)(uint8_t *bytes, uint16_t len, uint8_t is_sysex);
+    void (*amy_external_sequencer_hook)(uint32_t tick_count);
+    uint32_t (*amy_external_fopen_hook)(char *filename, char *mode);
+    uint32_t (*amy_external_fwrite_hook)(uint32_t fptr, uint8_t *bytes, uint32_t len);
+    uint32_t (*amy_external_fread_hook)(uint32_t fptr, uint8_t *bytes, uint32_t len);
+    void (*amy_external_fseek_hook)(uint32_t fptr, uint32_t pos);
+    void (*amy_external_fclose_hook)(uint32_t fptr);
+    void (*amy_external_file_transfer_done_hook)(const char *filename);
+
     // pins for MCU platforms
     int8_t i2s_lrc;
     int8_t i2s_dout;
@@ -827,18 +840,6 @@ uint32_t amy_sysclock();
 int amy_get_output_buffer(output_sample_type * samples);
 int amy_get_input_buffer(output_sample_type * samples);
 void amy_set_external_input_buffer(output_sample_type * samples);
-extern uint8_t (*amy_external_render_hook)(uint16_t, SAMPLE*, uint16_t);
-extern float (*amy_external_coef_hook)(uint16_t);
-extern void (*amy_external_block_done_hook)(void);
-extern void (*amy_external_midi_input_hook)(uint8_t *, uint16_t, uint8_t);
-extern void (*amy_external_sequencer_hook)(uint32_t);
-// Hooks for file reading / writing / opening if your AMY host supports that
-extern uint32_t (*amy_external_fopen_hook)(char * filename, char * mode) ;
-extern uint32_t (*amy_external_fwrite_hook)(uint32_t fptr, uint8_t * bytes, uint32_t len);
-extern uint32_t (*amy_external_fread_hook)(uint32_t fptr, uint8_t *bytes, uint32_t len);
-extern void (*amy_external_fseek_hook)(uint32_t fptr, uint32_t pos);
-extern void (*amy_external_fclose_hook)(uint32_t fptr);
-extern void (*amy_external_file_transfer_done_hook)(const char *filename);
 
 
 #ifdef __EMSCRIPTEN__

--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -164,8 +164,8 @@ void amy_event_midi_message_received(uint8_t * data, uint32_t len, uint8_t sysex
     }
 
     // Also send the external hooks if set
-    if(amy_external_midi_input_hook != NULL) {
-        amy_external_midi_input_hook(data, len, sysex);
+    if(amy_global.config.amy_external_midi_input_hook != NULL) {
+        amy_global.config.amy_external_midi_input_hook(data, len, sysex);
     }
 
     // Update web MIDI out hook if set

--- a/src/api.c
+++ b/src/api.c
@@ -3,35 +3,6 @@
 
 #include "amy.h"
 
-//////////////////////
-// Hooks
-
-// Optional render hook that's called per oscillator during rendering, used (now) for CV output from oscillators. 
-// return 1 if this oscillator should be silent
-uint8_t (*amy_external_render_hook)(uint16_t osc, SAMPLE*, uint16_t len ) = NULL;
-
-// Optional external coef setter (meant for CV control of AMY via CtrlCoefs)
-float (*amy_external_coef_hook)(uint16_t channel) = NULL;
-
-// Optional hook that's called after all processing is done for a block, meant for python callback control of AMY
-void (*amy_external_block_done_hook)(void) = NULL;
-
-// Optional hook for a consumer of AMY to access MIDI data coming IN to AMY
-void (*amy_external_midi_input_hook)(uint8_t * bytes, uint16_t len, uint8_t is_sysex) = NULL;
-
-// Called every sequencer tick
-void (*amy_external_sequencer_hook)(uint32_t) = NULL;
-
-// Hooks for file reading / writing / opening if your AMY host supports that
-uint32_t (*amy_external_fopen_hook)(char * filename, char * mode) = NULL;
-uint32_t (*amy_external_fwrite_hook)(uint32_t fptr, uint8_t * bytes, uint32_t len) = NULL;
-uint32_t (*amy_external_fread_hook)(uint32_t fptr, uint8_t * bytes, uint32_t len) = NULL;
-void (*amy_external_fseek_hook)(uint32_t fptr, uint32_t pos) = NULL;
-void (*amy_external_fclose_hook)(uint32_t fptr) = NULL;
-void (*amy_external_file_transfer_done_hook)(const char *filename) = NULL;
-
-
-
 amy_config_t amy_default_config() {
     amy_config_t c;
     c.features.reverb = 1;
@@ -48,6 +19,17 @@ amy_config_t amy_default_config() {
     c.platform.multithread = 1;
 
     c.write_samples_fn = NULL;
+    c.amy_external_render_hook = NULL;
+    c.amy_external_coef_hook = NULL;
+    c.amy_external_block_done_hook = NULL;
+    c.amy_external_midi_input_hook = NULL;
+    c.amy_external_sequencer_hook = NULL;
+    c.amy_external_fopen_hook = NULL;
+    c.amy_external_fwrite_hook = NULL;
+    c.amy_external_fread_hook = NULL;
+    c.amy_external_fseek_hook = NULL;
+    c.amy_external_fclose_hook = NULL;
+    c.amy_external_file_transfer_done_hook = NULL;
 
     c.midi = AMY_MIDI_IS_NONE;
     c.audio = AMY_AUDIO_IS_NONE;
@@ -245,7 +227,7 @@ void amy_start_web() {
     amy_config.midi = AMY_MIDI_IS_WEBMIDI;
     amy_config.features.default_synths = 1;
     amy_config.features.startup_bleep = 1;
-    amy_external_midi_input_hook = midi_cc_handler;
+    amy_config.amy_external_midi_input_hook = midi_cc_handler;
     amy_start(amy_config);
 }
 
@@ -254,7 +236,7 @@ void amy_start_web_no_synths() {
     amy_config_t amy_config = amy_default_config();
     amy_config.midi = AMY_MIDI_IS_WEBMIDI;
     amy_config.features.default_synths = 0;
-    amy_external_midi_input_hook = midi_cc_handler;
+    amy_config.amy_external_midi_input_hook = midi_cc_handler;
     amy_start(amy_config);
 }
 #endif
@@ -298,7 +280,7 @@ void amy_default_synths() {
     e.synth = 1;
     amy_add_event(&e);
     // Add some MIDI CCs for the Juno (defined in midi_mappings.c).
-    amy_external_midi_input_hook = juno_filter_midi_handler;
+    amy_global.config.amy_external_midi_input_hook = juno_filter_midi_handler;
 }
 
 // Schedule a bleep now
@@ -362,7 +344,9 @@ void amy_start(amy_config_t c) {
     if (amy_global.config.audio == AMY_AUDIO_IS_MINIAUDIO)
         miniaudio_start();
 #endif
-    amy_external_midi_input_hook = midi_cc_handler;
+    if (amy_global.config.amy_external_midi_input_hook == NULL) {
+        amy_global.config.amy_external_midi_input_hook = midi_cc_handler;
+    }
 }
 
 void amy_stop() {

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -111,8 +111,8 @@ static void fclose_if_file(memorypcm_preset_t *preset) {
     }
     if (preset->type == AMY_PCM_TYPE_FILE &&
         preset->file_handle != 0 &&
-        amy_external_fclose_hook != NULL) {
-        amy_external_fclose_hook(preset->file_handle);
+        amy_global.config.amy_external_fclose_hook != NULL) {
+        amy_global.config.amy_external_fclose_hook(preset->file_handle);
         preset->file_handle = 0;
     }
 }
@@ -126,14 +126,14 @@ void pcm_note_on(uint16_t osc) {
             if (preset->file_handle != 0) {
                 wave_info_t info = {0};
                 uint32_t data_bytes = 0;
-                amy_external_fseek_hook(preset->file_handle, 0);
+                amy_global.config.amy_external_fseek_hook(preset->file_handle, 0);
                 if (wave_parse_header(preset->file_handle, &info, &data_bytes)) {
                     preset->channels = info.channels;
                     preset->samplerate = info.sample_rate;
                     preset->log2sr = log2f((float)info.sample_rate / ZERO_LOGFREQ_IN_HZ);
                     preset->file_bytes_remaining = data_bytes;
                 } else {
-                    amy_external_fclose_hook(preset->file_handle);
+                    amy_global.config.amy_external_fclose_hook(preset->file_handle);
                 }
             }
         } else if (preset->type == AMY_PCM_TYPE_ROM) {
@@ -323,11 +323,11 @@ int pcm_load_file() {
     if (filename == NULL || filename[0] == '\0') {
         return 0;
     }
-    if (amy_external_fopen_hook == NULL || amy_external_fclose_hook == NULL) {
+    if (amy_global.config.amy_external_fopen_hook == NULL || amy_global.config.amy_external_fclose_hook == NULL) {
         fprintf(stderr, "fopen hook not enabled on platform\n");
         return 0;
     }
-    uint32_t handle = amy_external_fopen_hook((char *)filename, "rb");
+    uint32_t handle = amy_global.config.amy_external_fopen_hook((char *)filename, "rb");
     if (handle == 0) {
         fprintf(stderr, "Could not open file %s\n", filename);
         return 0;
@@ -336,7 +336,7 @@ int pcm_load_file() {
     uint32_t data_bytes = 0;
     if (!wave_parse_header(handle, &info, &data_bytes)) {
         fprintf(stderr, "Could not parse WAVE file %s\n", filename);
-        amy_external_fclose_hook(handle);
+        amy_global.config.amy_external_fclose_hook(handle);
         return 0;
     }
     uint32_t total_frames = 0;

--- a/src/sequencer.c
+++ b/src/sequencer.c
@@ -1,11 +1,6 @@
 #include "sequencer.h"
 #include "amy.h"
 
-
-
-// Optional sequencer hook that's called every tick
-extern void (*amy_external_sequencer_hook)(uint32_t);
-
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
@@ -116,8 +111,8 @@ static void sequencer_process_tick(void) {
         }
     }, amy_global.sequencer_tick_count);
 #endif
-    if(amy_external_sequencer_hook!=NULL) {
-        amy_external_sequencer_hook(amy_global.sequencer_tick_count);
+    if(amy_global.config.amy_external_sequencer_hook != NULL) {
+        amy_global.config.amy_external_sequencer_hook(amy_global.sequencer_tick_count);
     }
 }
 

--- a/src/transfer.c
+++ b/src/transfer.c
@@ -224,12 +224,12 @@ void start_receiving_file_transfer(uint32_t length, const char *filename) {
     if (filename == NULL || filename[0] == '\0') {
         return;
     }
-    if (amy_external_fopen_hook == NULL || amy_external_fwrite_hook == NULL || amy_external_fclose_hook == NULL) {
+    if (amy_global.config.amy_external_fopen_hook == NULL || amy_global.config.amy_external_fwrite_hook == NULL || amy_global.config.amy_external_fclose_hook == NULL) {
 
         fprintf(stderr, "file transfer hooks not enabled on platform\n");
         return;
     }
-        uint32_t handle = amy_external_fopen_hook((char *)filename, "wb");
+        uint32_t handle = amy_global.config.amy_external_fopen_hook((char *)filename, "wb");
     if (handle == HANDLE_INVALID) {
         fprintf(stderr, "could not open file for transfer: %s\n", filename);
         return;
@@ -249,8 +249,8 @@ void parse_transfer_message(char * message, uint16_t len) {
     size_t decoded = 0;
     uint8_t * block = b64_decode_ex (message, len, &decbuf, &decoded);
     if (amy_global.transfer_flag == AMY_TRANSFER_TYPE_FILE) {
-        if (amy_external_fwrite_hook != NULL && amy_global.transfer_file_handle != HANDLE_INVALID) {
-            uint32_t wrote = amy_external_fwrite_hook(amy_global.transfer_file_handle, block, (uint32_t)decoded);
+        if (amy_global.config.amy_external_fwrite_hook != NULL && amy_global.transfer_file_handle != HANDLE_INVALID) {
+            uint32_t wrote = amy_global.config.amy_external_fwrite_hook(amy_global.transfer_file_handle, block, (uint32_t)decoded);
             amy_global.transfer_stored_bytes += wrote;
         }
     } else {
@@ -260,11 +260,11 @@ void parse_transfer_message(char * message, uint16_t len) {
     }
     if (amy_global.transfer_stored_bytes >= amy_global.transfer_length_bytes) { // we're done
         if (amy_global.transfer_flag == AMY_TRANSFER_TYPE_FILE) {
-            if (amy_external_fclose_hook != NULL && amy_global.transfer_file_handle != HANDLE_INVALID) {
-                amy_external_fclose_hook(amy_global.transfer_file_handle);
+            if (amy_global.config.amy_external_fclose_hook != NULL && amy_global.transfer_file_handle != HANDLE_INVALID) {
+                amy_global.config.amy_external_fclose_hook(amy_global.transfer_file_handle);
             }
-            if (amy_external_file_transfer_done_hook != NULL) {
-                amy_external_file_transfer_done_hook(amy_global.transfer_filename); 
+            if (amy_global.config.amy_external_file_transfer_done_hook != NULL) {
+                amy_global.config.amy_external_file_transfer_done_hook(amy_global.transfer_filename); 
             }
             amy_global.transfer_file_handle = 0;
             amy_global.transfer_filename[0] = '\0';
@@ -452,11 +452,11 @@ void transfer_init() {
     #endif
 
  #if defined(_POSIX_VERSION) 
-    amy_external_fopen_hook = posix_external_fopen_hook;
-    amy_external_fread_hook = posix_external_fread_hook;
-    amy_external_fwrite_hook = posix_external_fwrite_hook;
-    amy_external_fclose_hook = posix_external_fclose_hook;
-    amy_external_fseek_hook = posix_external_fseek_hook;
+    amy_global.config.amy_external_fopen_hook = posix_external_fopen_hook;
+    amy_global.config.amy_external_fread_hook = posix_external_fread_hook;
+    amy_global.config.amy_external_fwrite_hook = posix_external_fwrite_hook;
+    amy_global.config.amy_external_fclose_hook = posix_external_fclose_hook;
+    amy_global.config.amy_external_fseek_hook = posix_external_fseek_hook;
 #endif
 }
 
@@ -470,12 +470,12 @@ static uint32_t read_u32_le(const uint8_t *buf) {
 }
 
 static int read_exact(uint32_t handle, uint8_t *buf, uint32_t len) {
-    if (amy_external_fread_hook == NULL) {
+    if (amy_global.config.amy_external_fread_hook == NULL) {
         return 0;
     }
     uint32_t offset = 0;
     while (offset < len) {
-        uint32_t got = amy_external_fread_hook(handle, buf + offset, len - offset);
+        uint32_t got = amy_global.config.amy_external_fread_hook(handle, buf + offset, len - offset);
         if (got == 0) {
             return 0;
         }
@@ -581,10 +581,10 @@ uint32_t wave_read_pcm_frames_s16(uint32_t handle, uint16_t channels,
         max_bytes = sizeof(raw_buf) - (sizeof(raw_buf) % bytes_per_frame);
         frames_to_read = max_bytes / bytes_per_frame;
     }
-    if (amy_external_fread_hook == NULL) {
+    if (amy_global.config.amy_external_fread_hook == NULL) {
         return 0;
     }
-    uint32_t got = amy_external_fread_hook(handle, raw_buf, max_bytes);
+    uint32_t got = amy_global.config.amy_external_fread_hook(handle, raw_buf, max_bytes);
     got -= got % bytes_per_frame;
     if (got == 0) {
         return 0;


### PR DESCRIPTION
## Summary
- move external hook function pointers into `amy_config_t`
- default all hook fields to `NULL` in `amy_default_config()`
- update hook assignments/call sites to use config-backed hooks

## Validation
- `make test` passes locally
