### PR TITLE
Bump version to 1.2.5

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AMY Synthesizer
-version=1.2.4
+version=1.2.5
 author=Brian Whitman <brian@variogram.com>, DAn Ellis <dan.ellis@gmail.com>
 maintainer=Brian Whitman <brian@variogram.com>
 sentence=AMY, the Music Synthesizer Library


### PR DESCRIPTION
Bump `library.properties` version to **1.2.5** for the Arduino release (previous release: 1.2.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)