### PR TITLE
Fix AMY_arduino for RPi Pico: No sysex alloc, add bus args to config_…

### DIFF
--- a/examples/AMY_MIDI_Synth/AMY_MIDI_Synth.ino
+++ b/examples/AMY_MIDI_Synth/AMY_MIDI_Synth.ino
@@ -50,9 +50,9 @@ void test_audio_in() {
   e.velocity = 1.0f;
   amy_add_event(&e);
   // Add echo to show that audio in is being processed.
-  config_echo(0.5f, 150.0f, 160.0f, 0.5f, 0.0f);  // I get errors on ESP32-S3 N8R8 if I go above 160.0ms
+  config_echo(/* bus */ 0, 0.5f, 150.0f, 160.0f, 0.5f, 0.0f);  // I get errors on ESP32-S3 N8R8 if I go above 160.0ms
   // Turn off chorus, for better audio pass-through.
-  config_chorus(0, 320, 0.5f, 0.5f);
+  config_chorus(/* bus */ 0, 0, 320, 0.5f, 0.5f);
 }
 
 

--- a/examples/BillieJeanScheduled/BillieJeanScheduled.ino
+++ b/examples/BillieJeanScheduled/BillieJeanScheduled.ino
@@ -41,7 +41,7 @@ void setup() {
   amy_add_event(&e);
 
   // Turn on reverb
-  config_reverb(0.5f, 0.85f, 0.5f, 3000.0f);
+  config_reverb(/* bus */ 0, 0.5f, 0.85f, 0.5f, 3000.0f);
 }
 
 struct timed_note {

--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -219,7 +219,7 @@ uint8_t * sysex_buffer = NULL;
 // arriving before the scheduled callback fires doesn't overwrite the previous
 // message. This matters when the sketch's loop() is CPU-heavy and the
 // mp_sched callback is delayed.
-char * sysex_message_copies[SYSEX_COPY_SLOTS] = {NULL};
+char * sysex_message_copies[SYSEX_COPY_SLOTS];  // zero-length unless AMYBOARD/TULIP; static => zero-initialized
 uint8_t sysex_copy_write_idx = 0;  // MIDI task writes here
 uint8_t sysex_copy_read_idx = 0;   // MP callback reads here
 void parse_sysex() {
@@ -555,11 +555,12 @@ extern void pico_teardown_midi();
 
 void run_midi() {
     if (sysex_buffer == NULL) {
-        // No SYSEX buffering on PICO - not enough RAM
-        //sysex_buffer = malloc_caps(MAX_SYSEX_BYTES, amy_global.config.ram_caps_sysex);
-        //for (int i = 0; i < SYSEX_COPY_SLOTS; i++) {
-        //    sysex_message_copies[i] = malloc_caps(MAX_SYSEX_BYTES, amy_global.config.ram_caps_sysex);
-        //}
+        // sysex_buffer is allocated on every platform; the SYSEX_COPY_SLOTS
+        // backup ring is sized 0 (no alloc) on Pico, so this loop is a no-op here.
+        sysex_buffer = malloc_caps(MAX_SYSEX_BYTES, amy_global.config.ram_caps_sysex);
+        for (int i = 0; i < SYSEX_COPY_SLOTS; i++) {
+            sysex_message_copies[i] = malloc_caps(MAX_SYSEX_BYTES, amy_global.config.ram_caps_sysex);
+        }
         if(amy_global.config.midi & AMY_MIDI_IS_UART) {
             uart_init(rp_get_uart(amy_global.config.midi_uart), 31250);
             gpio_set_function(amy_global.config.midi_out, UART_FUNCSEL_NUM(rp_get_uart(amy_global.config.midi_uart), amy_global.config.midi_out));

--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -555,10 +555,11 @@ extern void pico_teardown_midi();
 
 void run_midi() {
     if (sysex_buffer == NULL) {
-        sysex_buffer = malloc_caps(MAX_SYSEX_BYTES, amy_global.config.ram_caps_sysex);
-        for (int i = 0; i < SYSEX_COPY_SLOTS; i++) {
-            sysex_message_copies[i] = malloc_caps(MAX_SYSEX_BYTES, amy_global.config.ram_caps_sysex);
-        }
+        // No SYSEX buffering on PICO - not enough RAM
+        //sysex_buffer = malloc_caps(MAX_SYSEX_BYTES, amy_global.config.ram_caps_sysex);
+        //for (int i = 0; i < SYSEX_COPY_SLOTS; i++) {
+        //    sysex_message_copies[i] = malloc_caps(MAX_SYSEX_BYTES, amy_global.config.ram_caps_sysex);
+        //}
         if(amy_global.config.midi & AMY_MIDI_IS_UART) {
             uart_init(rp_get_uart(amy_global.config.midi_uart), 31250);
             gpio_set_function(amy_global.config.midi_out, UART_FUNCSEL_NUM(rp_get_uart(amy_global.config.midi_uart), amy_global.config.midi_out));

--- a/src/amy_midi.h
+++ b/src/amy_midi.h
@@ -23,7 +23,19 @@ void amy_external_midi_sync(uint8_t enabled);
 #define MIDI_QUEUE_DEPTH 1024
 #define MAX_SYSEX_BYTES (16384)
 extern uint8_t *sysex_buffer;
+// Every platform allocates the single sysex_buffer above. The sysex copy-slot
+// ring buffer below holds backup snapshots so a fast-arriving message isn't lost
+// while a previous one waits for the deferred MicroPython mp_sched callback.
+// Only the MicroPython-hosted boards (AMYBOARD, TULIP) create and read these
+// slots (see parse_sysex()); other platforms handle sysex synchronously from
+// sysex_buffer. Size the ring to 0 elsewhere so we don't malloc
+// SYSEX_COPY_SLOTS x MAX_SYSEX_BYTES (32 x 16KB = 512KB), which alone would
+// exhaust e.g. the rp2350's 520KB of SRAM.
+#if defined(AMYBOARD) || defined(TULIP)
 #define SYSEX_COPY_SLOTS 32
+#else
+#define SYSEX_COPY_SLOTS 0
+#endif
 extern char *sysex_message_copies[SYSEX_COPY_SLOTS];
 extern uint8_t sysex_copy_write_idx;
 extern uint8_t sysex_copy_read_idx;


### PR DESCRIPTION
…echo etc.

Confirmed that BillieJeanScheduled and AMY_MIDI_Synth sketches work on Pimoroni Pico2 using RPi Pico Core 5.5.1.  