### PR TITLE
amy_event->phase renamed trigger_phase; oscinfo[i]->trigger_phase now a float not PHASOR.

### DIFF
--- a/src/algorithms.c
+++ b/src/algorithms.c
@@ -101,7 +101,7 @@ void note_on_mod(uint16_t osc, uint16_t algo_osc) {
     synth[osc]->note_on_clock = amy_global.total_blocks * AMY_BLOCK_SIZE;
     synth[osc]->status = SYNTH_IS_ALGO_SOURCE; // to ensure it's rendered
     if (AMY_IS_SET(synth[osc]->trigger_phase))
-        synth[osc]->phase = synth[osc]->trigger_phase;
+        synth[osc]->phase = F2P(synth[osc]->trigger_phase);
     if(synth[osc]->wave==SINE) fm_sine_note_on(osc, algo_osc);
 }
 

--- a/src/amy.c
+++ b/src/amy.c
@@ -532,7 +532,7 @@ void amy_event_to_deltas_queue(amy_event *e, uint16_t base_osc, struct delta **q
     EVENT_TO_DELTA_COEFS(duty_coefs, DUTY)
     EVENT_TO_DELTA_COEFS(pan_coefs, PAN)
     EVENT_TO_DELTA_F(feedback, FEEDBACK)
-    EVENT_TO_DELTA_F(phase, PHASE)
+    EVENT_TO_DELTA_F(trigger_phase, PHASE)
     EVENT_TO_DELTA_F(volume, VOLUME)
     EVENT_TO_DELTA_F(pitch_bend, PITCH_BEND)
     EVENT_TO_DELTA_I(latency_ms, LATENCY)
@@ -1104,7 +1104,7 @@ void play_delta(struct delta *d) {
         synth[d->osc]->preset = (uint16_t)d->data.i;
     }
     if (d->param == PORTAMENTO) synth[d->osc]->portamento_alpha = portamento_ms_to_alpha(d->data.i);
-    if (d->param == PHASE) synth[d->osc]->trigger_phase = F2P(d->data.f);
+    if (d->param == PHASE) synth[d->osc]->trigger_phase = d->data.f;
 
     DELTA_TO_COEFS(AMP, amp_coefs)
     DELTA_TO_COEFS(FREQ, logfreq_coefs)
@@ -1248,7 +1248,7 @@ void play_delta(struct delta *d) {
 		    // We no longer reset the phase here; instead, we reset phase when an oscillator falls silent.
 		    // But if a trigger_phase is set, use that.
 		    if (AMY_IS_SET(synth[osc]->trigger_phase))
-			synth[osc]->phase = synth[osc]->trigger_phase;
+			synth[osc]->phase = F2P(synth[osc]->trigger_phase);
 
 		    // restart the waveforms
 		    // Guess at the initial frequency depending only on const & note.  Envelopes not "developed" yet.
@@ -1269,7 +1269,7 @@ void play_delta(struct delta *d) {
 		    uint16_t mod_osc = synth[osc]->mod_source;
 		    if(AMY_IS_SET(mod_osc)) {
 			if (AMY_IS_SET(synth[mod_osc]->trigger_phase))
-			    synth[mod_osc]->phase = synth[mod_osc]->trigger_phase;
+			    synth[mod_osc]->phase = F2P(synth[mod_osc]->trigger_phase);
 
 			synth[mod_osc]->note_on_clock = amy_global.total_blocks*AMY_BLOCK_SIZE;  // Need a note_on_clock to have envelope work correctly.
 			switch(synth[mod_osc]->wave) {

--- a/src/amy.h
+++ b/src/amy.h
@@ -464,7 +464,7 @@ typedef struct amy_event {
     float pan_coefs[NUM_COMBO_COEFS];
     float feedback;
     float velocity;
-    float phase;
+    float trigger_phase;
     float volume;  // event_only
     float pitch_bend;  // event_only
     float tempo;  // event_only
@@ -532,8 +532,8 @@ struct synthinfo {
     float feedback;
     uint8_t status;  // not in event
     float velocity;
-    PHASOR trigger_phase;  // not in event
-    PHASOR phase;
+    float trigger_phase;
+    PHASOR phase;  // not in event
     float step;  // not in event
     float substep;  // not in event
     SAMPLE mod_value;  // last value returned by this oscillator when acting as a MOD_SOURCE, not in event

--- a/src/api.c
+++ b/src/api.c
@@ -99,7 +99,7 @@ void amy_clear_event(amy_event *e) {
     AMY_UNSET(e->preset);
     AMY_UNSET(e->wave);
     AMY_UNSET(e->patch_number);
-    AMY_UNSET(e->phase);
+    AMY_UNSET(e->trigger_phase);
     AMY_UNSET(e->feedback);
     AMY_UNSET(e->velocity);
     AMY_UNSET(e->midi_note);

--- a/src/parse.c
+++ b/src/parse.c
@@ -534,7 +534,7 @@ int amy_parse_message(char * message, int length, amy_event *e) {
             case 'o': e->algorithm=atoi(arg); break;
             case 'O': parse_algo_source(arg, e->algo_source); break;
             case 'p': e->preset=atoi(arg); break;
-            case 'P': e->phase=atoff(arg); break;
+            case 'P': e->trigger_phase=atoff(arg); break;
             /* q unused */
             case 'Q': parse_coef_message(arg, e->pan_coefs); break;
             case 'r': parse_voices(arg, e->voices); break;

--- a/src/patches.c
+++ b/src/patches.c
@@ -264,7 +264,7 @@ int sprint_event(amy_event *e, char *s, size_t len, bool wirecode) {
     _EPRINT_COEF(duty_coefs, "duty_coefs", "d");
     _EPRINT_COEF(pan_coefs, "pan_coefs", "Q");
     _EPRINT_F(feedback, "feedback", "b");
-    _EPRINT_F(phase, "phase", "P");
+    _EPRINT_F(trigger_phase, "phase", "P");
     _EPRINT_F(volume, "volume", "V");  // NOT osc-dep
     _EPRINT_F(pitch_bend, "pitch_bend", "s");  // NOT osc-dep
     _EPRINT_F(tempo, "tempo", "j");  // NOT osc-dep
@@ -350,7 +350,7 @@ struct delta *deltas_to_event(struct delta *queue, struct amy_event *event) {
       _CASE_I(preset, PRESET)
       _CASE_F(midi_note, MIDI_NOTE)
       _CASE_F(feedback, FEEDBACK)
-      _CASE_F(phase, PHASE)
+      _CASE_F(trigger_phase, PHASE)
       _CASE_F(volume, VOLUME)
       _CASE_F(pitch_bend, PITCH_BEND)
       _CASE_I(latency_ms, LATENCY)
@@ -545,7 +545,7 @@ void set_event_for_osc(int osc, int baseosc, struct amy_event *event) {
     EVENT_FROM_OSC_ARRAY(duty_coefs, NUM_COMBO_COEFS);
     EVENT_FROM_OSC_ARRAY(pan_coefs, NUM_COMBO_COEFS);
     EVENT_FROM_OSC(feedback);
-    EVENT_FROM_OSC(phase);
+    EVENT_FROM_OSC(trigger_phase);
     EVENT_FROM_OSC_MAPPED(logratio, ratio, exp2f);
     EVENT_FROM_OSC(resonance);
     EVENT_FROM_OSC_MAPPED(portamento_alpha, portamento_ms, alpha_to_portamento_ms);


### PR DESCRIPTION
This confusion about which was the parameter (trigger_phase) and which was the state (phase) resulted in outlandish values coming out of set_event_for_osc which was trying to preserve the (momentary) oscillator phase.  This led to weird P values appearing in amyboardweb patch files.