### PR TITLE
Add amy.systime() for cpython; Make AMY_UNSET(int32_t) == AMY_UNSET(uint32_t)

### DIFF
--- a/amy/__init__.py
+++ b/amy/__init__.py
@@ -325,6 +325,9 @@ def inject_midi_bytes(data, usb=0):
     # unlike inject_midi(), which injects a single pre-formed message.
     _amy.inject_midi_bytes(data, usb)
 
+def systime():
+    return _amy.systime()
+
 def unload_sample(patch=0):
     s= "%d,%d" % (patch, 0)
     send(load_sample=s)

--- a/src/amy.h
+++ b/src/amy.h
@@ -453,14 +453,15 @@ static inline int isnan_c11(float test)
 
 #define AMY_UNSET_FLOAT nanf("")
 
-#define AMY_UNSET_VALUE(var) _Generic((var), \
+// UNSET for int32_t should be the same as uint32_t.
+#define AMY_UNSET_VALUE(var) _Generic((var),    \
     float: AMY_UNSET_FLOAT, \
+    int32_t: INT32_MIN,   \
     uint32_t: UINT32_MAX, \
     uint16_t: UINT16_MAX, \
     int16_t: SHRT_MAX, \
     uint8_t: UINT8_MAX, \
-    int8_t: SCHAR_MAX, \
-    int32_t: INT_MAX \
+    int8_t: SCHAR_MAX \
 )
 
 #define AMY_UNSET(var) var = AMY_UNSET_VALUE(var)

--- a/src/pyamy.c
+++ b/src/pyamy.c
@@ -288,6 +288,10 @@ static PyObject *set_cv_from_osc_wrapper(PyObject *self, PyObject *args) {
     return Py_None;
 }
 
+static PyObject *amy_systime_wrapper(PyObject *self, PyObject *args) {
+    return Py_BuildValue("i", amy_sysclock());
+}
+
 static PyMethodDef c_amyMethods[] = {
     {"render_to_list", render_wrapper, METH_VARARGS, "Render audio"},
     {"send_wire", send_wrapper, METH_VARARGS, "Send a message"},
@@ -300,6 +304,7 @@ static PyMethodDef c_amyMethods[] = {
     {"inject_midi_bytes", inject_midi_bytes_wrapper, METH_VARARGS, "Inject a raw MIDI byte stream through the parser"},
     {"get_synth_commands", get_synth_commands_wrapper, METH_VARARGS, "Read synth configuration commands"},
     {"set_cv_from_osc", set_cv_from_osc_wrapper, METH_VARARGS, "Feed external CV input from a mod osc"},
+    {"systime", amy_systime_wrapper, METH_VARARGS, "Read AMY millisecond clock"},
     { NULL, NULL, 0, NULL }
 };
 


### PR DESCRIPTION
Changes are unrelated.  Amy.systime() was previously available as tulip.amy_ticks_ms(), but it seems like it should be an Amy property.  It made me nervous that UNSET(uint32_t) was distinct from UNSET(int32_t).