### PR TITLE
Fix Windows/MSVC Godot build: guard <strings.h> include

### DIFF
--- a/src/amy.h
+++ b/src/amy.h
@@ -8,7 +8,6 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
-#include <strings.h>
 #ifdef _WIN32
 #include <io.h>
 #include <intrin.h>
@@ -22,6 +21,7 @@ static inline int __builtin_clz(unsigned int x) {
 }
 #else
 #include <unistd.h>
+#include <strings.h>  // POSIX-only (strcasecmp, bzero, ...); absent on MSVC, which uses the bzero/bcopy shims above
 #endif
 #include <inttypes.h>
 


### PR DESCRIPTION
The Godot **Windows** build for the 1.2.5 release failed:

```
src/amy.h(11): fatal error C1083: Cannot open include file: 'strings.h': No such file or directory
```

`<strings.h>` is a POSIX header that MSVC does not provide. It was added unconditionally to `amy.h` in 68a85e5 ("fix default config"), but nothing in AMY's own code needs it on Windows:
- `bzero`/`bcopy` are provided by the `#ifdef _WIN32` macro shims already in `amy.h`.
- The only `strcasecmp` use is in vendored `miniaudio.h`, which already guards its own include with `#if !defined(_MSC_VER)`.

This moves the include into the existing non-Windows (`#else`) branch, so POSIX builds keep it (for `bzero`/`bcopy`/`strcasecmp` declarations) and MSVC skips it — matching miniaudio's pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)