### PR TITLE
Fix Arduino compilation error for non-AMYboard targets

### DIFF
--- a/src/usb.c
+++ b/src/usb.c
@@ -3,7 +3,7 @@
 
 #include "amy.h"
 
-#if defined AMY_MCU
+#if defined(AMY_MCU) && (!defined(ARDUINO) || defined(AMYBOARD_ARDUINO))
 
 #define CONFIG_TOTAL_LEN_MIDI  (TUD_CONFIG_DESC_LEN + TUD_MIDI_DESC_LEN + TUD_CDC_DESC_LEN)
 

--- a/src/usb.h
+++ b/src/usb.h
@@ -1,7 +1,7 @@
 // usb.h
 // tinyusb stuff
 
-#ifdef AMY_MCU
+#if defined(AMY_MCU) && (!defined(ARDUINO) || defined(AMYBOARD_ARDUINO))
 
 #include "class/audio/audio.h"
 #include "class/midi/midi.h"


### PR DESCRIPTION
## Summary
- Fixes #607 — Arduino compilation errors on Pico 2 (and other non-AMYboard Arduino targets) introduced in 1.2.1
- The USB descriptor code in `usb.c`/`usb.h` was guarded by `AMY_MCU`, which is defined for all Arduino MCU builds. Plain Arduino targets don't have MicroPython or AMYboard headers, causing undeclared symbol errors (`MICROPY_HW_USB_VID`, `mp_usbd_init_tud`, etc.)
- Tightens the preprocessor guard to `#if defined(AMY_MCU) && (!defined(ARDUINO) || defined(AMYBOARD_ARDUINO))` so USB code only compiles for MicroPython or AMYboard Arduino builds

## Test plan
- [x] `make test` passes (desktop build unaffected)
- [ ] Verify Arduino Pico 2 build compiles with standard examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)