### PR TITLE
headers: import soundfile lazily so make web doesn't require it

### DIFF
--- a/amy/headers.py
+++ b/amy/headers.py
@@ -4,12 +4,15 @@ import os
 import sys
 import glob
 import numpy as np
-import soundfile as sf
 import amy
 
 from . import constants
 
 def _read_wavetables(wavetable_files):
+    # Lazy import: soundfile is only needed when (optionally) regenerating the PCM /
+    # wavetable headers. Keeping it out of module scope means `python3 -m amy.headers`
+    # (and therefore `make web`) does not require soundfile to be installed.
+    import soundfile as sf
     tables = []
     wavetable_len = None
     for wavfile in wavetable_files:


### PR DESCRIPTION
`make web` runs `python3 -m amy.headers` to generate `src/patches.h`, but `amy/headers.py` imported `soundfile` at module top — even though it's only used in `_read_wavetables()`, which is reached solely from the optional PCM/wavetable regen path (already guarded by `try/except ImportError`). That top-level import forced the whole web build to require soundfile.

Move the import into `_read_wavetables()` (matching the lazy import already used in `__init__.py`). Now `make web` runs with any Python that has numpy.

Tested:
- `make test` → 92 tests pass.
- `python3 -m amy.headers` with the ESP-IDF venv python (numpy present, **soundfile absent**) now completes and writes `patches.h` (PCM path gracefully skipped) — previously it died with `ModuleNotFoundError: No module named 'soundfile'`.

This removes the 'build web only from a non-IDF shell' footgun in tulipcc's `dev.sh`.