### PR TITLE
Guard I2S/MIDI pin config with #ifndef AMYBOARD_ARDUINO

### DIFF
--- a/examples/AMY_MIDI_Synth/AMY_MIDI_Synth.ino
+++ b/examples/AMY_MIDI_Synth/AMY_MIDI_Synth.ino
@@ -78,6 +78,9 @@ void setup() {
   // Install the default_synths on synths (MIDI chans) 1, 2, and 10 (this is the default).
   amy_config.features.default_synths = 1;
 
+  // If running an AMYboard, we set these parameters for you automatically. 
+  // For your own boards, set the pins and features you want.
+  #ifndef AMYBOARD_ARDUINO
   // Pins for i2s board
   // Note: On the Teensy, all these settings are ignored, and blck = 21, lrc = 20, dout = 7.
   amy_config.audio = AMY_AUDIO_IS_I2S;
@@ -88,13 +91,14 @@ void setup() {
   amy_config.i2s_lrc = 9;
   amy_config.i2s_dout = 10;
   amy_config.i2s_din = 11;
-
+  
   // If you want MIDI over UART (5-pin or 3-pin serial MIDI)
   amy_config.midi = AMY_MIDI_IS_UART;
   // Pins for UART MIDI
   // Note: On the Teensy, these are ignored and midi_out = 35, midi_in = 34.
   amy_config.midi_out = 4;
   amy_config.midi_in = 5;
+  #endif
 
   amy_start(amy_config);
 

--- a/examples/BillieJeanDrums/BillieJeanDrums.ino
+++ b/examples/BillieJeanDrums/BillieJeanDrums.ino
@@ -9,12 +9,16 @@ void setup() {
   // Install the default_synths on synths (MIDI chans) 1, 2, and 10.
   amy_config.features.default_synths = 1;
 
+  // If running an AMYboard, we set these parameters for you automatically. 
+  // For your own boards, set the pins and features you want.
+  #ifndef AMYBOARD_ARDUINO
   amy_config.audio = AMY_AUDIO_IS_I2S;
   // Pins for i2s board
   amy_config.i2s_bclk = 8;
   amy_config.i2s_lrc = 9;
   amy_config.i2s_dout = 10;
-
+  #endif
+  
   amy_start(amy_config);
 }
 

--- a/examples/BillieJeanDrumsBass/BillieJeanDrumsBass.ino
+++ b/examples/BillieJeanDrumsBass/BillieJeanDrumsBass.ino
@@ -9,12 +9,16 @@ void setup() {
   // Install the default_synths on synths (MIDI chans) 1, 2, and 10 (this is the default).
   amy_config.features.default_synths = 1;
 
+  // If running an AMYboard, we set these parameters for you automatically. 
+  // For your own boards, set the pins and features you want.
+  #ifndef AMYBOARD_ARDUINO
   amy_config.audio = AMY_AUDIO_IS_I2S;
   // Pins for i2s board
   amy_config.i2s_bclk = 8;
   amy_config.i2s_lrc = 9;
   amy_config.i2s_dout = 10;
-
+  #endif
+  
   amy_start(amy_config);
 
   // Set up synth 2 as monophonic bass

--- a/examples/BillieJeanScheduled/BillieJeanScheduled.ino
+++ b/examples/BillieJeanScheduled/BillieJeanScheduled.ino
@@ -13,12 +13,17 @@ void setup() {
   // Install the default_synths on synths (MIDI chans) 1, 2, and 10 (this is the default).
   amy_config.features.default_synths = 1;
 
+
+  // If running an AMYboard, we set these parameters for you automatically. 
+  // For your own boards, set the pins and features you want.
+  #ifndef AMYBOARD_ARDUINO
   amy_config.audio = AMY_AUDIO_IS_I2S;
   // Pins for i2s board
   amy_config.i2s_bclk = 8;
   amy_config.i2s_lrc = 9;
   amy_config.i2s_dout = 10;
-
+  #endif
+  
   amy_start(amy_config);
 
   // Reconfigure synth 1 as a 6-note polyphonic synth (for chords)


### PR DESCRIPTION
## Summary
- Wrap I2S and MIDI pin configuration in `#ifndef AMYBOARD_ARDUINO` guards in all 4 Arduino examples
- AMYboard sets these pins automatically, so examples should skip manual config when compiled for AMYboard
- Affected examples: AMY_MIDI_Synth, BillieJeanDrums, BillieJeanDrumsBass, BillieJeanScheduled

## Test plan
- [ ] Compile examples for AMYboard — should use automatic pin config
- [ ] Compile examples for other boards — should use manual pin config as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)