### PR TITLE
HW CI: fix fork-PR dispatch (pull_request_target)

### DIFF
--- a/.github/workflows/amyboard-hwci-trigger.yml
+++ b/.github/workflows/amyboard-hwci-trigger.yml
@@ -9,15 +9,24 @@ name: AMYboard HW CI (dispatch)
 # comment the pass/fail back on this PR.
 #
 # SECURITY: the bench is a self-hosted Pi and this repo is public, so it must
-# never execute UNVETTED fork code. Same-repo PRs (maintainers push branches to
-# shorepine/amy) run automatically — no label needed. A fork PR runs ONLY after a
-# maintainer adds the `hwci-ok` label; only maintainers can apply labels, so that
-# label IS the human-review gate (and GitHub's own "Approve and run" for fork
-# workflows still applies on top). A maintainer can also bench a fork by manually
+# never run UNVETTED fork code. Same-repo PRs (maintainers push branches to
+# shorepine/amy) dispatch automatically — no label needed. A fork PR dispatches
+# ONLY after a maintainer adds the `hwci-ok` label; only maintainers can label, so
+# that label IS the human-review gate. This job never checks out PR code — it only
+# reads head.sha + number and fires the dispatch (see the `on:` note for why it
+# runs as `pull_request_target`). A maintainer can also bench a fork by manually
 # dispatching tulipcc's "AMYboard PR preview" workflow with the fork's amy SHA.
 
 on:
-  pull_request:
+  # `pull_request_target`, NOT `pull_request`: the job must run in THIS repo's
+  # trusted context to read HWCI_BRIDGE_TOKEN. A fork's `pull_request` run is given
+  # NO secrets (a hard GitHub rule), so it could never dispatch — that's why
+  # labeling a fork PR did nothing. SAFE here because the job never checks out or
+  # runs the PR's code; it only reads head.sha + number and fires the cross-repo
+  # dispatch. (The fork's code runs only downstream on the bench — the `hwci-ok`
+  # label is the maintainer gate for that.) Note: the workflow that runs is always
+  # main's version, so changes here take effect only once merged.
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled]
     paths:
       - 'src/**'                                   # only src/ is compiled into firmware


### PR DESCRIPTION
## The bug

The `hwci-ok` label gate ([#745](https://github.com/shorepine/amy/pull/745)) can't actually bench a fork PR. Two reasons, found while debugging why labeling fork PR #744 did nothing:

1. **No secrets for forks.** A fork's `pull_request` workflow is denied all repository secrets (GitHub's security model — only a read-only `GITHUB_TOKEN`). So the dispatch step can never read `HWCI_BRIDGE_TOKEN`, and the cross-repo dispatch to tulipcc is impossible from a fork. The label gate as written is structurally unable to work for forks.
2. **Timing race** (secondary): #744's label was added 37s after the gate merged, before GitHub recomputed the PR's merge-ref, so the `labeled` event evaluated the pre-gate workflow and fired nothing.

## The fix

Switch the trigger from `pull_request` to **`pull_request_target`**, which runs in this repo's **trusted context** — so it has `HWCI_BRIDGE_TOKEN` and always uses `main`'s workflow (no merge-ref race).

```diff
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled]
```

## Why this is safe (the usual `pull_request_target` footgun does NOT apply)

The classic `pull_request_target` vulnerability is checking out and **running** the PR's code while secrets are in scope. **This job never does that** — it has no `checkout`, runs no PR code, and only reads `head.sha` (a hash) + `number` (an int) to fire the dispatch. The fork's code only ever runs *downstream on the bench*, which is precisely what a maintainer authorizes by applying `hwci-ok`.

- Gate is unchanged: same-repo **OR** `hwci-ok` label. Only maintainers can label.
- Unlabeled fork PRs: the job's `if` skips before anything privileged happens.
- Same-repo PRs: unaffected (still auto-dispatch; now always with secrets present).

## Testing after merge
Re-apply `hwci-ok` to fork PR #744 (rt-rtos's reverb-OOM fix) — it should dispatch, bench, and comment back. The label is already on, so remove + re-add to fire a fresh event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)