### PR TITLE
Add amy_config.midi_thru: echo MIDI in to MIDI out (#738)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -155,6 +155,7 @@ amy_start(amy_config);
 | `i2s_lrc`, `i2s_dout`, `i2s_din`, `i2s_bclk`, `i2s_mclk` | Int | -1 | Pin numbers for the I2S interface |
 | `midi_out`, `midi_in` | Int | -1 | Pin number for the MIDI UART pins |
 | `midi_uart` | 0,1,[2] | -1 | UART device index for MCU. Default 1 (`UART1`) on Pi Pico and ESP. Teensy is always `8` |
+| `midi_thru` | `0=off, 1=on` | Off | If set, every incoming MIDI byte is echoed straight to MIDI out, in addition to being processed normally. Can be toggled at runtime via `amy_global.config.midi_thru` |
 | `capture_device_id`, `playback_device_id` | Int | -1 | Which miniaudio device to use, -1 is auto |
 
 

--- a/docs/midi.md
+++ b/docs/midi.md
@@ -41,6 +41,10 @@ Preface your wire message with AMY's SYSEX manufacturer code: `0x00 0x03 0x45`.
 For example, to send the wire message `v0f440l1` (sine wave, 440Hz, note on) to AMY over SYSEX, you'd send `0xF0 0x00 0x03 0x45 v 0 f 4 4 0 l 1 0xF7`. 
 
 
+## MIDI Thru
+
+AMY can pass every incoming MIDI byte straight through to its MIDI output, in addition to processing it normally. This is off by default. Enable it by setting `midi_thru` on `amy_config_t` (e.g. `amy_config.midi_thru = 1` before `amy_start`), or toggle it at runtime via `amy_global.config.midi_thru`. When enabled, all bytes received on any MIDI input (UART, USB) are echoed to all active MIDI outputs as they are parsed. On Tulip this is exposed as `tulip.amy_midi_thru(True)` / `tulip.amy_midi_thru(False)`.
+
 ## Others
 
 AMY supports MIDI realtime transport for the internal sequencer:

--- a/src/amy.h
+++ b/src/amy.h
@@ -729,6 +729,7 @@ typedef struct  {
     int8_t midi_out;
     int8_t midi_in;
     int8_t midi_uart;
+    uint8_t midi_thru;  // If set, echo every incoming MIDI byte straight to MIDI out (in addition to normal processing). Off by default.
 
     // memory caps for MCUs
     uint32_t ram_caps_events;

--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -291,6 +291,18 @@ void convert_midi_bytes_to_messages(uint8_t * data, size_t len, uint8_t usb) {
 
         uint8_t byte = data[i];
 
+        // MIDI thru: when amy_config.midi_thru is set, echo every incoming MIDI
+        // byte straight back out (in addition to processing it normally below).
+        // We forward here, byte-by-byte inside the parse loop, rather than
+        // blasting the whole `data` buffer at once: USB MIDI always arrives in
+        // fixed 3-byte groups (padded with junk for <3-byte messages), and the
+        // `if(usb) i = len+1` early-exits below stop the loop before those
+        // padding bytes -- so only real MIDI bytes get forwarded. UART input has
+        // no padding and forwards in full. Off by default.
+        if(amy_global.config.midi_thru) {
+            midi_out(&byte, 1);
+        }
+
         // Skip sysex in this parser until we get an F7. We do not pass sysex over to python (yet)
         if(sysex_flag) {
             if(byte == 0xF7) {

--- a/src/api.c
+++ b/src/api.c
@@ -71,7 +71,8 @@ amy_config_t amy_default_config() {
     c.i2s_mclk_mult = 256;  // MCLK = mclk_mult * Fs.
     c.midi_out = -1;
     c.midi_in = -1;
-    c.midi_uart = -1; 
+    c.midi_uart = -1;
+    c.midi_thru = 0;  // MIDI thru (echo MIDI in -> MIDI out) off by default
 
     #if defined(AMYBOARD_ARDUINO) || defined(AMYBOARD)
     // Set default pins 


### PR DESCRIPTION
Closes #738.

## What

Adds an `amy_config_t.midi_thru` flag. When set, AMY echoes **every incoming MIDI byte straight to MIDI out**, in addition to processing it normally. **Off by default.**

```c
amy_config_t c = amy_default_config();
c.midi_thru = 1;          // enable at startup
amy_start(c);
// ...or toggle at runtime:
amy_global.config.midi_thru = 1;
```

## How

Forwarding is done byte-by-byte at the top of `convert_midi_bytes_to_messages()` — the single function that all MIDI inputs (UART via `esp_poll_midi`/`on_pico_uart_rx`, USB via `check_tusb_midi`) funnel through.

Forwarding inside the parse loop (rather than blasting the whole input buffer) keeps USB correct: USB MIDI always delivers fixed 3-byte groups, padded with junk for <3-byte messages. The existing `if(usb) i = len+1` early-exits stop the loop before those padding bytes, so only the real MIDI bytes of a USB message are passed through. UART input has no padding and forwards in full.

## Notes

- No new symbols added to `amy_midi.c` (only the body of an existing function changed), so no Godot platform-stub updates are needed.
- On Tulip this is exposed to Python as `tulip.amy_midi_thru(True/False)` (companion tulipcc PR).
- Web targets are out of scope for now; the field is platform-agnostic and stays off unless explicitly enabled.

## Test

- `make test` — all 94 tests pass (midi_thru is off by default; no behavior change to existing paths).
- Verified `amyboard` (ESP32-S3) firmware compiles with the change.

Docs updated: `docs/api.md` (config table) and `docs/midi.md` (new "MIDI Thru" section).