### PR TITLE
Gamma9001 UI polish: start modal, small-screen gate, Safari share fix [skip release]

### DIFF
--- a/docs/gamma9001/app.js
+++ b/docs/gamma9001/app.js
@@ -265,22 +265,26 @@ async function loadPreset(presetIdx) {
   sendSampleToAmy(presetIdx, buf);
 }
 
+function setLoadStatus(text) {
+  document.getElementById("loadstatus").textContent = text;
+  document.getElementById("startlabel").textContent = text;
+}
+
 async function loadAllSamples() {
-  const status = document.getElementById("loadstatus");
   // Kit samples first so the machine is playable immediately.
   for (const ch of state.channels) await loadPreset(ch.sample);
-  status.textContent = "kit ready";
+  setLoadStatus("kit ready");
   let n = 0;
   for (let i = 0; i < manifest.length; i++) {
     if (!loadedPresets.has(i)) {
       await loadPreset(i);
       if (++n % 8 === 0) {
-        status.textContent = `loading samples ${loadedPresets.size}/${manifest.length}`;
+        setLoadStatus(`loading samples ${loadedPresets.size}/${manifest.length}`);
         await new Promise(r => setTimeout(r, 0));
       }
     }
   }
-  status.textContent = `${manifest.length} samples loaded`;
+  setLoadStatus(`${manifest.length} samples loaded`);
 }
 
 // ---------------------------------------------------------------- triggering
@@ -738,7 +742,6 @@ function rebuildUI() {
   document.getElementById("bpm").value = state.bpm;
   document.getElementById("shuffle").value = state.shuffle;
   document.getElementById("shuffleval").textContent = `${state.shuffle}%`;
-  document.getElementById("mastervol").value = Math.round(state.masterVol * 10);
   document.getElementById("loop").checked = state.loop;
   document.getElementById("songname").value = state.name;
   document.getElementById("poslcd").textContent = `${state.pattern + 1}.1`;
@@ -757,26 +760,41 @@ function setLane(lane) {
 function buildFx() {
   const fx = document.getElementById("fxknobs");
   fx.innerHTML = "";
+  // gap: true inserts a group separator before that knob
   const defs = [
     { label: "Reverb", min: 0, max: 1, step: 0.01, reset: 0, key: "reverb", fmt: v => v.toFixed(2) },
     { label: "Liveness", min: 0, max: 1, step: 0.01, reset: 0.85, key: "liveness", fmt: v => v.toFixed(2) },
-    { label: "Chorus", min: 0, max: 1, step: 0.01, reset: 0, key: "chorus", fmt: v => v.toFixed(2) },
-    { label: "Echo", min: 0, max: 1, step: 0.01, reset: 0, key: "echo", fmt: v => v.toFixed(2) },
+    { label: "Chorus", min: 0, max: 1, step: 0.01, reset: 0, key: "chorus", fmt: v => v.toFixed(2), gap: true },
+    { label: "Echo", min: 0, max: 1, step: 0.01, reset: 0, key: "echo", fmt: v => v.toFixed(2), gap: true },
     { label: "Time", min: 20, max: 743, step: 1, reset: 250, key: "echoDelay", fmt: v => `${v}ms` },
     { label: "Feedbk", min: 0, max: 0.95, step: 0.01, reset: 0.3, key: "echoFb", fmt: v => v.toFixed(2) },
     // EQ shelves at AMY's low/mid/high centers, in dB
-    { label: "EQ Lo", min: -15, max: 15, step: 0.5, reset: 0, key: "eqL", fmt: v => `${v > 0 ? "+" : ""}${v}dB` },
+    { label: "EQ Lo", min: -15, max: 15, step: 0.5, reset: 0, key: "eqL", fmt: v => `${v > 0 ? "+" : ""}${v}dB`, gap: true },
     { label: "EQ Mid", min: -15, max: 15, step: 0.5, reset: 0, key: "eqM", fmt: v => `${v > 0 ? "+" : ""}${v}dB` },
     { label: "EQ Hi", min: -15, max: 15, step: 0.5, reset: 0, key: "eqH", fmt: v => `${v > 0 ? "+" : ""}${v}dB` },
+    // master volume lives on state, not state.fx
+    { label: "Volume", min: 0, max: 10, step: 0.1, reset: 1, key: "masterVol", master: true, fmt: v => v.toFixed(1), gap: true },
   ];
   for (const def of defs) {
-    const knob = makeKnob(def,
-      () => state.fx[def.key],
-      v => {
-        state.fx[def.key] = v;
-        if (def.key === "echoDelay") setEchoSync(null);  // manual move unsyncs
-        applyFx();
-      });
+    if (def.gap) {
+      const gap = document.createElement("div");
+      gap.className = "fxgap";
+      fx.appendChild(gap);
+    }
+    const knob = def.master
+      ? makeKnob(def,
+          () => state.masterVol,
+          v => {
+            state.masterVol = v;
+            if (audioOn) amy_send({ volume: v });
+          })
+      : makeKnob(def,
+          () => state.fx[def.key],
+          v => {
+            state.fx[def.key] = v;
+            if (def.key === "echoDelay") setEchoSync(null);  // manual move unsyncs
+            applyFx();
+          });
     fx.appendChild(knob);
     if (def.key === "echoDelay") {
       echoTimeKnob = knob;
@@ -914,14 +932,26 @@ async function boot() {
   if (sharedIn) saveState();   // a loaded share link becomes the local state
 
   const shareBtn = document.getElementById("sharebtn");
-  shareBtn.addEventListener("click", async () => {
-    const url = await makeShareUrl();
-    try {
-      await navigator.clipboard.writeText(url);
+  shareBtn.addEventListener("click", () => {
+    // Safari revokes the user gesture as soon as the handler awaits, which
+    // makes a post-await writeText() throw NotAllowedError. The sanctioned
+    // workaround: synchronously hand the clipboard a ClipboardItem whose
+    // content is a *promise* — the write is authorized now, resolved later.
+    const urlPromise = makeShareUrl();
+    const copied = () => {
       shareBtn.textContent = "Copied!";
       setTimeout(() => { shareBtn.textContent = "Share"; }, 2000);
-    } catch (e) {
-      window.prompt("Copy this link:", url);   // clipboard blocked — manual fallback
+    };
+    const manual = async () => { window.prompt("Copy this link:", await urlPromise); };
+    if (typeof ClipboardItem !== "undefined" && navigator.clipboard?.write) {
+      const item = new ClipboardItem({
+        "text/plain": urlPromise.then(u => new Blob([u], { type: "text/plain" })),
+      });
+      navigator.clipboard.write([item]).then(copied).catch(() =>
+        // e.g. Firefox: no promise-in-ClipboardItem — try the direct path
+        urlPromise.then(u => navigator.clipboard.writeText(u)).then(copied).catch(manual));
+    } else {
+      urlPromise.then(u => navigator.clipboard.writeText(u)).then(copied).catch(manual);
     }
   });
 
@@ -954,17 +984,20 @@ async function boot() {
     window.location.reload();
   });
 
-  document.getElementById("power").addEventListener("click", async function () {
+  // Startup modal: one click starts audio (browsers require a gesture) and
+  // loads the samples, then the machine is fully live.
+  const startModal = document.getElementById("startmodal");
+  startModal.addEventListener("click", async () => {
     if (audioOn) return;
-    this.textContent = "STARTING…";
+    startModal.classList.add("loading");
+    setLoadStatus("starting audio…");
     await amy_js_start();
     audioOn = true;
-    this.textContent = "AUDIO ON";
-    this.classList.add("on");
     amy_send({ volume: state.masterVol });
     applyAllChannelFilters();
     applyFx();
     await loadAllSamples();
+    startModal.classList.add("hidden");
   });
 
   document.getElementById("play").addEventListener("click", () => {
@@ -984,10 +1017,6 @@ async function boot() {
     const v = Math.max(1, Math.min(16, +e.target.value || 16));
     state.patterns[state.pattern].length = v;
     drawSteps();
-  });
-  document.getElementById("mastervol").addEventListener("input", e => {
-    state.masterVol = +e.target.value / 10;
-    if (audioOn) amy_send({ volume: state.masterVol });
   });
   document.getElementById("loop").addEventListener("change", e => { state.loop = e.target.checked; });
   document.querySelectorAll(".lanebtn").forEach(b => {

--- a/docs/gamma9001/index.html
+++ b/docs/gamma9001/index.html
@@ -11,7 +11,6 @@
     <div id="titlebar">
       <span class="logo">Gamma<span class="logo9000">9001</span></span>
       <span class="sub">Powered by <a href="https://github.com/shorepine/amy" target="_blank" rel="noopener">AMY</a></span>
-      <button id="power">POWER ON</button>
       <span id="loadstatus"></span>
       <button id="reset" title="Clear saved song, patterns and settings">Reset</button>
     </div>
@@ -33,7 +32,6 @@
           <label>Tempo <input type="number" id="bpm" min="40" max="240" value="120"></label>
           <label>Shuffle <input type="range" id="shuffle" min="0" max="100" value="0"><span id="shuffleval">0%</span></label>
           <label>Length <input type="number" id="patlen" min="1" max="16" value="16"></label>
-          <label>Volume <input type="range" id="mastervol" min="0" max="30" value="10"></label>
         </div>
       </div>
       <div class="panel" id="patpanel">
@@ -72,6 +70,21 @@
       <div id="pickerhead">Select sound <button id="pickerclose">&times;</button></div>
       <div id="pickerbanks"></div>
       <div id="pickerlist"></div>
+    </div>
+  </div>
+
+  <div id="startmodal">
+    <div id="startbox">
+      <div class="logo biglogo">Gamma<span class="logo9000">9001</span></div>
+      <div id="startlabel">Click to start</div>
+    </div>
+  </div>
+
+  <div id="toosmall">
+    <div id="toosmallbox">
+      <div class="logo biglogo">Gamma<span class="logo9000">9001</span></div>
+      <p>This drum machine needs more room than your screen has.<br>
+      Please open it on an iPad, laptop or desktop.</p>
     </div>
   </div>
 

--- a/docs/gamma9001/style.css
+++ b/docs/gamma9001/style.css
@@ -28,14 +28,7 @@ body {
 .sub { color: #cabfe4; font-style: italic; }
 .sub a { color: #ffb14d; text-decoration: none; }
 .sub a:hover { text-decoration: underline; }
-#power {
-  margin-left: auto;
-  background: linear-gradient(#ff9d3f, #d96f10); color: #2b1a00;
-  border: 1px solid #8a4d00; border-radius: 5px;
-  font-weight: bold; padding: 6px 14px; cursor: pointer;
-}
-#power.on { background: linear-gradient(#8dff70, #3cb814); border-color: #1f6f00; color: #0c2b00; }
-#loadstatus { color: #ffce8a; font-size: 11px; min-width: 130px; }
+#loadstatus { margin-left: auto; color: #ffce8a; font-size: 11px; }
 #reset {
   background: none; color: #7a6ba3; border: 1px solid #4a3b6d;
   border-radius: 4px; padding: 4px 10px; cursor: pointer; font-size: 10px;
@@ -265,3 +258,40 @@ body.lane-pitch .step::before {
 .samplebtn:hover { color: #ffb14d; }
 .samplebtn.current { color: #ff8c1a; border-color: #ff8c1a; }
 .samplebtn .dur { color: #7a6ba3; float: right; font-size: 10px; }
+
+/* ------- start & too-small overlays ------- */
+#startmodal {
+  position: fixed; inset: 0; z-index: 50; cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  background: linear-gradient(160deg, #2c2050e6, #17102bf2);
+  backdrop-filter: blur(3px);
+}
+#startbox { text-align: center; pointer-events: none; }
+.biglogo { font-size: 56px; }
+#startlabel {
+  margin-top: 18px; font-size: 18px; color: #ffce8a;
+  border: 1px solid #ffce8a66; border-radius: 8px; display: inline-block;
+  padding: 12px 28px; background: #ffffff10;
+  animation: startpulse 1.6s ease-in-out infinite;
+}
+#startmodal.loading #startlabel { animation: none; }
+@keyframes startpulse { 50% { background: #ffffff2a; } }
+#startmodal.hidden { display: none; }
+
+#toosmall {
+  display: none; position: fixed; inset: 0; z-index: 60;
+  align-items: center; justify-content: center; text-align: center;
+  background: linear-gradient(160deg, #4f3f78, #17102b);
+  padding: 24px;
+}
+#toosmall p { color: #cabfe4; font-size: 14px; line-height: 1.6; }
+@media (max-width: 699px) {
+  #toosmall { display: flex; }
+}
+
+/* effects knob group separators */
+.fxgap {
+  width: 1px; align-self: stretch; margin: 2px 7px;
+  background: #2c2050; box-shadow: 1px 0 0 #ffffff22;
+  flex: none;
+}


### PR DESCRIPTION
Follow-up polish for the Gamma9001 drum machine (docs-only, hence `[skip release]` in the title):

- **Startup modal replaces the POWER ON button** — first load shows a full-screen "Click to start"; the click starts audio (browsers need the gesture), shows sample-loading progress, and dismisses when the machine is live.
- **Small-screen gate** — below 700px viewport width (phones) a friendly overlay asks for a bigger screen instead of showing a broken layout. iPad portrait (768px) and up is unaffected.
- **Master volume is now an effects knob** — 0–10, default 1, sends `volume=`; the transport slider is gone.
- **Effects knobs grouped with separators** — reverb/liveness | chorus | echo/time/sync/feedback | EQ | volume.
- **Safari Share fix** — Safari revokes the user gesture at the first `await`, so `clipboard.writeText` after building the URL threw `NotAllowedError`. The handler now synchronously hands the clipboard a `ClipboardItem` whose text is a promise (Safari's sanctioned pattern), with `writeText` and prompt fallbacks for other browsers.

Verified in the browser: modal boot flow loads all 128 samples, overlay appears at 375px and not at 1280px, volume knob emits `V…Z` wire messages, share button flips to "Copied!".

🤖 Generated with [Claude Code](https://claude.com/claude-code)