### PR TITLE
feat(arduino): Add USB Host MIDI example for ESP32-S3

### DIFF
--- a/examples/AMY_USB_Host_MIDI/AMY_USB_Host_MIDI.ino
+++ b/examples/AMY_USB_Host_MIDI/AMY_USB_Host_MIDI.ino
@@ -20,22 +20,20 @@
 //   - LilyGO T-Display-S3 + PCM5102A DAC + Arturia Minilab 25
 
 extern "C" {
-    void amy_process_single_midi_byte(uint8_t byte, uint8_t from_usb);
+    void convert_midi_bytes_to_messages(uint8_t *data, size_t len, uint8_t usb);
 }
 
 USBConnection usbMidi;
 
 // Bridge: forward USB-MIDI event packets into AMY's MIDI parser.
 // USB-MIDI packets are 4 bytes: [CIN+Cable, MIDI0, MIDI1, MIDI2].
-// We skip byte 0 (Cable/CIN) and feed bytes 1-3 with the USB flag,
-// which tells AMY to process them as a complete 3-byte group.
+// We pass bytes 1-3 as a group with the USB flag so AMY's parser can
+// exit early after completing the message, skipping padded bytes on
+// short messages (e.g. Program Change, Channel Pressure).
 void onUsbMidiData(void* ctx, const uint8_t* data, size_t length) {
     for (size_t i = 0; i + 4 <= length; i += 4) {
-        uint8_t cin = data[i] & 0x0F;
-        if (cin == 0x00) continue;  // Skip empty packets
-        amy_process_single_midi_byte(data[i + 1], 1);
-        amy_process_single_midi_byte(data[i + 2], 1);
-        amy_process_single_midi_byte(data[i + 3], 1);
+        if ((data[i] & 0x0F) == 0x00) continue;  // Skip empty packets
+        convert_midi_bytes_to_messages((uint8_t*)(data + i + 1), 3, 1);
     }
 }
 


### PR DESCRIPTION
## Summary

Add an Arduino example that enables **USB Host MIDI input** on ESP32-S3/S2/P4. Plug a USB MIDI keyboard directly via USB OTG cable — no shields or adapters needed.

The example bridges [ESP32_Host_MIDI](https://github.com/sauloverissimo/ESP32_Host_MIDI)'s USB transport to AMY's MIDI parser via `amy_process_single_midi_byte()`. AMY's default Juno-6 synth handles all note processing, voice stealing, and audio output.

### How it works

1. `USBConnection` (from ESP32_Host_MIDI) initializes the ESP-IDF USB Host stack on a FreeRTOS task pinned to core 0
2. On device connect, it scans config descriptors for Audio Class / MIDI Streaming interfaces, claims the interface, and starts bulk IN transfers
3. The bridge callback receives 4-byte USB-MIDI event packets, strips the CIN header byte, and feeds the 3 MIDI bytes into `amy_process_single_midi_byte(byte, 1)`
4. AMY's existing parser handles running status, NoteOn/Off, CC, pitch bend, program changes, etc.

### Hardware tested

- LilyGO T-Display-S3 + PCM5102A DAC + Arturia Minilab 25

![USB Host MIDI on ESP32-S3](https://raw.githubusercontent.com/sauloverissimo/ESP32_Host_MIDI/main/examples/T-Display-S3-Piano/images/pianno-MIDI-25.jpeg)

### Dependencies

- [ESP32_Host_MIDI](https://github.com/sauloverissimo/ESP32_Host_MIDI) (optional, only required for this example)

Refs #176
