### PR TITLE
Fix Godot Windows build: MSVC zero-length array + missing cv_trigger.c

### DIFF
--- a/godot/SConstruct
+++ b/godot/SConstruct
@@ -37,6 +37,7 @@ amy_sources = [
     "amy.c",
     "api.c",
     "custom.c",
+    "cv_trigger.c",
     "delay.c",
     "envelope.c",
     "examples.c",

--- a/setup_godot.sh
+++ b/setup_godot.sh
@@ -463,6 +463,7 @@ amy_sources = [
     "amy.c",
     "api.c",
     "custom.c",
+    "cv_trigger.c",
     "delay.c",
     "envelope.c",
     "examples.c",

--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -219,7 +219,7 @@ uint8_t * sysex_buffer = NULL;
 // arriving before the scheduled callback fires doesn't overwrite the previous
 // message. This matters when the sketch's loop() is CPU-heavy and the
 // mp_sched callback is delayed.
-char * sysex_message_copies[SYSEX_COPY_SLOTS];  // zero-length unless AMYBOARD/TULIP; static => zero-initialized
+char * sysex_message_copies[SYSEX_COPY_SLOTS_DIM];  // dim floored at 1 for MSVC; loops use SYSEX_COPY_SLOTS (0 off-board)
 uint8_t sysex_copy_write_idx = 0;  // MIDI task writes here
 uint8_t sysex_copy_read_idx = 0;   // MP callback reads here
 void parse_sysex() {

--- a/src/amy_midi.h
+++ b/src/amy_midi.h
@@ -36,7 +36,13 @@ extern uint8_t *sysex_buffer;
 #else
 #define SYSEX_COPY_SLOTS 0
 #endif
-extern char *sysex_message_copies[SYSEX_COPY_SLOTS];
+// The alloc/free loops use SYSEX_COPY_SLOTS directly (0 => no slots off-board),
+// but the array dimension must be >= 1: MSVC (the Godot Windows build includes
+// this header transitively via amy.h) rejects a zero-length array with C2466,
+// unlike the GCC/Clang extension. Floor the dimension at 1; that lone slot is
+// never touched off-board because the loops iterate 0 times.
+#define SYSEX_COPY_SLOTS_DIM ((SYSEX_COPY_SLOTS) > 0 ? (SYSEX_COPY_SLOTS) : 1)
+extern char *sysex_message_copies[SYSEX_COPY_SLOTS_DIM];
 extern uint8_t sysex_copy_write_idx;
 extern uint8_t sysex_copy_read_idx;
 extern uint16_t sysex_len;


### PR DESCRIPTION
Two fixes that make the **Godot Windows (MSVC)** addon build compile *and* link. Verified green on a `workflow_dispatch` run (Windows + Linux pass; macOS unaffected).

**1. Zero-length array (C2466)** — the conditional `SYSEX_COPY_SLOTS 0` (off the MicroPython boards) made `sysex_message_copies[0]` a zero-length array. GCC/Clang accept it as an extension (all Arduino CI passed), but MSVC rejects it, and the Godot build pulls in `amy_midi.h` transitively via `amy.h`. Floor the array dimension at 1 (`SYSEX_COPY_SLOTS_DIM`); the alloc/free loops still use `SYSEX_COPY_SLOTS`, so off-board it's still 0 slots allocated.

**2. Missing `cv_trigger.c` (LNK2019/LNK1120)** — `cv_trigger.c` (added in the 1.2.5 range) was never added to the Godot `amy_sources` list in `godot/SConstruct` or `setup_godot.sh`, so `amy.c`/`parse.c` referenced unresolved `cv_trigger_*` symbols. macOS/Linux shared libs tolerate undefined symbols (masking it); Windows DLLs don't. Added it to both lists.

These were stacked behind the earlier `strings.h` fix (#711) — each compile error masked the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)