### PR TITLE
Fix off-by-one in _EPRINT_I_SEQ dropping last element

### DIFF
--- a/src/patches.c
+++ b/src/patches.c
@@ -184,7 +184,7 @@ void add_deltas_to_queue_with_baseosc(struct delta *d, int base_osc, struct delt
     if (last_set >= 0) { \
         sprintf(s, "%s", wirecode ? WIRECODE : " " NAME ": ");       \
         s += strlen(s);  \
-        for (int i = 0; i < last_set; ++i) { \
+        for (int i = 0; i <= last_set; ++i) { \
             if (i > 0) { sprintf(s, ","); s += strlen(s); }        \
             if (AMY_IS_SET(e->FIELD[i])) { \
                 sprintf(s, "%" PRId32, (int32_t)e->FIELD[i]); \


### PR DESCRIPTION
## Summary
- `_EPRINT_I_SEQ` used `i < last_set` which excluded the final set element
- For DX7 `algo_source` with 6 operators (indices 0–5), this dropped operator 7 from saved patch files, producing `O2,3,4,5,6` instead of `O2,3,4,5,6,7`
- Reloading the saved patch file produced silence because the algorithm was missing an operator
- Changed to `i <= last_set` to match `_EPRINT_BP` which was already correct

## Test plan
- [x] `make test` passes (same 4 pre-existing FM threshold failures)
- [ ] Save DX7 preset to patch file, reload — should now produce sound

🤖 Generated with [Claude Code](https://claude.com/claude-code)