### PR TITLE
Guard miniaudio externs with AMY_NO_MINIAUDIO define

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -348,8 +348,10 @@ void amy_bleep_synth(uint32_t start) {
     amy_add_event(&e);
 }
 
+#ifndef AMY_NO_MINIAUDIO
 extern void miniaudio_start();
 extern void miniaudio_stop();
+#endif
 
 void amy_start(amy_config_t c) {
     global_init(c);
@@ -365,7 +367,7 @@ void amy_start(amy_config_t c) {
         else
             amy_bleep(0);  // bleep using raw oscs.
     }
-#if !defined(ESP_PLATFORM) && !defined(PICO_ON_DEVICE) && !defined(ARDUINO) && !defined(__EMSCRIPTEN__)
+#if !defined(ESP_PLATFORM) && !defined(PICO_ON_DEVICE) && !defined(ARDUINO) && !defined(__EMSCRIPTEN__) && !defined(AMY_NO_MINIAUDIO)
     if (amy_global.config.audio == AMY_AUDIO_IS_MINIAUDIO)
         miniaudio_start();
 #endif
@@ -375,7 +377,7 @@ void amy_start(amy_config_t c) {
 }
 
 void amy_stop() {
-#if !defined(ESP_PLATFORM) && !defined(PICO_ON_DEVICE) && !defined(ARDUINO)
+#if !defined(ESP_PLATFORM) && !defined(PICO_ON_DEVICE) && !defined(ARDUINO) && !defined(AMY_NO_MINIAUDIO)
     if (amy_global.config.audio == AMY_AUDIO_IS_MINIAUDIO)
         miniaudio_stop();
 #endif


### PR DESCRIPTION
## Summary
- Wraps `extern void miniaudio_start()` / `miniaudio_stop()` declarations in `#ifndef AMY_NO_MINIAUDIO`
- Adds `!defined(AMY_NO_MINIAUDIO)` to the `#if` preprocessor guards around the `miniaudio_start()` and `miniaudio_stop()` call sites in `amy_start()` and `amy_stop()`
- Allows embedders to compile with `-DAMY_NO_MINIAUDIO` to cleanly exclude all miniaudio references

## Motivation
When embedding AMY in a host that handles audio output itself (e.g. a Godot GDExtension routing audio through `AudioStreamGenerator`), AMY is compiled with `audio=AMY_AUDIO_IS_NONE`. However, the `extern` declarations for `miniaudio_start`/`miniaudio_stop` in `api.c` still create linker dependencies on `libminiaudio-audio.c` symbols, even though they're never called at runtime. This forces embedders to provide stub functions to satisfy the linker.

With this change, embedders can add `-DAMY_NO_MINIAUDIO` to their compile flags and the miniaudio symbols are completely excluded at compile time — no stubs needed.

## Test plan
- [ ] Verify existing builds (macOS/Linux desktop with miniaudio) still work unchanged (no define needed)
- [ ] Verify embedded builds with `-DAMY_NO_MINIAUDIO -DAMY_AUDIO_IS_NONE` link without miniaudio stubs
- [ ] Tested in a Godot 4.6 GDExtension build that uses `AudioStreamGenerator` for audio output

🤖 Generated with [Claude Code](https://claude.com/claude-code)