### PR TITLE
src/patches.c: Function checks for empty synth events, skips.

### DIFF
--- a/src/patches.c
+++ b/src/patches.c
@@ -328,6 +328,75 @@ int sprint_event(amy_event *e, char *s, size_t len, bool wirecode) {
     return s - s_entry;
 }
 
+#define _RET_FALSE_IF_SET(FIELD) if (AMY_IS_SET(e->FIELD)) return false;
+#define _RET_FALSE_IF_SET_SEQ(FIELD, LEN)          \
+    for (int i = 0; i < LEN; ++i) {                \
+       if (AMY_IS_SET(e->FIELD[i])) return false;  \
+    }
+#define _RET_FALSE_IF_SET_COEF(FIELD)   _RET_FALSE_IF_SET_SEQ(FIELD, NUM_COMBO_COEFS)
+#define _RET_FALSE_IF_SET_BP(TFIELD, VFIELD) {        \
+        _RET_FALSE_IF_SET_SEQ(TFIELD, MAX_BPS)        \
+        _RET_FALSE_IF_SET_SEQ(VFIELD, MAX_BPS)        \
+    }
+
+bool event_is_empty(amy_event *e) {
+    // We don't want to go through the rigmarole of passing events down to voices if the instruments haven't been set up yet.
+    // Check to see if this event has any fields set other than time, osc, synth.
+    _RET_FALSE_IF_SET(wave);
+    _RET_FALSE_IF_SET(preset);
+    _RET_FALSE_IF_SET(midi_note);
+    _RET_FALSE_IF_SET(velocity);
+    _RET_FALSE_IF_SET(patch_number);
+    _RET_FALSE_IF_SET_COEF(amp_coefs);
+    _RET_FALSE_IF_SET_COEF(freq_coefs);
+    _RET_FALSE_IF_SET_COEF(filter_freq_coefs);
+    _RET_FALSE_IF_SET_COEF(duty_coefs);
+    _RET_FALSE_IF_SET_COEF(pan_coefs);
+    _RET_FALSE_IF_SET(feedback);
+    _RET_FALSE_IF_SET(trigger_phase);
+    _RET_FALSE_IF_SET_SEQ(volume, AMY_NUM_BUSES);  // NOT osc-dep
+    _RET_FALSE_IF_SET(pitch_bend);  // NOT osc-dep
+    _RET_FALSE_IF_SET(tempo);  // NOT osc-dep
+    _RET_FALSE_IF_SET(latency_ms);  // NOT osc-dep
+    _RET_FALSE_IF_SET(ratio);
+    _RET_FALSE_IF_SET(resonance);
+    _RET_FALSE_IF_SET(portamento_ms);
+    _RET_FALSE_IF_SET(chained_osc);
+    _RET_FALSE_IF_SET(mod_source);
+    _RET_FALSE_IF_SET(algorithm);
+    _RET_FALSE_IF_SET(filter_type);
+    _RET_FALSE_IF_SET_SEQ(bp_is_set, MAX_BREAKPOINT_SETS);
+    // Convert these two at least to vectors of ints, save several hundred bytes
+    _RET_FALSE_IF_SET_SEQ(algo_source, MAX_ALGO_OPS);
+    _RET_FALSE_IF_SET_SEQ(voices, MAX_VOICES_PER_INSTRUMENT);
+    _RET_FALSE_IF_SET_BP(eg0_times, eg0_values);
+    _RET_FALSE_IF_SET_BP(eg1_times, eg1_values);
+    _RET_FALSE_IF_SET(eg_type[0]);
+    _RET_FALSE_IF_SET(eg_type[1]);
+    // Instrument-layer values.
+    //_RET_FALSE_IF_SET(synth);
+    _RET_FALSE_IF_SET(synth_flags);  // Special flags to set when defining instruments.
+    _RET_FALSE_IF_SET(synth_delay_ms);  // Extra delay added to synth note-ons to allow decay on voice-stealing.
+    _RET_FALSE_IF_SET(to_synth);  // For moving setup between synth numbers.
+    _RET_FALSE_IF_SET(grab_midi_notes);  // To enable/disable automatic MIDI note-on/off generating note-on/off.
+    _RET_FALSE_IF_SET(note_source);  // Marks synth as MIDI-driven, so note-on events aren't echo'd to output MIDI.
+    _RET_FALSE_IF_SET(pedal);  // MIDI pedal value.
+    _RET_FALSE_IF_SET(num_voices);
+    _RET_FALSE_IF_SET(oscs_per_voice);
+    _RET_FALSE_IF_SET_SEQ(sequence, 3); // tick, period, tag
+    //
+    //_RET_FALSE_IF_SET(status, "status");
+    _RET_FALSE_IF_SET(note_source);  // .. to mark note on/offs that come from MIDI so we don't send them back out again.
+    _RET_FALSE_IF_SET(reset_osc);
+    // Global effects
+    //_EPRINT_VALS_5(e->eq_l, e->eq_m, e->eq_h, AMY_UNSET_FLOAT, AMY_UNSET_FLOAT, "eq_{l,m,h}", "x");
+    //_EPRINT_VALS_5(e->echo_level, e->echo_delay_ms, e->echo_max_delay_ms, e->echo_feedback, e->echo_filter_coef, "echo_{level,delay,max,fb,filt}", "M");
+    //_EPRINT_VALS_5(e->chorus_level, e->chorus_max_delay, e->chorus_lfo_freq, e->chorus_depth, AMY_UNSET_FLOAT, "chorus_{level,delay,lfo,depth}", "k");
+    //_EPRINT_VALS_5(e->reverb_level, e->reverb_liveness, e->reverb_damping, e->reverb_xover_hz, AMY_UNSET_FLOAT, "reverb_{level,live,damp,xover}", "h");
+
+    return true;
+}
+
 
 #define _CASE_I(FIELD, PARAM) case PARAM: event->FIELD = queue->data.i; break;
 #define _CASE_F(FIELD, PARAM) case PARAM: event->FIELD = queue->data.f; break;
@@ -335,7 +404,7 @@ int sprint_event(amy_event *e, char *s, size_t len, bool wirecode) {
 #define _TEST_COEFS(FIELD, PARAM)  \
     for (int i = 0; i < NUM_COMBO_COEFS; ++i) {                          \
         if ((int)queue->param == (int)PARAM + i) event->FIELD[i] = queue->data.f; \
-    } \
+    }
 // Const freq coef is in Hz, rest are linear.
 #define _TEST_FREQ_COEFS(FIELD, PARAM) \
     for (int i = 0; i < NUM_COMBO_COEFS; ++i) {      \
@@ -879,7 +948,6 @@ uint8_t patches_voices_for_event(amy_event *e, uint16_t voices[]) {
             fprintf(stderr, "You specified both synth %" PRId32 " and voices %" PRIu16 "...  Synth implies voices, ignoring voices.\n",
                     (int32_t)e->synth, e->voices[0]);
         }
-        synth_flags = instrument_get_flags(e->synth);
         if (AMY_IS_SET(e->to_synth)) {
             // This involves moving the instrument number.
             instrument_change_number(e->synth, e->to_synth);
@@ -905,6 +973,7 @@ uint8_t patches_voices_for_event(amy_event *e, uint16_t voices[]) {
         if (AMY_IS_SET(e->pedal)) {
             // Pedal events are a special case
             bool sustain = (e->pedal != 0);
+            synth_flags = instrument_get_flags(e->synth);
             if (synth_flags & _SYNTH_FLAGS_NEGATE_PEDAL) {
                 sustain = !sustain;  // Some MIDI pedals report backwards.
             }
@@ -916,6 +985,7 @@ uint8_t patches_voices_for_event(amy_event *e, uint16_t voices[]) {
             //fprintf(stderr, "synth %d pedal %d num_voices %d\n", e->synth, e->pedal, num_voices);
         } else if (AMY_IS_SET(e->velocity)) {
             bool stolen = false;
+            synth_flags = instrument_get_flags(e->synth);
             num_voices = patches_voices_for_note_onoff_event(e, voices, synth_flags, &stolen);
             if (stolen) {
                 // Here, we issue a quick note-off for the stolen note, to support short decay.  Kind of an abstraction violation.
@@ -951,6 +1021,7 @@ uint8_t patches_voices_for_event(amy_event *e, uint16_t voices[]) {
 // If the event also has synth and patch_number specified (a "load patch"), those are handled before this is called.
 // So i know that the patch / voice alloc already exists and the patch has already been set!
 void patches_event_has_voices(amy_event *e, struct delta **queue) {
+    if (event_is_empty(e)) return;  // Early exit.
     peek_stack("has_voices");
     uint16_t voices[MAX_VOICES_PER_INSTRUMENT];
     uint8_t num_voices = patches_voices_for_event(e, voices);
@@ -1194,5 +1265,4 @@ void patches_load_patch(amy_event *e) {
         if (AMY_IS_SET(e->bus)) bus = e->bus;
         instrument_add_new(e->synth, num_voices, voices, patch_number, oscs_per_voice, bus, flags);
     }
-
 }


### PR DESCRIPTION
Previously, any time we had an event with synth set, `patches_event_has_voices` took a look and tried to apply it to every voice.  Sometimes the synth hadn't even been defined which printed a warning, but often there's nothing left after the `patches_load_patch`.  A new function, `event_is_empty`, scans all the event fields except for `time`, `osc`, and `synth`, and returns `true` if nothing is there.  `patches_event_has_voices` returns immediately if passed an event that is empty by this measure.