### PR TITLE
fix: make reverb allocation failure safe (mirrors existing echo guard)

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -330,10 +330,10 @@ void config_chorus(uint8_t bus, float level, uint16_t max_delay, float lfo_freq,
     amy_global.bus[bus]->chorus.depth = depth;
 }
 
-void alloc_reverb_delay_lines(uint8_t bus) {
+bool alloc_reverb_delay_lines(uint8_t bus) {
     if (amy_global.bus[bus]->reverb.rev == NULL)
         amy_global.bus[bus]->reverb.rev = new_reverb();
-    init_stereo_reverb(amy_global.bus[bus]->reverb.rev);
+    return init_stereo_reverb(amy_global.bus[bus]->reverb.rev);
 }
 
 void dealloc_reverb_delay_lines(uint8_t bus) {
@@ -352,7 +352,10 @@ void config_reverb(uint8_t bus, float level, float liveness, float damping, floa
         //printf("config_reverb: level %f liveness %f xover %f damping %f\n",
         //      level, liveness, xover_hz, damping);
         if (amy_global.bus[bus]->reverb.level == 0) {
-            alloc_reverb_delay_lines(bus);
+            if (!alloc_reverb_delay_lines(bus)) {
+                amy_global.bus[bus]->reverb.level = 0;
+                return;
+            }
         }
         config_stereo_reverb(amy_global.bus[bus]->reverb.rev, liveness, xover_hz, damping);
     }
@@ -1977,7 +1980,7 @@ int16_t * amy_fill_buffer() {
         }
         if(AMY_HAS_REVERB) {
             // apply per-bus reverb.
-            if(amy_global.bus[bus]->reverb.level > 0) {
+            if(amy_global.bus[bus]->reverb.level > 0 && amy_global.bus[bus]->reverb.rev != NULL && amy_global.bus[bus]->reverb.rev->delay_1 != NULL) {
                 if(AMY_NCHANS == 1) {
                     stereo_reverb(amy_global.bus[bus]->reverb.rev, fbl[0][bus], NULL, fbl[0][bus], NULL, AMY_BLOCK_SIZE, amy_global.bus[bus]->reverb.level);
                 } else {

--- a/src/delay.c
+++ b/src/delay.c
@@ -240,22 +240,32 @@ void config_stereo_reverb(reverb_params_t *rev, float a_liveness, float crossove
 #define REF6SAMPS 602   // 13.645 ms
 
 
-void init_stereo_reverb(reverb_params_t *rev) {
-    if (rev->delay_1 == NULL) {
-        rev->delay_1 = new_delay_line(DELAY_POW2, DELAY1SAMPS, amy_global.config.ram_caps_delay);
-        rev->delay_2 = new_delay_line(DELAY_POW2, DELAY2SAMPS, amy_global.config.ram_caps_delay);
-        rev->delay_3 = new_delay_line(DELAY_POW2, DELAY3SAMPS, amy_global.config.ram_caps_delay);
-        rev->delay_4 = new_delay_line(DELAY_POW2, DELAY4SAMPS, amy_global.config.ram_caps_delay);
+bool init_stereo_reverb(reverb_params_t *rev) {
+    if (rev->delay_1 != NULL)
+        return true;  // already initialised
 
-        rev->ref_1 = new_delay_line(4096, REF1SAMPS, amy_global.config.ram_caps_delay);
-        rev->ref_2 = new_delay_line(2048, REF2SAMPS, amy_global.config.ram_caps_delay);
-        rev->ref_3 = new_delay_line(2048, REF3SAMPS, amy_global.config.ram_caps_delay);
-        rev->ref_4 = new_delay_line(1024, REF4SAMPS, amy_global.config.ram_caps_delay);
-        rev->ref_5 = new_delay_line(1024, REF5SAMPS, amy_global.config.ram_caps_delay);
-        rev->ref_6 = new_delay_line(1024, REF6SAMPS, amy_global.config.ram_caps_delay);
-        
-        config_stereo_reverb(rev, INITIAL_LIVENESS, INITIAL_XOVER_HZ, INITIAL_DAMPING);
+    rev->delay_1 = new_delay_line(DELAY_POW2, DELAY1SAMPS, amy_global.config.ram_caps_delay);
+    rev->delay_2 = new_delay_line(DELAY_POW2, DELAY2SAMPS, amy_global.config.ram_caps_delay);
+    rev->delay_3 = new_delay_line(DELAY_POW2, DELAY3SAMPS, amy_global.config.ram_caps_delay);
+    rev->delay_4 = new_delay_line(DELAY_POW2, DELAY4SAMPS, amy_global.config.ram_caps_delay);
+
+    rev->ref_1 = new_delay_line(4096, REF1SAMPS, amy_global.config.ram_caps_delay);
+    rev->ref_2 = new_delay_line(2048, REF2SAMPS, amy_global.config.ram_caps_delay);
+    rev->ref_3 = new_delay_line(2048, REF3SAMPS, amy_global.config.ram_caps_delay);
+    rev->ref_4 = new_delay_line(1024, REF4SAMPS, amy_global.config.ram_caps_delay);
+    rev->ref_5 = new_delay_line(1024, REF5SAMPS, amy_global.config.ram_caps_delay);
+    rev->ref_6 = new_delay_line(1024, REF6SAMPS, amy_global.config.ram_caps_delay);
+
+    if (rev->delay_1 == NULL || rev->delay_2 == NULL || rev->delay_3 == NULL || rev->delay_4 == NULL ||
+        rev->ref_1 == NULL || rev->ref_2 == NULL || rev->ref_3 == NULL ||
+        rev->ref_4 == NULL || rev->ref_5 == NULL || rev->ref_6 == NULL) {
+        fprintf(stderr, "init_stereo_reverb: allocation failed, reverb disabled\n");
+        deinit_stereo_reverb(rev);  // rolls back all partial allocations, NULLs all pointers
+        return false;
     }
+
+    config_stereo_reverb(rev, INITIAL_LIVENESS, INITIAL_XOVER_HZ, INITIAL_DAMPING);
+    return true;
 }
 
 void deinit_stereo_reverb(reverb_params_t *rev) {

--- a/src/delay.h
+++ b/src/delay.h
@@ -16,7 +16,7 @@ void apply_fixed_delay(SAMPLE *block, delay_line_t *delay_line, uint32_t delay_s
 reverb_params_t *new_reverb();
 void delete_reverb(reverb_params_t *rev);
 void config_stereo_reverb(reverb_params_t *rev, float a_liveness, float crossover_hz, float damping);
-void init_stereo_reverb(reverb_params_t *rev);
+bool init_stereo_reverb(reverb_params_t *rev);
 void deinit_stereo_reverb(reverb_params_t *rev);
 void stereo_reverb(reverb_params_t *rev, SAMPLE *r_in, SAMPLE *l_in, SAMPLE *r_out, SAMPLE *l_out, int n_samples, SAMPLE level);
 


### PR DESCRIPTION
### Bug:
`init_stereo_reverb()` allocates 10 delay lines but returns `void`, so a partial
allocation failure is silently ignored. The idempotency guard at the top of the
function checks only rev->delay_1: if delay_1 succeeds but any later line fails,
`rev->delay_1` is non-NULL on all subsequent calls, so the half-initialised struct
is never repaired. `config_reverb()` then sets reverb.level unconditionally, and
the render guard in `amy_fill_buffer` checks only `reverb.level > 0` — so
`stereo_reverb()` runs and dereferences a `NULL` delay-line pointer, guaranteed crash.

Echo already has the correct guard `(echo_delay_lines[0] != NULL)`. This PR brings
reverb in line, adapted to the struct-based `reverb_params_t design`:


**Allocator — returns bool, rolls back on failure:**  
```c
amy.c - line 204

bool alloc_echo_delay_lines(uint8_t bus, uint32_t max_delay_samples) {
    bool success = true;
    for (int c = 0; c < AMY_NCHANS; ++c) {
        delay_line_t *delay_line = new_delay_line(max_delay_samples, 0, amy_global.config.ram_caps_delay);
        if (delay_line) {
            amy_global.bus[bus]->echo.echo_delay_lines[c] = delay_line;
        } else {
            success = false;
            break;
        }
    }
    if (!success) {
        fprintf(stderr, "unable to alloc echo of %d samples\n", (int)max_delay_samples);
        dealloc_echo_delay_lines(bus);
        return false;
    }
    return true;
}
``` 

**config_echo — bails on allocation failure before committing level:** 
```c
amy.c - line 243-245

    if (level > 0) {
        if (amy_global.bus[bus]->echo.echo_delay_lines[0] == NULL) {
            if (!alloc_echo_delay_lines(bus, max_delay_samples)) return;
        }
        ...
    }
    amy_global.bus[bus]->echo.level = F2S(level);
```

**Render guard:** 
```c
amy.c - line 1975
if (amy_global.bus[bus]->echo.level > 0 && amy_global.bus[bus]->echo.echo_delay_lines[0] != NULL) {
````

### Fix:
- `init_stereo_reverb(reverb_params_t *rev)` returns `bool`. On any allocation
  failure it calls the existing `deinit_stereo_reverb()` to roll back all partial
  allocations (leaving every pointer `NULL`) and returns `false`.
- `alloc_reverb_delay_lines()` returns `bool`, propagating the failure to its caller.
- `config_reverb()` forces level=0 and returns early on allocation failure instead
  of committing a non-zero level against an uninitialised rev.
- The render guard adds `rev != NULL && rev->delay_1 != NULL` as a final defence
  against NULL deref (mirrors the echo pattern; delay_1 is the first line
  allocated and the last freed, making it a reliable sentinel).

Behaviour is unchanged when allocation succeeds. The added render-path check is
two pointer comparisons per block.

Pardon me if I am missing something obvious and wasted anyones time.
