### PR TITLE
Fix chorus max_delay type from int to int32_t

### DIFF
--- a/src/amy.h
+++ b/src/amy.h
@@ -707,7 +707,7 @@ typedef struct reverb_state {
 
 typedef struct chorus_config {
     SAMPLE level;     // How much of the delayed signal to mix in to the output, typ F2S(0.5).
-    int max_delay;    // Max delay when modulating.  Must be <= DELAY_LINE_LEN
+    int32_t max_delay;    // Max delay when modulating.  Must be <= DELAY_LINE_LEN
     float lfo_freq;
     float depth;
 } chorus_config_t;


### PR DESCRIPTION
## Summary
- Change `chorus_config.max_delay` from `int` to `int32_t`
- Fixes `_Generic` compile error on GCC (ESP-IDF xtensa toolchain) where plain `int` doesn't match any association in `AMY_UNSET_VALUE`

## Test plan
- [x] `make test` passes (72 tests)
- [ ] tulipcc amyboard ESP build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)