### PR TITLE
CI: build the emscripten (make web) target

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -48,6 +48,11 @@ jobs:
       run: pip install numpy
 
     - uses: mymindstorm/setup-emsdk@v14
+      with:
+        # Pin to the emsdk the web build is developed/deployed against. Newer
+        # emsdk fails the link with undefined pthread_* symbols under the
+        # AUDIO_WORKLET / WASM_WORKERS flags make web uses.
+        version: 4.0.22
 
     - name: Build web (emscripten)
       run: make web

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -29,3 +29,25 @@ jobs:
       env:
         AMY_TEST_THRESHOLD_DB: "-70.0"
       run: make test
+
+  web:
+    # Build the emscripten / WASM target (`make web`) so breaks there are caught.
+    # The other CI jobs build the MCU targets and run the Python tests but never
+    # the browser build, so e.g. a stale `make web` EXPORTED_FUNCTIONS entry
+    # (exporting a removed symbol) links fine on-device yet fails wasm-ld.
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.13'
+
+    - name: Install dependencies
+      run: pip install numpy
+
+    - uses: mymindstorm/setup-emsdk@v14
+
+    - name: Build web (emscripten)
+      run: make web


### PR DESCRIPTION
AMY's CI builds the MCU targets (ESP32-S3, RP2040, RP2350, Teensy) and runs the Python tests, but never the **browser / WASM** build (`make web`). So a break there links fine on-device yet fails the emscripten link and ships a broken amyboard web build.

Concretely, this just happened: removing `yield_patch_events` from the source (in #728) left a stale `'_yield_patch_events'` in the `make web` `EXPORTED_FUNCTIONS`, and `make web` died with `wasm-ld: error: symbol exported via --export not found: yield_patch_events` — while all CI stayed green (fix: #729).

This adds a `web` job to the C/C++ CI that installs emsdk and runs `make web`, so that class of breakage is caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)