### PR TITLE
make web: stop exporting removed yield_patch_events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ EMSCRIPTEN_OPTIONS = -s WASM=1 --bind \
 -s EXPORTED_RUNTIME_METHODS="['cwrap','ccall', 'HEAPU8']" \
 -s EXPORTED_FUNCTIONS="['_amy_add_message', '_amy_add_event', '_amy_reset_sysclock', '_amy_sysclock', '_amy_process_single_midi_byte', \
 	 '_amy_live_stop', '_amy_get_input_buffer', '_amy_get_output_buffer', '_amy_set_external_input_buffer', '_amy_live_start_web', '_amy_live_start_web_audioin',\
-	  '_amy_start_web', '_amy_start_web_no_synths', '_sequencer_ticks', '_malloc', '_free', '_amy_bleep', '_yield_patch_events', '_size_of_amy_event', '_yield_synth_commands', '_amy_dump_state_to_string']" \
+	  '_amy_start_web', '_amy_start_web_no_synths', '_sequencer_ticks', '_malloc', '_free', '_amy_bleep', '_size_of_amy_event', '_yield_synth_commands', '_amy_dump_state_to_string']" \
 -s SUPPORT_LONGJMP=emscripten \
 -s INITIAL_MEMORY=128mb -s TOTAL_STACK=64mb -s ALLOW_MEMORY_GROWTH=1  \
 -s ASYNCIFY -s ASYNCIFY_STACK_SIZE=128000


### PR DESCRIPTION
Stacked on #728. `yield_patch_events` is removed from the source in #728, and its web-editor `cwrap` binding was removed in tulipcc #990, but `Makefile` still lists `'_yield_patch_events'` in the `make web` `EXPORTED_FUNCTIONS`. emscripten's `wasm-ld` then fails:

```
wasm-ld: error: symbol exported via --export not found: yield_patch_events
```

AMY CI builds the MCU targets (ESP32-S3, RP2040, RP2350, Teensy) and runs the Python tests, but **not** the emscripten (`make web`) build — so #728 is green even though the amyboard web (WASM) build is broken. Caught while building the amyboard dev web from #728.

Fix: drop the dead export. (Separately worth considering: add `make web` to AMY CI so emscripten breaks get caught.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)