### PR TITLE
Remove stale brianklay SSH note from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,4 +32,3 @@ The `docs/amy.js` file is a concatenation of the Emscripten build (`build/amy.js
 ## GitHub Auth
 
 - The `bwhitman` account needs `workflow` scope on its token to push changes to `.github/workflows/` files. Run `gh auth refresh -h github.com -s workflow` if pushes are rejected.
-- SSH pushes to `shorepine/amy` use the `brianklay` key by default; use HTTPS with `gh auth token` for `bwhitman` access.


### PR DESCRIPTION
Removes the stale GitHub-auth bullet in `CLAUDE.md` claiming SSH pushes to `shorepine/amy` use the `brianklay` key.

That's no longer true: the default github.com SSH key now authenticates as `bwhitman` (verified — `ssh -T git@github.com` → `Hi bwhitman!`), and `brianklay` is an unrelated account. The accurate `workflow`-scope bullet above it is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)