### PR TITLE
Fix NULL deref on freed chained_osc in render_osc_wave

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -1702,7 +1702,7 @@ SAMPLE render_osc_wave(uint16_t osc, uint8_t core, SAMPLE* buf) {
         if(AMY_IS_SET(synth[osc]->chained_osc)) {
             // Stack oscillators - render next osc into same buffer.
             uint16_t chained_osc = synth[osc]->chained_osc;
-            if (synth[chained_osc]->status == SYNTH_AUDIBLE) {  // We have to recheck this since we're bypassing the skip in amy_render.
+            if (synth[chained_osc] != NULL && synth[chained_osc]->status == SYNTH_AUDIBLE) {  // We have to recheck this since we're bypassing the skip in amy_render.
                 SAMPLE new_max_val = render_osc_wave(chained_osc, core, buf);
                 if (new_max_val > max_val)  max_val = new_max_val;
             }


### PR DESCRIPTION
`render_osc_wave` dereferences ` synth[chained_osc]->status` with no NULL check on
`synth[chained_osc]` itself. A chained_osc slot can be freed or left unallocated
during a patch toggle, causing a NULL deref fault 
The fix adds a NULL check before the status check, matching the pattern used
elsewhere for `synth[]` slot access. When` chained_osc` is NULL the `chained osc `is
skipped — it cannot be `SYNTH_AUDIBLE`, so behaviour is unchanged when allocation
is intact.