### PR TITLE
amy/__init__.py: get_synth_stub rejected 2 args.

### DIFF
--- a/amy/__init__.py
+++ b/amy/__init__.py
@@ -3,7 +3,7 @@ from .constants import *
 from . import examples
 import collections
 import time
-def _get_synth_commands_stub(synth):
+def _get_synth_commands_stub(synth, include_fx=False):
     return []
 
 _get_synth_commands = _get_synth_commands_stub


### PR DESCRIPTION
This made `amy.get_synth_commands()` error out on Web-Tulip, instead of just returning [].