### PR TITLE
Bump version to 1.2.2 for Arduino release

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AMY Synthesizer
-version=1.2.1
+version=1.2.2
 author=Brian Whitman <brian@variogram.com>, DAn Ellis <dan.ellis@gmail.com>
 maintainer=Brian Whitman <brian@variogram.com>
 sentence=AMY, the Music Synthesizer Library


### PR DESCRIPTION
## Summary
- Bumps `library.properties` version to 1.2.2
- Includes fixes for Arduino compilation on non-AMYboard targets (#608), Teensy (#610, #612, #613), and new CI (#609, #611)

🤖 Generated with [Claude Code](https://claude.com/claude-code)