### PR TITLE
Fix ic255 to work without full payload

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -344,21 +344,21 @@ int amy_parse_synth_layer_message(char *message, amy_event *e) {
     else if (cmd == 'n')  e->oscs_per_voice = atoi(message);
     else if (cmd == 'c')  {
         // MIDI CC mapping ic<C>,<L>,<N>,<X>,<O>,<CODE>, see https://github.com/shorepine/amy/issues/524
-        // ic255 clears all MIDI CC mappings for this synth.
-        int32_t cc_code, is_log;
-        float min_val, max_val, offset_val;
-        skip_chars = parse_midi_cc_payload(message, &cc_code, &is_log, &min_val, &max_val, &offset_val);
-        if (skip_chars < 0) {
-            // payload didn't parse.
-            fprintf(stderr, "synth_layer: midi cc payload didn't parse for %s.\n", message - 1);
-            return 1;  // skip over the 'c'.
-        }
-        if (cc_code == 255) {
+        // ic255 clears all MIDI CC mappings for this synth (short form, no extra fields needed).
+        if (atoi(message) == 255) {
             midi_clear_channel_mappings(e->synth);
+            skip_chars = strlen(message) + 1;
         } else {
+            int32_t cc_code, is_log;
+            float min_val, max_val, offset_val;
+            skip_chars = parse_midi_cc_payload(message, &cc_code, &is_log, &min_val, &max_val, &offset_val);
+            if (skip_chars < 0) {
+                fprintf(stderr, "synth_layer: midi cc payload didn't parse for %s.\n", message - 1);
+                return 1;  // skip over the 'c'.
+            }
             midi_store_control_code(e->synth, cc_code, is_log, min_val, max_val, offset_val, message + skip_chars);
+            skip_chars = strlen(message) + 1;
         }
-        skip_chars = strlen(message) + 1;
     }
     else fprintf(stderr, "Unrecognized synth-level command '%s'\n", message - 1);
     return skip_chars;


### PR DESCRIPTION
## Summary
- `ic255` was failing because `parse_midi_cc_payload` requires 5 comma-separated fields
- Check for 255 via `atoi()` before calling the full parser, so `ic255` works as a short-form clear command

## Test plan
- [x] `make test` — 72 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)