### PR TITLE
Guard Teensy AudioOutputUSB behind USB type check

### DIFF
--- a/src/teensy_support.cpp
+++ b/src/teensy_support.cpp
@@ -9,9 +9,11 @@ AudioOutputPT8211           i2s1;
 //AudioOutputI2S unused;
 AudioPlayQueue           queue_l;
 AudioPlayQueue           queue_r;
-AudioOutputUSB           usb_out;    
+#if defined(USB_AUDIO) || defined(USB_MIDI_AUDIO_SERIAL) || defined(USB_MIDI16_AUDIO_SERIAL)
+AudioOutputUSB           usb_out;
 AudioConnection          patchCord1(queue_r, 0, usb_out, 1);
 AudioConnection          patchCord2(queue_l, 0, usb_out, 0);
+#endif
 AudioConnection          patchCord3(queue_r, 0, i2s1, 1);
 AudioConnection          patchCord4(queue_l, 0, i2s1, 0);
 


### PR DESCRIPTION
## Summary
- `AudioOutputUSB` only exists when the Teensy USB type includes Audio (`USB_AUDIO`, `USB_MIDI_AUDIO_SERIAL`, etc.)
- With the default USB type (Serial), compilation fails with `'AudioOutputUSB' does not name a type`
- Wraps the USB audio output and its patch cords in `#if defined(USB_AUDIO) || defined(USB_MIDI_AUDIO_SERIAL) || defined(USB_MIDI16_AUDIO_SERIAL)`
- I2S output path remains unconditional

## Test plan
- [ ] Arduino CI Teensy 4.1 build passes (on #609 after rebase)
- [ ] Teensy build with USB type "MIDI + Audio + Serial" still includes USB audio output

🤖 Generated with [Claude Code](https://claude.com/claude-code)