### PR TITLE
cv_trigger: declare amy_web_cv_1/2 in amy.h so the web (emscripten) build links

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -1520,8 +1520,6 @@ float amp_combine_controls(float *controls, float *coefs) {
 // apply an mod & bp, if any, to the osc
 #ifdef __EMSCRIPTEN__
 #include "emscripten/webaudio.h"
-extern float amy_web_cv_1;
-extern float amy_web_cv_2;
 #endif
 void hold_and_modify(uint16_t osc) {
     AMY_PROFILE_START(HOLD_AND_MODIFY)

--- a/src/amy.h
+++ b/src/amy.h
@@ -973,6 +973,11 @@ extern void substitute_midi_special_values(char *dest, const char *src, int chan
 extern void midi_msg_handler(uint8_t * bytes, uint16_t len, uint8_t is_sysex, uint32_t time);
 
 extern float cv_inputs[AMY_MAX_CV_IN];
+#ifdef __EMSCRIPTEN__
+// Web CV input voltages, sampled from JS each block (defined in libminiaudio-audio.c).
+extern float amy_web_cv_1;
+extern float amy_web_cv_2;
+#endif
 extern void cv_trigger_debug(void);
 extern void cv_trigger_new(uint8_t trigger_cv, float thresh_high, float thresh_low, uint8_t pitch_cv, float pitch_scale, float pitch_offset, char *message_template);
 extern void cv_trigger_init(void);


### PR DESCRIPTION
## Problem
`make web` (the emscripten/WASM build) fails to compile `src/cv_trigger.c`:

```
src/cv_trigger.c:145:24: error: use of undeclared identifier 'amy_web_cv_1'
src/cv_trigger.c:146:24: error: use of undeclared identifier 'amy_web_cv_2'
```

`cv_trigger.c` reads `amy_web_cv_1`/`amy_web_cv_2` inside `update_external_cv_in()` under `#ifdef __EMSCRIPTEN__`. Those globals are **defined** in `src/libminiaudio-audio.c` and were only `extern`-declared **locally inside `amy.c`**. Since each `.c` is its own translation unit, `cv_trigger.c` had no declaration in scope and failed to compile under emcc. Native and ESP32 builds compile because they don't take the `__EMSCRIPTEN__` path.

## Fix
Move the `extern` declarations into `amy.h` (next to `cv_inputs`), guarded by `__EMSCRIPTEN__`, so every TU that includes `amy.h` sees them. Drop the now-redundant local externs in `amy.c` (keeping the `emscripten/webaudio.h` include).

## Validation
- `make web` → links `build/amy.js` cleanly.
- `make test` → **92 tests pass**, including `TestCVTrigger`, `TestCVTriggerNote`, `TestCVTriggerNoteOff`, `TestCVFromOsc`.
- Native + ESP32 (TulipCC AMYboard firmware) builds unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)