### PR TITLE
Fix Godot web export issues

### DIFF
--- a/docs/godot.md
+++ b/docs/godot.md
@@ -118,13 +118,13 @@ AMY works on web exports. The native GDExtension isn't used on web — instead, 
 
 1. **Run the install script** in the Godot editor:
    - Open `addons/amy/install.gd` in the Script Editor
-   - Run it via **Script > Run** (or `Ctrl/Cmd+Shift+X`)
+   - Run it via **File > Run** (or `Ctrl/Cmd+Shift+X`)
    - This copies web audio files to the right locations
 
 2. **Configure the web export preset**:
    - Open **Project > Export > Web**
    - Set **Custom HTML Shell** to `res://export/custom_shell.html`
-   - Set **Exclude Filter** to `addons/amy/*` (the native library isn't needed on web)
+   - Set **Exclude Filter** to `addons/amy/bin/*,addons/amy/src/*,addons/amy/amy_src/*,addons/amy/web/*,addons/amy/SConstruct,addons/amy/install.gd,addons/amy/amy.gdextension` (exclude native libraries and build files, but keep `amy.gd`)
 
 3. **Export as usual** — the HTML shell includes AMY's WASM automatically.
 

--- a/scripts/gen_amy_js_api.py
+++ b/scripts/gen_amy_js_api.py
@@ -220,11 +220,13 @@ def generate_js(kw_map_list, coef_fields, constants=None):
     // Constants from amy/constants.py (mirrors amy.SINE, amy.FILTER_LPF, etc.)
     var AMY = %CONSTANTS%;
 
-    window.amy_message = amy_message;
-    window.amy_send = amy_send;
-    window.AMY = AMY;
-    window.AMY_KW_MAP = AMY_KW_MAP;
-    window.AMY_COEF_FIELDS = AMY_COEF_FIELDS;
+    if (typeof globalThis !== "undefined") {
+      globalThis.amy_message = amy_message;
+      globalThis.amy_send = amy_send;
+      globalThis.AMY = AMY;
+      globalThis.AMY_KW_MAP = AMY_KW_MAP;
+      globalThis.AMY_COEF_FIELDS = AMY_COEF_FIELDS;
+    }
 
     })();
     """)

--- a/setup_godot.sh
+++ b/setup_godot.sh
@@ -1007,7 +1007,7 @@ cat > "${ADDON_DIR}/install.gd" << 'INSTALLEOF'
 extends EditorScript
 ## AMY Synthesizer Addon - Web Export Setup
 ##
-## Run this script once (via Script > Run) to copy web export files
+## Run this script once (via File > Run) to copy web export files
 ## to the correct locations in your project.
 ##
 ## It copies:
@@ -1052,7 +1052,7 @@ func _run() -> void:
 	print("")
 	print("Next steps:")
 	print("  1. In Export dialog, set Custom HTML Shell to: res://export/custom_shell.html")
-	print("  2. Set Exclude Filter to: addons/amy/*")
+	print("  2. Set Exclude Filter to: addons/amy/bin/*,addons/amy/src/*,addons/amy/amy_src/*,addons/amy/web/*,addons/amy/SConstruct,addons/amy/install.gd,addons/amy/amy.gdextension")
 	print("  3. Export for Web as usual!")
 	print("")
 


### PR DESCRIPTION
## Summary
- **Exclude filter was too broad**: `addons/amy/*` excluded `amy.gd` itself from web exports, causing "Could not parse global class Amy" errors. Changed to a specific list that keeps `amy.gd` while excluding native binaries and build files.
- **`window` not defined in AudioWorklet**: The generated JS API wrapper used `window.` to export globals, but `amy.js` also runs in AudioWorklet context where `window` doesn't exist. Changed to `globalThis` with a guard.
- **Wrong menu path in docs**: "Script > Run" → "File > Run" to match current Godot 4.x.

## Test plan
- [ ] Run `setup_godot.sh` to generate a fresh addon and verify `install.gd` has the updated exclude filter and menu path
- [ ] Export a Godot project for web with the new exclude filter and confirm no "Could not parse global class Amy" error
- [ ] Verify no "window is not defined" error in browser console
- [ ] Confirm audio plays correctly on web

🤖 Generated with [Claude Code](https://claude.com/claude-code)