### PR TITLE
Don't allocate the 512KB sysex copy-slot ring on Tulip

### DIFF
--- a/src/amy_midi.h
+++ b/src/amy_midi.h
@@ -26,12 +26,15 @@ extern uint8_t *sysex_buffer;
 // Every platform allocates the single sysex_buffer above. The sysex copy-slot
 // ring buffer below holds backup snapshots so a fast-arriving message isn't lost
 // while a previous one waits for the deferred MicroPython mp_sched callback.
-// Only the MicroPython-hosted boards (AMYBOARD, TULIP) create and read these
-// slots (see parse_sysex()); other platforms handle sysex synchronously from
-// sysex_buffer. Size the ring to 0 elsewhere so we don't malloc
-// SYSEX_COPY_SLOTS x MAX_SYSEX_BYTES (32 x 16KB = 512KB), which alone would
-// exhaust e.g. the rp2350's 520KB of SRAM.
-#if defined(AMYBOARD) || defined(TULIP)
+// Only AMYBOARD creates and reads these slots (see parse_sysex()): the ring
+// exists for the SPSS z* sketch-transfer bursts over USB-gadget MIDI, which
+// only AMYboard receives. Size the ring to 0 everywhere else so we don't
+// malloc SYSEX_COPY_SLOTS x MAX_SYSEX_BYTES (32 x 16KB = 512KB): that alone
+// would exhaust e.g. the rp2350's 520KB of SRAM, and on Tulip ESP32-S3 it ate
+// a third of the free SPIRAM. With 0 slots, parse_sysex() finds a NULL slot
+// and the scheduled callback ACKs SPSS messages without processing them;
+// non-SPSS sysex is unaffected.
+#if defined(AMYBOARD)
 #define SYSEX_COPY_SLOTS 32
 #else
 #define SYSEX_COPY_SLOTS 0


### PR DESCRIPTION
The 32-slot × 16KB sysex snapshot ring exists for AMYboard's SPSS `z*` sketch-transfer bursts over USB-gadget MIDI. Tulip compiled it in too (`#if defined(AMYBOARD) || defined(TULIP)`), but Tulip has no USB-gadget MIDI and nothing sends it SPSS transfers — the ring was 512KB of pure SPIRAM overhead on Tulip ESP32-S3.

That overhead became visible in tulipcc HW CI: with WiFi up, `tulip.screenshot()`'s ~615KB lodepng scratch allocation now starves (free SPIRAM is ~996KB idle on current tulipcc main), wedging the board in endless failed reallocs.

This gates `SYSEX_COPY_SLOTS` to AMYBOARD only. With 0 slots the existing guards already handle Tulip correctly:
- `parse_sysex()` finds a NULL slot and skips the copy (the `% SYSEX_COPY_SLOTS` is inside `if(slot)`, no div-by-zero)
- tulipcc's `tulip_amy_send_sysex` callback compiles its existing `SYSEX_COPY_SLOTS==0` branch (ACKs without processing)
- non-SPSS sysex never used the ring and is unaffected
- the alloc/free loops in `run_midi()`/`stop_midi()` iterate 0 times

`make test`: 104 tests pass.

Will be validated on the tulipcc HW CI bench with a TULIP4_R11 build pinned to this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)