### PR TITLE
Fix Teensy compilation errors in i2s.c

### DIFF
--- a/src/i2s.c
+++ b/src/i2s.c
@@ -551,7 +551,7 @@ void amy_platform_deinit() {
 }
 
 void amy_update_tasks() {
-    if(amy_config.global.midi & AMY_MIDI_IS_UART) {
+    if(amy_global.config.midi & AMY_MIDI_IS_UART) {
         // do midi in here
         uint8_t bytes[1];
         int t;
@@ -570,7 +570,7 @@ int16_t *amy_render_audio() {
 }
 
 size_t amy_i2s_write(const uint8_t *buffer, size_t nbytes) {
-    return teensy_i2s_send(buffer, nbytes);
+    return teensy_i2s_write(buffer, nbytes);
 }
 
 #else


### PR DESCRIPTION
## Summary
- Fixes two compile errors when building for Teensy 4.1 (caught by the new Arduino CI in #609)
- `amy_config.global.midi` → `amy_global.config.midi` — the global state struct is `amy_global`, matching how RP2040 does it on line 417
- `teensy_i2s_send` → `teensy_i2s_write` — matches the extern on line 537 and the definition in `teensy_support.cpp`

## Test plan
- [ ] Arduino CI passes for Teensy 4.1 (once #609 is also merged)
- [ ] `make test` passes (desktop build unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)