### PR TITLE
Reset oscs in a synth before loading patch

### DIFF
--- a/src/patches.c
+++ b/src/patches.c
@@ -1071,6 +1071,18 @@ void patches_load_patch(amy_event *e) {
                     (int32_t)e->synth, patch_number, (int32_t)e->num_voices, e->voices[0]);
         }
         return;
+    } else {
+        // Reset every osc belonging to each voice so stale state doesn't persist
+        // before we reallocate and reinitialize them below.
+        for (uint8_t v = 0; v < num_voices; v++) {
+            if (AMY_IS_SET(voice_to_base_osc[voices[v]])) {
+                uint16_t base = voice_to_base_osc[voices[v]];
+                for (uint16_t j = 0; j < AMY_OSCS - base; j++) {
+                    if (osc_to_voice[base + j] != voices[v]) break;
+                    reset_osc(base + j);
+                }
+            }
+        }
     }
 
     // At this point, we have the voices[] array and num_voices set up to be initialized.


### PR DESCRIPTION
## Summary
- When reloading a patch on a synth that already has voices, reset each osc of each voice before reallocation
- Prevents stale osc state from persisting into the new patch
- Implements the TODO at the `num_voices > 0` branch in `load_patch`

## Test plan
- [x] `make test` passes (72 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)