### PR TITLE
[TEST - do not merge] HWCI smoke test

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -1,6 +1,8 @@
 // DAn Ellis and Brian Whitman
 // brian@variogr.am / dan.ellis@gmail.com
 
+// HWCI smoke test — no-op comment to exercise the AMYboard hardware-CI pipeline.
+
 #include "amy.h"
 #include "delay.h"
 


### PR DESCRIPTION
Throwaway PR to exercise the new AMYboard hardware-CI pipeline end to end (added by Claude at Brian's request).

It adds a single no-op comment to `src/amy.c` to trip the `src/**` path filter. Because a comment doesn't change the firmware, the bench audio should match the reference and report **PASS**.

Expected sequence:
1. `amyboard-hwci-trigger` fires here, posts a "dispatched" note, and dispatches to tulipcc.
2. tulipcc builds AMYboard firmware with this PR's amy SHA, runs the physical bench.
3. A pass/fail comment lands back on this PR.

**Not for merge — close when done.**