### PR TITLE
parse: add 'zY' transfer-layer command to start/stop the sequencer

### DIFF
--- a/amy/__init__.py
+++ b/amy/__init__.py
@@ -147,7 +147,7 @@ _KW_MAP_LIST = [   # Order matters because patch_string must come last.
     ('mod_source', 'LI'),  ('eq', 'xL'), ('filter_type', 'GI'), ('ratio', 'IF'), ('latency_ms', 'NI'),
     ('algo_source', 'OL'), ('load_sample', 'zL'), ('transfer_file', 'zTL'), ('disk_sample', 'zFL'), 
     ('algorithm', 'oI'), ('chorus', 'kL'), ('reverb', 'hL'), ('echo', 'ML'), ('patch', 'KI'), ('voices', 'rL'),
-    ('external_channel', 'WI'), ('portamento', 'mI'), ('sequence', 'HL'), ('tempo', 'jF'),
+    ('external_channel', 'WI'), ('portamento', 'mI'), ('sequence', 'HL'), ('tempo', 'jF'), ('sequencer_run', 'zYI'),
     ('synth', 'iI'), ('pedal', 'ipI'), ('synth_flags', 'ifI'), ('num_voices', 'ivI'), ('oscs_per_voice', 'inI'),
     ('to_synth', 'itI'), ('grab_midi_notes', 'imI'),  ('note_source', 'iMI'), ('synth_delay', 'idI'),
     ('preset', 'pI'), ('num_partials', 'pI'), # note aliasing

--- a/src/parse.c
+++ b/src/parse.c
@@ -613,6 +613,13 @@ uint16_t amy_parse_transfer_layer_message(char *message) {
             return total;
         }
     }
+    else if (cmd == 'Y') {
+        // zY: sequencer transport. zY1 starts the sequencer, zY0 stops it. Lets a
+        // host drive playback without MIDI clock sync (see external_midi_sync).
+        if (atoi(message)) sequencer_midi_start();
+        else sequencer_midi_stop();
+        return 1;
+    }
     else fprintf(stderr, "Unrecognized transfer-level command '%s'\n", message - 1);
     return 0;
 }


### PR DESCRIPTION
## What

Adds a `z`-layer command to start/stop the sequencer transport directly:

- `amy.send(sequencer_run=1)` → `zY1` → `sequencer_midi_start()`
- `amy.send(sequencer_run=0)` → `zY0` → `sequencer_midi_stop()`

Lives in the `z` transfer/control-command namespace (next to `zT`/`zF`/`zS`/`zO`/`zD`/`zA`/`zP`) rather than spending a top-level wire letter — `Y` stays "still available". `sequencer_midi_start/stop()` are already called in parse.c (file-transfer pause), so no new declarations.

## Why

A host that wants to drive sequencer playback (e.g. the AMYboard Online editor's Start/Stop buttons) otherwise has to send MIDI Start/Stop (0xFA/0xFC). After the external-sync gating change, AMY ignores those unless the user enabled external MIDI clock sync (`external_midi_sync`) — correct for not letting a DAW hijack transport, but it leaves no un-gated way to start/stop the sequencer from a wire message. This adds one. It's also the only lever available to the **wasm** build, where AMY runs as a separate module reachable only via `amy_add_message`.

## Changes
- `src/parse.c`: `zY` handler in `amy_parse_transfer_layer_message` (mirrors `zO`).
- `amy/__init__.py`: map `sequencer_run` → `zYI`.

## Testing
`make test` → **99 tests pass** (additive). End-to-end verified via the companion tulipcc change (AMYboard editor Start/Stop in control and simulate modes).

`sequencer_run` is a new public `amy.send()` param name — happy to rename if you prefer.