### PR TITLE
wave.py: inline Chunk for Python 3.13+ compatibility

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -10,12 +10,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.12', '3.13', '3.14']
+
     steps:
     - uses: actions/checkout@v4
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: pip install numpy scipy

--- a/amy/wave.py
+++ b/amy/wave.py
@@ -85,8 +85,106 @@ _array_fmts = None, 'b', 'h', None, 'i'
 #import audioop
 import struct
 import sys
-from chunk import Chunk
 from collections import namedtuple
+
+
+# Vendored from CPython's chunk.py (removed in Python 3.13 by PEP 594).
+# Reads IFF-style chunks: 4-byte ID, 4-byte size, then `size` bytes of data.
+class Chunk:
+    def __init__(self, file, align=True, bigendian=True, inclheader=False):
+        self.closed = False
+        self.align = align
+        strflag = '>' if bigendian else '<'
+        self.file = file
+        self.chunkname = file.read(4)
+        if len(self.chunkname) < 4:
+            raise EOFError
+        try:
+            self.chunksize = struct.unpack_from(strflag + 'L', file.read(4))[0]
+        except struct.error:
+            raise EOFError
+        if inclheader:
+            self.chunksize = self.chunksize - 8
+        self.size_read = 0
+        try:
+            self.offset = self.file.tell()
+        except (AttributeError, OSError):
+            self.seekable = False
+        else:
+            self.seekable = True
+
+    def getname(self):
+        return self.chunkname
+
+    def getsize(self):
+        return self.chunksize
+
+    def close(self):
+        if not self.closed:
+            try:
+                self.skip()
+            finally:
+                self.closed = True
+
+    def isatty(self):
+        if self.closed:
+            raise ValueError("I/O operation on closed file")
+        return False
+
+    def seek(self, pos, whence=0):
+        if self.closed:
+            raise ValueError("I/O operation on closed file")
+        if not self.seekable:
+            raise OSError("cannot seek")
+        if whence == 1:
+            pos = pos + self.size_read
+        elif whence == 2:
+            pos = pos + self.chunksize
+        if pos < 0 or pos > self.chunksize:
+            raise RuntimeError
+        self.file.seek(self.offset + pos, 0)
+        self.size_read = pos
+
+    def tell(self):
+        if self.closed:
+            raise ValueError("I/O operation on closed file")
+        return self.size_read
+
+    def read(self, size=-1):
+        if self.closed:
+            raise ValueError("I/O operation on closed file")
+        if self.size_read >= self.chunksize:
+            return b''
+        if size < 0:
+            size = self.chunksize - self.size_read
+        if size > self.chunksize - self.size_read:
+            size = self.chunksize - self.size_read
+        data = self.file.read(size)
+        self.size_read = self.size_read + len(data)
+        if (self.size_read == self.chunksize and
+                self.align and (self.chunksize & 1)):
+            dummy = self.file.read(1)
+            self.size_read = self.size_read + len(dummy)
+        return data
+
+    def skip(self):
+        if self.closed:
+            raise ValueError("I/O operation on closed file")
+        if self.seekable:
+            try:
+                n = self.chunksize - self.size_read
+                if self.align and (self.chunksize & 1):
+                    n = n + 1
+                self.file.seek(n, 1)
+                self.size_read = self.size_read + n
+                return
+            except OSError:
+                pass
+        while self.size_read < self.chunksize:
+            n = min(8192, self.chunksize - self.size_read)
+            dummy = self.read(n)
+            if not dummy:
+                raise EOFError
 
 _wave_params = namedtuple('_wave_params',
                      'nchannels sampwidth framerate nframes comptype compname')


### PR DESCRIPTION
## Summary
- The vendored `amy/wave.py` did `from chunk import Chunk`, but PEP 594 removed the `chunk` stdlib module in Python 3.13, breaking `amy.load_sample` (and `TestLoadSample`, `TestDiskSample*`) for anyone on 3.13+.
- Inlined a faithful port of CPython's old `chunk.py` directly into `wave.py`. No behavior change on 3.12.
- Expanded the CI matrix from a single `3.12` job to `[3.12, 3.13, 3.14]` so the next stdlib removal is caught here instead of on someone's laptop.

## Test plan
- [x] `make test` passes locally on Python 3.14.2 (86/86, including `TestLoadSample`, `TestDiskSampleStereo`, etc.)
- [x] All three matrix jobs (3.12, 3.13, 3.14) pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)