### PR TITLE
Add missing stop_midi() for Teensy

### DIFF
--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -554,6 +554,9 @@ extern void teensy_start_midi();
 void run_midi() {
     if(amy_global.config.midi & AMY_MIDI_IS_UART) teensy_start_midi();
 }
+
+void stop_midi() {
+}
 #endif
 
 


### PR DESCRIPTION
## Summary
- The Teensy `__IMXRT1062__` section in `amy_midi.c` defined `run_midi()` but not `stop_midi()`
- `amy_stop()` in `api.c` calls `stop_midi()`, causing an undefined reference linker error
- Adds an empty `stop_midi()` stub matching what Linux and other minimal platforms do

## Test plan
- [ ] Arduino CI Teensy 4.1 build passes (on #609 after rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)