### PR TITLE
Bump version to 1.2.6

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AMY Synthesizer
-version=1.2.5
+version=1.2.6
 author=Brian Whitman <brian@variogram.com>, DAn Ellis <dan.ellis@gmail.com>
 maintainer=Brian Whitman <brian@variogram.com>
 sentence=AMY, the Music Synthesizer Library


### PR DESCRIPTION
Bump `library.properties` to **1.2.6** for the Arduino release.

Includes since 1.2.5: the rp2350 sysex-buffer fix ([#712](https://github.com/shorepine/amy/pull/712)) — `sysex_buffer` on all platforms, the 32 × 16KB copy slots only on AMYBOARD/TULIP — plus the Windows/MSVC Godot build fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)