### PR TITLE
Fix float-mode build break: add MUL5A_SS / MUL6A_SS fallbacks

### DIFF
--- a/src/amy_fixedpoint.h
+++ b/src/amy_fixedpoint.h
@@ -96,6 +96,8 @@
 
 #define MUL0_SS(a, b) ((a) * (b))
 #define MUL4_SS(a, b) ((a) * (b))
+#define MUL5A_SS(a, b) ((a) * (b))
+#define MUL6A_SS(a, b) ((a) * (b))
 #define MUL8_SS(a, b) ((a) * (b))
 #define MUL8F_SS(a, b) ((a) * (b))
 #define MUL4E_SS(a, b) ((a) * (b))


### PR DESCRIPTION
### What

Adds float-mode fallbacks for `MUL5A_SS` and `MUL6A_SS` in `src/amy_fixedpoint.h`.

### Why

Since 98ea6bc ("Change multiply resolution to help Xanadu"), `oscillators.c:18`
references `MUL5A_SS` unconditionally:

    #define MULA_SS(a, b) MUL5A_SS(a, b)

But `MUL5A_SS` and `MUL6A_SS` are defined only inside the fixed-point block of
`amy_fixedpoint.h`. Building with `AMY_USE_FIXEDPOINT` undefined (the float path
used on FPU targets — desktop, wasm/Emscripten, ESP32-S3, MicroPython) fails:

    oscillators.c:18:23: error: implicit declaration of function 'MUL5A_SS'

### Fix

Add the same `(a) * (b)` fallback that every other `MUL*_SS` macro already has
in the float block:

    #define MUL5A_SS(a, b) ((a) * (b))
    #define MUL6A_SS(a, b) ((a) * (b))

### Notes

- The change is entirely inside `#ifndef AMY_USE_FIXEDPOINT`, so the default
  fixed-point build is untouched.
- Verified: the float translation unit reproduces the implicit-declaration error
  without these lines and compiles cleanly with them.