### PR TITLE
 Title: Fix copy-paste typo in stereo_reverb low-pass filter state

### DIFF
--- a/src/delay.c
+++ b/src/delay.c
@@ -334,7 +334,7 @@ void stereo_reverb(reverb_params_t *rev, SAMPLE *r_in, SAMPLE *l_in, SAMPLE *r_o
         d3 = LPF(d3, rev->f3state, rev->lpfcoef, rev->lpfgain, rev->liveness);
 
         SAMPLE d4 = DEL_OUT(rev->delay_4, 0);
-        d4 = LPF(d4, rev->f3state, rev->lpfcoef, rev->lpfgain, rev->liveness);
+        d4 = LPF(d4, rev->f4state, rev->lpfcoef, rev->lpfgain, rev->liveness);
 
         // Mixing and feedback.
         DEL_IN(rev->delay_1, d1 + d2 + d3 + d4);


### PR DESCRIPTION

  There is a small copy-paste typo in the  stereo_reverb  function where  f3state  is mistakenly passed to the low-
  pass filter for  d4 .
```c
            SAMPLE d3 = DEL_OUT(delay_3, 0);
            d3 = LPF(d3, f3state, lpfcoef, lpfgain, liveness);

            SAMPLE d4 = DEL_OUT(delay_4, 0);
            d4 = LPF(d4, f3state, lpfcoef, lpfgain, liveness); // <-- uses f3state instead of f4state
``` 
  Because  d3  and  d4  are processing independent delay lines, sharing the same  f3state  variable causes their low-
  pass filters to unintentionally cross-talk.

  This PR corrects the  d4  filter to use the explicitly declared (but previously unused)  f4state  variable.