### PR TITLE
Rebuild web assets on every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,14 @@ name: Release
 # refs/tags/<version>, so its existing release job attaches the zip. No PAT, and
 # nothing to renew.
 #
+# WHY WEB ASSETS ARE REBUILT HERE: docs/amy.js + amy.wasm + amy.aw.js + amy.ww.js
+# are Emscripten build outputs (not hand-edited), and both the docs/ web demo and
+# the Godot zip (godot-addon.yml copies docs/amy.*) ship them. So before tagging
+# we run `make deploy-web` and fold the rebuilt docs/amy.* into the same bump
+# commit -- guaranteeing main, the tag, and the Godot zip all carry web assets
+# built from this exact source. The toolchain mirrors the `web` job in c-cpp.yml
+# (same pinned emsdk), which already verifies `make web` links on every PR.
+#
 # TO SKIP a release for a given merge, include "[skip release]" in the merge
 # commit message.
 
@@ -52,6 +60,20 @@ jobs:
           ref: main
           fetch-depth: 0          # full history + tags, needed to bump and tag
 
+      # Toolchain for the `make deploy-web` rebuild below. Mirrors the `web` job
+      # in c-cpp.yml -- same pinned emsdk so the committed bytes match what CI
+      # builds and verifies on every PR.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install web build deps
+        run: pip install numpy
+
+      - uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: 4.0.22
+
       - name: Compute next patch version
         id: ver
         run: |
@@ -68,6 +90,17 @@ jobs:
           echo "next=$next" >> "$GITHUB_OUTPUT"
           echo "Releasing $current -> $next"
 
+      - name: Rebuild web assets from this main
+        run: |
+          # Regenerate docs/amy.js + amy.wasm + amy.aw.js + amy.ww.js from the
+          # current source so the tagged release -- and the Godot zip dispatched
+          # afterwards, which copies docs/amy.* -- always ship web assets built
+          # from this exact commit. Folded into the bump commit below so main and
+          # the tag carry them. (Only docs/amy.* are deploy-web outputs; the
+          # static docs/enable-threads.js and the MicroPython docs/micropython.*
+          # REPL files are intentionally not rebuilt here.)
+          make deploy-web
+
       - name: Open and merge the version-bump PR
         env:
           GH_TOKEN: ${{ github.token }}
@@ -80,12 +113,19 @@ jobs:
           branch="bump-$NEXT"
           git switch -c "$branch"
           sed -i -E "s/^version=.*/version=$NEXT/" library.properties
-          git commit -am "Bump version to $NEXT"
+          # Stage the version bump alongside the rebuilt web assets so the single
+          # tagged commit carries both. Explicit paths (not `commit -a`) keep any
+          # other files `make` touched (build/, src/patches.h, amy/constants.py)
+          # out of the commit. If a rebuilt asset is byte-identical, `git add` is
+          # a harmless no-op and only library.properties lands.
+          git add library.properties \
+            docs/amy.js docs/amy.wasm docs/amy.aw.js docs/amy.ww.js
+          git commit -m "Bump version to $NEXT, rebuild web assets"
           git push -u origin "$branch"
 
           gh pr create --base main --head "$branch" \
             --title "Bump version to $NEXT" \
-            --body "Automated release bump to $NEXT, cut on merge to main by .github/workflows/release.yml."
+            --body "Automated release bump to $NEXT (with rebuilt web assets), cut on merge to main by .github/workflows/release.yml."
 
           # The PR was created with GITHUB_TOKEN, so it triggers no checks and is
           # immediately mergeable; retry briefly while GitHub computes mergeability.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,8 @@ Releases are cut **automatically on every merge to `main`** by `.github/workflow
 2. It creates the GitHub release with a plain version tag (e.g. `1.2.8`, NOT `v1.2.8`) — Arduino requires this format — which the Arduino Library Manager picks up.
 3. The Godot addon build (`godot-addon.yml`) attaches `amy-godot-addon.zip`. A `GITHUB_TOKEN`-created tag can't fire `godot-addon.yml`'s `push: tags` trigger, so the release workflow instead dispatches it via `workflow_dispatch` at the new tag (the one event `GITHUB_TOKEN` *can* trigger). No PAT is involved.
 
+The bump PR also carries **freshly rebuilt web assets**: the workflow runs `make deploy-web` and stages `docs/amy.js` / `amy.wasm` / `amy.aw.js` / `amy.ww.js` into that same bump commit, so the tagged release — and the Godot zip, which copies `docs/amy.*` — always ship web built from that exact source. (`docs/enable-threads.js` is static and the MicroPython `docs/micropython.*` REPL files are a separate build; neither is rebuilt here.)
+
 To **skip** a release for a given merge, put `[skip release]` in the merge commit message. To cut a release manually, the same three steps work by hand (bump `library.properties` via PR, `gh release create <ver>`, then the Godot build).
 
 ## Godot GDExtension
@@ -25,7 +27,7 @@ The live Python REPL at `docs/tutorial.html` runs MicroPython in the browser wit
 1. In `tulipcc`, update the amy submodule to latest: `cd tulipcc && git submodule update --remote amy`
 2. Rebuild MicroPython: `cd tulip/amyrepl && make clean && make`
 3. Copy the output to amy's docs: `cp build-standard/tulip/obj/micropython.mjs build-standard/tulip/obj/micropython.wasm <amy-repo>/docs/`
-4. If the AMY C code or JS API also changed, rebuild those too: `cd <amy-repo> && make web && make deploy-web`
+4. The browser AMY build (`docs/amy.js`, `docs/amy.wasm`, `docs/amy.aw.js`, `docs/amy.ww.js`) is now rebuilt and committed automatically on every release by `.github/workflows/release.yml` (it runs `make deploy-web` and folds the output into the version-bump commit it tags), so you don't need `make deploy-web` by hand for a release. Run `cd <amy-repo> && make web && make deploy-web` locally only to preview those changes before merging. This automation covers only `docs/amy.*` — the `docs/micropython.*` REPL files above are still the separate tulipcc build.
 
 The `docs/amy.js` file is a concatenation of the Emscripten build (`build/amy.js`), `src/amy_connector.js`, and `build/amy_api.generated.js`. The JS API is auto-generated from `amy/__init__.py` by `scripts/gen_amy_js_api.py`.
 


### PR DESCRIPTION
## What

Rebuild the browser AMY web assets — `docs/amy.js`, `amy.wasm`, `amy.aw.js`, `amy.ww.js` — from source on every release and fold them into the version-bump commit that `release.yml` tags.

## Why

These four files are Emscripten build outputs, but until now they were only refreshed by hand via `make deploy-web`. The Godot addon zip and the `docs/` web demo both ship them, so a release could tag and ship **stale** web assets that didn't match the released source. Now `main`, the release tag, and the Godot zip all carry web built from that exact commit — by construction, since `godot-addon.yml` is dispatched *at the tag*.

## How

- Add the web toolchain to the `release` job (Python 3.13 + numpy + `mymindstorm/setup-emsdk@4.0.22`) — the same setup the `web` job in `c-cpp.yml` already uses, so the committed bytes match what CI verifies on every PR.
- New step runs `make deploy-web`.
- The bump commit now stages `library.properties` **plus** the four `docs/amy.*` outputs.

## Notes

- **Scope is `docs/amy.*` only.** `docs/enable-threads.js` (static) and `docs/micropython.*` (the separate tulipcc REPL build) are intentionally not rebuilt here.
- **No-op when unchanged:** with the pinned emsdk, identical source produces identical bytes, so `docs/` only churns when web output actually changes.
- **~3–5 min added per release**, serialized under the existing `concurrency: release` lock. If `make deploy-web` fails it aborts *before* any tag/release is created, and `c-cpp.yml` already gates the same `make web` on every PR.
- **Self-applying:** merging this runs the updated `release.yml`, so the first release to use it is the one cut by this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
