### PR TITLE
Bump version to 1.2.7

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=AMY Synthesizer
-version=1.2.6
+version=1.2.7
 author=Brian Whitman <brian@variogram.com>, DAn Ellis <dan.ellis@gmail.com>
 maintainer=Brian Whitman <brian@variogram.com>
 sentence=AMY, the Music Synthesizer Library


### PR DESCRIPTION
Cuts release **1.2.7** from `main`.

`main` already contains the MSVC zero-length-array fix (#714,
`SYSEX_COPY_SLOTS_DIM`) that broke the **Windows** leg of the Godot addon
build on the `1.2.5` and `1.2.6` tags. Because the `package`/`release`
jobs in `godot-addon.yml` are gated on the full build matrix, the Windows
failure meant `amy-godot-addon.zip` was never attached to those releases —
so `https://github.com/shorepine/amy/releases/latest/download/amy-godot-addon.zip`
returns "Not Found" (#717).

Tagging `1.2.7` off `main` builds Windows cleanly and re-attaches the addon
zip, restoring the dead link.

Fixes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)