### PR TITLE
Custom osc example for Arduino

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -173,12 +173,12 @@ Hook fields in `amy_config_t`:
 
 | Hook | Signature | Used by | Description |
 | ---- | --------- | ------- | ----------- |
-| `amy_external_render_hook` | `uint8_t (uint16_t osc, SAMPLE *buf, uint16_t len)` | — | Custom oscillator renderer. Return 1 if handled. |
+| `amy_external_render_hook` | `uint8_t (uint16_t osc, SAMPLE *buf, uint16_t len)` | — | Custom oscillator renderer for redirecting the output waveforms on an osc-by-osc level. Return 1 if handled, in which case that osc does not contribute to the normal output. |
 | `amy_external_coef_hook` | `float (uint16_t channel)` | — | Provide external coefficient values (e.g. CV input). |
 | `amy_external_block_done_hook` | `void (void)` | — | Called after each audio block is rendered. |
 | `amy_external_midi_input_hook` | `void (uint8_t *bytes, uint16_t len, uint8_t is_sysex)` | — | Called when MIDI bytes are received. |
 | `amy_external_sequencer_hook` | `void (uint32_t tick_count)` | — | Called on each sequencer tick. |
-| `amy_external_fopen_hook` | `uint32_t (char *filename, char *mode)` | `zT`, `zD`, `zF` | Open a file on host disk. Returns opaque handle. |
+| `amy_external_fopen_hook` | `uint32_t (char *filename, const char *mode)` | `zT`, `zD`, `zF` | Open a file on host disk. Returns opaque handle. |
 | `amy_external_fwrite_hook` | `uint32_t (uint32_t fptr, uint8_t *bytes, uint32_t len)` | `zT` | Write bytes to a file opened via fopen hook. |
 | `amy_external_fread_hook` | `uint32_t (uint32_t fptr, uint8_t *bytes, uint32_t len)` | `zD` | Read bytes from a file opened via fopen hook. |
 | `amy_external_fseek_hook` | `void (uint32_t fptr, uint32_t pos)` | `zD` | Seek to position in a file opened via fopen hook. |

--- a/examples/AMY_custom_osc/AMY_custom_osc.ino
+++ b/examples/AMY_custom_osc/AMY_custom_osc.ino
@@ -1,0 +1,126 @@
+#include <AMY-Arduino.h>
+
+// Example of using the AMY "custom oscillator" from Arduino.
+
+// Custom osc types are defined by 7 functions:
+
+void my_custom_init() {
+  // Called once at synth setup.
+}
+
+void my_custom_deinit() {
+  // Called at synth teardown, to release resources.
+}
+
+void my_custom_note_on(uint16_t osc, float freq) {
+  // Called when note-on received, to set up any per-note state, with initial frequency value.
+}
+
+// Magic number AMY uses to indicate "unset" clocks.
+#define CLOCK_UNSET UINT32_MAX
+
+void my_custom_note_off(uint16_t osc) {
+  // Called when note-off received.
+  // If you want the built-in ADSR to work, the note-off has to signal that we've moved into release phase.
+  synth[osc]->note_on_clock = CLOCK_UNSET;
+  synth[osc]->note_off_clock = amy_global.total_blocks * AMY_BLOCK_SIZE;  // time (in samples) that release began.
+}
+
+void my_custom_mod_trigger(uint16_t osc) {
+  // Called when this osc is the mod_osc to another osc which receives a note-on.
+}
+
+// Non-anti-aliased square wave as an example custom oscillator.
+SAMPLE my_custom_render(SAMPLE *buf, uint16_t osc) {
+  // Called to render the next block of AMY_BLOCK_SIZE samples.  They should be summed into buf.  Return the peak value.
+  // We have access to the msynth[osc] parameters for this frame, and the persistent synth[osc] state.
+  // Calculate the phase advance per sample.  PHASOR is S.31 fixed point value, F2P converts a float to the PHASOR domain.
+  float freq = freq_of_logfreq(msynth[osc]->logfreq);  // Current pitch, including effects like pitch bend etc.
+  PHASOR step = F2P(freq / (float)AMY_SAMPLE_RATE);    // Phase advance per sample: cycles per sec / samples per sec -> cycles per sample
+  SAMPLE amp = F2S(msynth[osc]->amp);                  // msynth params are floats, but buffer etc are in S8.23 fixed point.
+  SAMPLE max_value = 0;
+  for (int i = 0; i < AMY_BLOCK_SIZE; ++i) {
+    SAMPLE value = MUL8_SS(amp,                        // MUL8_SS is fixed-point multiply, to apply ADSR envelope scaling in amp.
+                           (synth[osc]->phase >= F2P(0.5f)) ? F2S(0.5f) : F2S(-0.5f));  // Naive square wave.  Causes harsh alias tones.
+    buf[i] += value;                                   // Add it into the output buffer.
+    if (value < 0)  value = -value;   // i.e. calculate ABS(value)
+    if (value > max_value)  max_value = value;  // track the max
+    // Step on the phase variable.
+    synth[osc]->phase = P_WRAPPED_SUM(synth[osc]->phase, step);
+  }
+  return max_value;
+}
+
+SAMPLE my_custom_compute_mod(uint16_t osc) {
+  // Return the one value per block generated when this is mod_osc.
+  return 0;
+}
+
+// -------------------------------------
+
+void setup() {
+  amy_config_t amy_config = amy_default_config();
+  amy_config.features.startup_bleep = 1;
+  amy_config.features.default_synths = 0;
+
+  // If running an AMYboard, we set these parameters for you automatically. 
+  // For your own boards, set the pins and features you want.
+  #ifndef AMYBOARD_ARDUINO
+  // Pins for i2s board
+  // Note: On the Teensy, all these settings are ignored, and blck = 21, lrc = 20, dout = 7.
+  amy_config.audio = AMY_AUDIO_IS_I2S;
+  amy_config.i2s_mclk = 7;
+  amy_config.i2s_bclk = 8;
+  // On Pi Pico (RP2040, RP2350), i2s_lrc has to be i2s_bclk + 1, otherwise code will stop on an assert.
+  amy_config.i2s_lrc = 9;
+  amy_config.i2s_dout = 10;
+  amy_config.i2s_din = 11;
+  // If you want MIDI over UART (5-pin or 3-pin serial MIDI)
+  amy_config.midi = AMY_MIDI_IS_UART;
+  // Pins for UART MIDI
+  // Note: On the Teensy, these are ignored and midi_out = 35, midi_in = 34.
+  amy_config.midi_out = 4;
+  amy_config.midi_in = 5;
+  #endif
+
+  amy_config.features.custom = 1;  // We are using a custom oscillator.
+
+  // Install the custom oscillator functions.
+  struct custom_oscillator custom = {
+    my_custom_init,
+    my_custom_deinit,
+    my_custom_note_on,
+    my_custom_note_off,
+    my_custom_mod_trigger,
+    my_custom_render,
+    my_custom_compute_mod,
+  };
+  amy_set_custom(&custom);
+
+  amy_start(amy_config);
+
+  // Set up a single-osc synth using the custom osc.
+  amy_event e = amy_default_event();
+  e.synth = 1;
+  e.oscs_per_voice = 1;
+  e.num_voices = 4;
+  amy_add_event(&e);
+
+  e = amy_default_event();
+  e.synth = 1;
+  e.osc = 0;
+  e.wave = CUSTOM;
+  // Setup decaying ADSR
+  e.eg0_times[0] = 10;      // attack (in ms)
+  e.eg0_times[1] = 1000;    // decay
+  e.eg0_times[2] = 1000;    // release
+  e.eg0_values[0] = 1.0f;   // (attack target level)
+  e.eg0_values[1] = 0.3f;   // sustain
+  e.eg0_values[2] = 0;      // (release target level) 
+  amy_add_event(&e);
+}
+
+void loop() {
+  // Your loop() must contain this call to amy:
+  amy_update();
+}

--- a/src/amy.c
+++ b/src/amy.c
@@ -350,7 +350,7 @@ void config_reverb(float level, float liveness, float damping, float xover_hz) {
 }
 
 
-int8_t check_init(amy_err_t (*fn)(), char *name) {
+int8_t check_init(amy_err_t (*fn)(), const char *name) {
     //fprintf(stderr,"starting %s: ", name);
     const amy_err_t ret = (*fn)();
     if(ret != AMY_OK) {
@@ -371,7 +371,7 @@ uint8_t *get_sp() {
     //return NULL;
 }
 
-int peek_stack(char *tag) {
+int peek_stack(const char *tag) {
     if (stack_baseline == NULL) {
         stack_baseline = get_sp();
     }
@@ -382,7 +382,7 @@ int peek_stack(char *tag) {
 
 #else  // !DEBUG_STACK
 
-int peek_stack(char *tag)  { return 0; }
+int peek_stack(const char *tag)  { return 0; }
 
 #endif
 

--- a/src/amy.h
+++ b/src/amy.h
@@ -687,7 +687,7 @@ typedef struct  {
     void (*amy_external_block_done_hook)(void);
     void (*amy_external_midi_input_hook)(uint8_t *bytes, uint16_t len, uint8_t is_sysex);
     void (*amy_external_sequencer_hook)(uint32_t tick_count);
-    uint32_t (*amy_external_fopen_hook)(char *filename, char *mode);
+    uint32_t (*amy_external_fopen_hook)(char *filename, const char *mode);
     uint32_t (*amy_external_fwrite_hook)(uint32_t fptr, uint8_t *bytes, uint32_t len);
     uint32_t (*amy_external_fread_hook)(uint32_t fptr, uint8_t *bytes, uint32_t len);
     void (*amy_external_fseek_hook)(uint32_t fptr, uint32_t pos);
@@ -824,7 +824,7 @@ float logfreq_of_freq(float freq);
 float freq_of_logfreq(float logfreq);
 float portamento_ms_to_alpha(uint16_t portamento_ms);
 uint16_t alpha_to_portamento_ms(float alpha);
-int8_t check_init(amy_err_t (*fn)(), char *name);
+int8_t check_init(amy_err_t (*fn)(), const char *name);
 void * malloc_caps(uint32_t size, uint32_t flags);
 void config_reverb(float level, float liveness, float damping, float xover_hz);
 void config_chorus(float level, uint16_t max_delay, float lfo_freq, float depth);
@@ -973,7 +973,7 @@ extern void instrument_release(int instrument_number);
 extern void instrument_change_number(int old_instrument_number, int new_instrument_number);
 #define _INSTRUMENT_NO_VOICE (255)
 extern uint16_t instrument_voice_for_note_event(int instrument_number, int note, bool is_note_off, bool *pstolen);
-extern bool instrument_number_exists(int instrument_number, char *tag);
+extern bool instrument_number_exists(int instrument_number, const char *tag);
 extern int instrument_get_num_voices(int instrument_number, uint16_t *amy_voices);
 extern int instrument_all_notes_off(int instrument_number, uint16_t *amy_voices);
 extern int instrument_sustain(int instrument_number, bool sustain, uint16_t *amy_voices);
@@ -1076,6 +1076,6 @@ extern void delta_release_list(struct delta *d);  // releases a whole list of de
 extern int32_t delta_list_len(struct delta *d);
 extern int32_t delta_num_free();  // The size of the remaining pool.
 
-extern int peek_stack(char *tag);
+extern int peek_stack(const char *tag);
 
 #endif

--- a/src/instrument.c
+++ b/src/instrument.c
@@ -13,7 +13,7 @@
 #define INSTRUMENT_RAM_CAPS SYNTH_RAM_CAPS
 
 struct voice_fifo {
-    char *name;
+    const char *name;
     uint8_t length;
     uint8_t entries[MAX_VOICES_PER_INSTRUMENT + 1];  // fifo has one extra element to distinguish empty and full.
     uint8_t head;
@@ -32,7 +32,7 @@ void voice_fifo_debug(struct voice_fifo *fifo) {
     fprintf(stderr, "\n");
 }
 
-struct voice_fifo *voice_fifo_init(int size, char *name) {
+struct voice_fifo *voice_fifo_init(int size, const char *name) {
     if (size <=0 || size > MAX_VOICES_PER_INSTRUMENT) {
         fprintf(stderr, "init_voice_fifo: size %d value error (max size is %d)\n", size, MAX_VOICES_PER_INSTRUMENT);
         return NULL;
@@ -340,7 +340,7 @@ void instrument_release(int instrument_number) {
     instruments[instrument_number] = NULL;
 }
 
-bool instrument_number_ok(int instrument_number, char *tag) {
+bool instrument_number_ok(int instrument_number, const char *tag) {
     if (instrument_number < 0 || instrument_number >= max_instruments) {
         if (tag) fprintf(stderr, "instrument_number %d is out of range 0..%d (%s)\n", instrument_number, max_instruments, tag);
         return false;
@@ -348,7 +348,7 @@ bool instrument_number_ok(int instrument_number, char *tag) {
     return true;
 }
 
-bool instrument_number_exists(int instrument_number, char *tag) {
+bool instrument_number_exists(int instrument_number, const char *tag) {
     if (instrument_number_ok(instrument_number, tag)) {
         if (instruments[instrument_number])
             return true;

--- a/src/transfer.c
+++ b/src/transfer.c
@@ -66,7 +66,7 @@ static void free_handle(uint32_t h) {
 // uint32_t (*amy_external_fread_hook)(uint32_t fptr, uint8_t * bytes, uint32_t len) = NULL;
 // void (*amy_external_fclose_hook)(uint32_t fptr) = NULL;
 
-uint32_t posix_external_fopen_hook(char * filename, char *mode) {
+uint32_t posix_external_fopen_hook(char * filename, const char *mode) {
 #ifdef __EMSCRIPTEN__
     uint32_t js_handle = EM_ASM_INT({
         if (typeof amy_shared_open === 'function') {


### PR DESCRIPTION
This gives a small example of using `amy_set_custom` to define a custom oscillator waveform function.