### PR TITLE
src/parse.c: Rework 'ic255' handling

### DIFF
--- a/amy/test.py
+++ b/amy/test.py
@@ -1006,6 +1006,57 @@ ic10,1,1.000,100.000,1.000,i%id%vZ"""
     return is_ok, message
 
 
+class TestClearMidiCCs(AmyTest):
+  """Test that ic255 clears the MIDI CC settings."""
+
+  def test(self):
+    _amy.stop()
+    _amy.start(0)
+    amy.send(time=0, synth=1, num_voices=4, oscs_per_voice=2)
+    amy.send(time=0, synth=1, osc=0, wave=amy.SINE, freq=110, chained_osc=1)
+    amy.send(time=0, synth=1, osc=1, wave=amy.SAW_UP, freq=440)
+    amy.send_raw('i1ic5,0,0,10,0,hello')
+    amy.send_raw('i1ic10,1,1,100,1,i%id%v')
+    # Test that you can have other commands after the ic255 too.
+    amy.send_raw('i1ic255v0f999')
+    amy.render(1)  # Let the events execute.
+    commands = amy.get_synth_commands(1)
+    expected = """v0f999.000c1Z
+v1w3f440.000Z"""
+    if commands != expected:
+      is_ok = False
+      message = 'TestClearMidiCcs : get_synth_commands mismatch: expected:\n++\n%s\n--\n;saw:\n++\n%s\n--;' % (expected, commands)
+    else:
+      is_ok = True
+      message = 'TestClearMidiCcs : ok'
+    return is_ok, message
+
+class TestClearOneMidiCC(AmyTest):
+  """Test that ic5 with no further args clears that MIDI CC."""
+
+  def test(self):
+    _amy.stop()
+    _amy.start(0)
+    amy.send(time=0, synth=1, num_voices=4, oscs_per_voice=2)
+    amy.send(time=0, synth=1, osc=0, wave=amy.SINE, freq=110, chained_osc=1)
+    amy.send(time=0, synth=1, osc=1, wave=amy.SAW_UP, freq=440)
+    amy.send_raw('i1ic5,0,0,10,0,hello')
+    amy.send_raw('i1ic10,1,1,100,1,i%id%v')
+    amy.send_raw('i1ic5v0f999')
+    amy.render(1)  # Let the events execute.
+    commands = amy.get_synth_commands(1)
+    expected = """v0f999.000c1Z
+v1w3f440.000Z
+ic10,1,1.000,100.000,1.000,i%id%vZ"""
+    if commands != expected:
+      is_ok = False
+      message = 'TestClearOneMidiCC : get_synth_commands mismatch: expected:\n++\n%s\n--\n;saw:\n++\n%s\n--;' % (expected, commands)
+    else:
+      is_ok = True
+      message = 'TestClearOneMidiCC : ok'
+    return is_ok, message
+
+
 def main(argv):
   if len(argv) > 1 and argv[1] == 'quiet':
     quiet = True

--- a/src/amy.h
+++ b/src/amy.h
@@ -870,6 +870,7 @@ extern void reset_osc_by_pointer(struct synthinfo *psynth, struct mod_synthinfo 
 extern void reset_osc(uint16_t i );
 
 extern int midi_store_control_code(int channel, int code, int is_log, float min_val, float max_val, float offset_val, char *message);
+extern int midi_clear_control_code(int channel, int code);
 extern bool midi_fetch_control_code_command(int channel, int code, char *s, size_t len);
 extern void cc_mapping_debug();
 extern void midi_mappings_init();

--- a/src/midi_mappings.c
+++ b/src/midi_mappings.c
@@ -114,6 +114,17 @@ struct cc_mapping **cc_mapping_find(int channel, int code) {
     return NULL;
 }
 
+int midi_clear_control_code(int channel, int code) {
+    if (code == 255) {
+        // Magic value means clear all MIDI CCs for this channel
+        midi_clear_channel_mappings(channel);
+        return 1;
+    }
+    struct cc_mapping **p_mapping = cc_mapping_find(channel, code);
+    if (p_mapping) { cc_mapping_free(p_mapping); return 1; }
+    return 0;  // nothing found.
+}
+
 int midi_store_control_code(int channel, int code, int is_log, float min_val, float max_val, float offset_val, char *message) {
     // Register a MIDI control code and mapping and a wire code template.
     // Strip trailing wire protocol terminator(s) so they don't accumulate on round-trips.

--- a/src/parse.c
+++ b/src/parse.c
@@ -68,20 +68,6 @@ float atoff(const char *s) {
     int16_t:  atoi \
 )
 
-#define PARSE_VAL_TO_SEP(type) \
-    int parse_val_to_sep_##type(char *message, type *val, char sep) {   \
-        int c = 0;                                                      \
-        *val = PARSE_LIST_ATO(*val)(message);                           \
-        c = strspn(message, PARSE_LIST_STRSPN2(*val));                  \
-        if (message[c] == sep) {                                        \
-            return c + 1;                                               \
-        }                                                               \
-        return -1;                                                      \
-    }
-
-PARSE_VAL_TO_SEP(float)
-PARSE_VAL_TO_SEP(int32_t)
-
 #define PARSE_LIST(type) \
     int parse_list_##type(char *message, type *vals, int max_num_vals, type skipped_val) { \
         uint16_t c = 0, last_c; \
@@ -117,6 +103,17 @@ PARSE_LIST(uint16_t)
 PARSE_LIST(int32_t)
 PARSE_LIST(int16_t)
 
+
+#define PARSE_VAL(type) \
+    int parse_val_##type(char *message, type *val) {             \
+        int c = 0;                                                      \
+        *val = PARSE_LIST_ATO(*val)(message);                           \
+        c = strspn(message, PARSE_LIST_STRSPN2(*val));                  \
+        return c; \
+    }
+
+PARSE_VAL(float)
+PARSE_VAL(int32_t)
 
 char *copy_with_trim(char *dest, size_t dest_len, const char *src, size_t src_len) {
     // Copy a string while trimming leading and trailing spaces.
@@ -310,18 +307,17 @@ extern const mp_obj_fun_builtin_var_t tulip_pcm_load_file_obj;
 #endif
 
 int parse_midi_cc_payload(char *message, int32_t *p_cc_code, int32_t *p_is_log, float *p_min_val, float *p_max_val, float *p_offset_val) {
-    int c;
     char *m = message;
-    if ((c = parse_val_to_sep_int32_t(m, p_cc_code, ',')) < 0)  return -1;
-    m += c;
-    if ((c = parse_val_to_sep_int32_t(m, p_is_log, ',')) < 0)  return -1;
-    m += c;
-    if ((c = parse_val_to_sep_float(m, p_min_val, ',')) < 0)  return -1;
-    m += c;
-    if ((c = parse_val_to_sep_float(m, p_max_val, ',')) < 0)  return -1;
-    m += c;
-    if ((c = parse_val_to_sep_float(m, p_offset_val, ',')) < 0)  return -1;
-    m += c;
+    m += parse_val_int32_t(m, p_cc_code);
+    if (m[0] != ',') goto end; else ++m;
+    m += parse_val_int32_t(m, p_is_log);
+    if (m[0] != ',') goto end; else ++m;
+    m += parse_val_float(m, p_min_val);
+    if (m[0] != ',') goto end; else ++m;
+    m += parse_val_float(m, p_max_val);
+    if (m[0] != ',') goto end; else ++m;
+    m += parse_val_float(m, p_offset_val);
+ end:
     return m - message;
 }
 
@@ -345,20 +341,24 @@ int amy_parse_synth_layer_message(char *message, amy_event *e) {
     else if (cmd == 'c')  {
         // MIDI CC mapping ic<C>,<L>,<N>,<X>,<O>,<CODE>, see https://github.com/shorepine/amy/issues/524
         // ic255 clears all MIDI CC mappings for this synth (short form, no extra fields needed).
-        if (atoi(message) == 255) {
-            midi_clear_channel_mappings(e->synth);
-            skip_chars = strlen(message) + 1;
-        } else {
-            int32_t cc_code, is_log;
-            float min_val, max_val, offset_val;
-            skip_chars = parse_midi_cc_payload(message, &cc_code, &is_log, &min_val, &max_val, &offset_val);
-            if (skip_chars < 0) {
+        int32_t cc_code, is_log;
+        float min_val, max_val, offset_val;
+        AMY_UNSET(cc_code);
+        AMY_UNSET(is_log);
+        skip_chars = parse_midi_cc_payload(message, &cc_code, &is_log, &min_val, &max_val, &offset_val);
+        if (*(message + skip_chars) != ',') {
+            if (AMY_IS_UNSET(cc_code) || AMY_IS_SET(is_log)) {
+                // Either parsing bailed without even a CC code, or it got past the is_log, meaning it wasn't a bare ic<NUM> command.
                 fprintf(stderr, "synth_layer: midi cc payload didn't parse for %s.\n", message - 1);
-                return 1;  // skip over the 'c'.
+                return skip_chars;  // maybe the rest will parse?
             }
-            midi_store_control_code(e->synth, cc_code, is_log, min_val, max_val, offset_val, message + skip_chars);
-            skip_chars = strlen(message) + 1;
+            // Else we got an incomplete message with a valid CC code - clear it
+            midi_clear_control_code(e->synth, cc_code);  // (handles 255 as special case).
+            return skip_chars;
         }
+        ++skip_chars;  // step over the "," before the wire string template.
+        midi_store_control_code(e->synth, cc_code, is_log, min_val, max_val, offset_val, message + skip_chars);
+        skip_chars = strlen(message) + 1;
     }
     else fprintf(stderr, "Unrecognized synth-level command '%s'\n", message - 1);
     return skip_chars;


### PR DESCRIPTION
`ic` usually has 6 args (CC,ISLOG,MIN,MAX,OFFSET,wirecode).
But we extended the syntax so that a bare CC of 255 (without further commas and args) means clear all CCs.
This change extends it to allow *any* bare CC to mean "remove this single MIDI CC" (we used to have to send a full command with an empty wirecode).
It also allows other commands to follow the bare `ic<CC>`.
Adds tests for clearing all, or just one CC, and for commands following bare `ic<CC>`.

