### PR TITLE
Replace scipy.io.wav with soundfile for read/write of WAV files.

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: pip install numpy scipy
+      run: pip install numpy soundfile
 
     - name: Build and test
       env:

--- a/amy/__init__.py
+++ b/amy/__init__.py
@@ -286,9 +286,9 @@ def show(data):
 
 # Writes a WAV file of rendered data
 def write(data, filename):
-    import scipy.io.wavfile as wav
+    import soundfile as sf
     import numpy as np
-    wav.write(filename, int(AMY_SAMPLE_RATE), (32768.0 * data).astype(np.int16))
+    sf.write(filename, (32768.0 * data).astype(np.int16), int(AMY_SAMPLE_RATE), subtype='PCM_16')
 
 # Play a rendered sound out of default sounddevice
 def play(samples):

--- a/amy/headers.py
+++ b/amy/headers.py
@@ -1,8 +1,10 @@
 # headers.py
 # Generate headers for AMY
+import os
 import sys
 import glob
 import numpy as np
+import soundfile as sf
 import amy
 
 from . import constants
@@ -12,7 +14,7 @@ def _read_wavetables(wavetable_files):
     wavetable_len = None
     for wavfile in wavetable_files:
         with open(wavfile, 'rb') as f:
-            samplerate, wav_data = wav.read(f)
+            wav_data, samplerate = sf.read(f, dtype='int16')
         if getattr(wav_data, "ndim", 1) != 1:
             raise ValueError(f"{wavfile} is not mono")
         wav_data = wav_data.astype(np.int16)
@@ -516,9 +518,6 @@ def make_interp_partials(filename, data_dict):
 
     print("wrote", filename)
 
-
-import scipy.io.wavfile as wav
-import os
 
 """
     Generate all the headers except for the partials headers

--- a/amy/test.py
+++ b/amy/test.py
@@ -5,7 +5,7 @@ import string
 import tempfile
 
 import numpy as np
-import scipy.io.wavfile as wav
+import soundfile as sf
 
 import amy
 import c_amy as _amy
@@ -16,10 +16,9 @@ from . import constants
 def wavread(filename):
   """Read in audio data from a wav file.  Return d, sr."""
   # Read in wav file.
-  file_handle = open(filename, 'rb')
-  samplerate, wave_data = wav.read(file_handle)
+  wav_data, samplerate = sf.read(filename, dtype='int16')
   # Normalize short ints to floats in range [-1..1).
-  data = (wave_data.astype(np.float32)) / 32768.0
+  data = (wav_data.astype(np.float32)) / 32768.0
   return data, samplerate
 
 

--- a/amy/timing.py
+++ b/amy/timing.py
@@ -2,7 +2,7 @@ import sys
 import os
 
 import numpy as np
-import scipy.io.wavfile as wav
+import soundfile as sf
 
 import amy
 
@@ -10,10 +10,9 @@ import amy
 def wavread(filename):
   """Read in audio data from a wav file.  Return d, sr."""
   # Read in wav file.
-  file_handle = open(filename, 'rb')
-  samplerate, wave_data = wav.read(file_handle)
+  wav_data, samplerate = sf.read(filename, dtype='int16')
   # Normalize short ints to floats in range [-1..1).
-  data = (wave_data.astype(np.float32)) / 32768.0
+  data = (wav_data.astype(np.float32)) / 32768.0
   return data, samplerate
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@ name = "amy"
 version = "0.1.0"
 description = "AMY synthesizer"
 readme = "README.md"
-dependencies = ['numpy', 'scipy']
+dependencies = ['numpy', 'soundfile']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy
-scipy
+soundfile
 


### PR DESCRIPTION
The impetus for this was that I couldn't install scipy on my machine.  But using soundfile is a better choice if the only thing we were using in scipy was, ahem, wav file read and write.  Tests (which involve reading soundfiles) all pass unmodified.