### PR TITLE
Add tools/arduino_loadsweep: per-commit render-load regression sweep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,14 @@ timing: amy-module
 	cat /tmp/timings.txt | grep FILTER_PROCESS: | sed -e 's/us//' | sort -n | awk ' { a[i++]=$$4; } END { print a[int(i/2)]; }'
 	cat /tmp/timings.txt | grep PARAMETRIC_EQ_PROCESS: | sed -e 's/us//' | sort -n | awk ' { a[i++]=$$4; } END { print a[int(i/2)]; }'
 
+speedtest:
+	echo "Patching src/i2s.c..."
+	python tools/arduino_loadsweep/patch_render_load.py src/i2s.c
+	echo "Compiling LoadTestChord.ino..."
+	arduino-cli compile --fqbn esp32:esp32:amyboard --build-path ./build tools/arduino_loadsweep/LoadTestChord
+	echo 'Running measure.py.  Press RESET on board after seeing "[flash] ok (attempt 1)"'
+	python tools/arduino_loadsweep/measure.py --out ./load --port /dev/cu.usbserial-0001 ./build
+
 valgrind: amy-example
 	valgrind --leak-check=full --show-reachable=yes --suppressions=valgrind.suppressions ./amy-example
 

--- a/tools/arduino_loadsweep/LoadTestChord/LoadTestChord.ino
+++ b/tools/arduino_loadsweep/LoadTestChord/LoadTestChord.ino
@@ -1,0 +1,62 @@
+// LoadTestChord - fixed render-load test signal for the arduino_loadsweep tool.
+//
+// Resets AMY, sets up synth 1 as 8 voices of patch 1 (Juno), then adds one
+// held note to the chord every 2 seconds: 40, 42, ... 54.  Nothing is ever
+// released, so by t=16s all 8 voices are sounding and the render load has
+// stepped up 8 times.  The sweep's i2s.c patch prints RENDER_LOAD lines on
+// stderr (the debug UART); this sketch adds NOTE markers so the load steps
+// can be aligned to note count.
+//
+// Only uses amy_event fields that exist across the whole sweep window
+// (2026-04-01 / v1.2.4 onwards): synth, patch_number, num_voices, midi_note,
+// velocity, reset_osc.
+
+#include <AMY-Arduino.h>
+
+void setup() {
+  amy_config_t amy_config = amy_default_config();
+
+  // If running an AMYboard, pins/features are set automatically.
+  #ifndef AMYBOARD_ARDUINO
+  amy_config.audio = AMY_AUDIO_IS_I2S;
+  amy_config.i2s_bclk = 8;
+  amy_config.i2s_lrc = 9;
+  amy_config.i2s_dout = 10;
+  #endif
+
+  amy_start(amy_config);
+
+  // amy.reset()
+  amy_event e = amy_default_event();
+  e.reset_osc = RESET_AMY;
+  amy_add_event(&e);
+
+  // amy.send(synth=1, num_voices=8, patch=1)
+  e = amy_default_event();
+  e.synth = 1;
+  e.patch_number = 1;
+  e.num_voices = 8;
+  amy_add_event(&e);
+
+  fprintf(stderr, "LOADTEST_START ms=%lu\n", (unsigned long)millis());
+}
+
+static int note_i = 0;
+static unsigned long last_note_ms = 0;
+
+void loop() {
+  amy_update();
+
+  // Every 2 seconds: amy.send(synth=1, note=40+(i*2), vel=0.2), held forever.
+  if (note_i < 8 && millis() - last_note_ms >= 2000) {
+    last_note_ms = millis();
+    amy_event e = amy_default_event();
+    e.synth = 1;
+    e.midi_note = 40 + (note_i * 2);
+    e.velocity = 0.2f;
+    amy_add_event(&e);
+    fprintf(stderr, "NOTE i=%d note=%d ms=%lu\n",
+            note_i, 40 + (note_i * 2), (unsigned long)millis());
+    note_i++;
+  }
+}

--- a/tools/arduino_loadsweep/README.md
+++ b/tools/arduino_loadsweep/README.md
@@ -1,0 +1,67 @@
+# arduino_loadsweep — per-commit AMY render-load regression sweep
+
+The arduino-cli sibling of tulipcc's `tools/amyboard_loadsweep`
+([tulipcc#1108](https://github.com/shorepine/tulipcc/pull/1108)): find the AMY
+commit where render load regressed by building a fixed test sketch against
+every state of `main` since a start date, running it on a real AMYboard, and
+graphing the measured render load per commit.
+
+## What it does
+
+For each `--first-parent` commit on `origin/main` since `--since` (default
+2026-04-01) that changed any `.c`/`.h` file:
+
+1. Check the commit out in a throwaway clone (`~/amy-loadsweep/tree`).
+2. Patch `src/i2s.c` in place to print `RENDER_LOAD ms=<ms> load=<0..1>` on
+   stderr at 2 Hz (`patch_render_load.py`). Pre-#826 trees get the
+   measurement backported from [amy#826](https://github.com/shorepine/amy/pull/826);
+   post-#826 trees just print AMY's own `amy_global.render_load` (same
+   smoothing, directly comparable) with the failsafe disabled.
+3. Build `LoadTestChord` against it with arduino-cli
+   (`esp32:esp32:amyboard`, isolated sketchbook — your real one is untouched).
+4. Flash over the debug-UART dongle, whose DTR/RTS lines drive the board's
+   auto-reset circuit — no BOOT/RST pressing, and a wedged board is recovered
+   automatically by the next flash (`measure.py`).
+5. Capture 20 s of the same UART while the sketch stacks up a held chord:
+   `reset`, `synth=1 num_voices=8 patch=1`, then one held note
+   (`40+2i`, vel 0.2) every 2 s — 8 load steps, full chord from t≈17s.
+6. Write `results/<idx>_<date>_<sha>/` with `load.csv`, `serial.log`,
+   `meta.json`.
+
+## Usage
+
+```sh
+cd tools/arduino_loadsweep
+
+# smoke-test one commit first
+python3 sweep.py --commit upstream-main
+
+# the full sweep (resumable: done/failed commits are skipped on rerun)
+python3 sweep.py
+
+# graph it
+python3 plot.py --results ~/amy-loadsweep/results
+```
+
+Needs: `arduino-cli` with the `esp32:esp32` core, `pyserial`, `matplotlib`,
+an AMYboard whose debug UART is on a DTR/RTS-wired dongle (default
+`/dev/cu.usbserial-A5069RR4`, override with `--port`).
+
+Other knobs: `--all-commits` (every non-merge commit touching `.c`/`.h`, not
+just main's spine), `--limit N`, `--retry-failed`, `--list` (print the commit
+list and exit), `--seconds`, `--work`.
+
+Two consecutive flash failures abort the sweep on the assumption the bench
+(not the code) is broken; rerunning resumes where it left off.
+
+## Sharing the bench
+
+`measure.py` serializes bench access so multiple harnesses (e.g. this sweep
+and tulipcc's amyboard_loadsweep) can share one board: it takes an exclusive
+flock on **`/tmp/amyboard-bench.lock`** for the whole flash+capture and also
+waits until `lsof` shows no other holder of the serial port. Any other tool
+that flashes this board should take the same flock. A power-on reset or
+ROM-bootloader entry appearing mid-capture is treated as external
+interference: the measurement is retried once, then recorded as failed
+(panic/watchdog reboots are NOT interference — they're the commit under test
+crashing, flagged `board_crashed` in meta.json).

--- a/tools/arduino_loadsweep/measure.py
+++ b/tools/arduino_loadsweep/measure.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Flash one LoadTestChord build to the AMYboard and record its render load.
+
+Flashes a compiled arduino-cli build over the debug-UART dongle by invoking
+the esp32 core's esptool directly — NOT `arduino-cli upload`, because the
+amyboard board definition uses 1200bps-touch + wait-for-upload-port, which
+makes arduino-cli hop to the board's native USB port instead of the dongle.
+The dongle's DTR/RTS lines drive the board's auto-reset circuit, so esptool
+enters the ROM bootloader by itself (no BOOT/RST pressing) and recovers a
+wedged board.  After flashing, pulses RTS to restart the board at a known
+t=0, then tails the same UART for the `RENDER_LOAD ms=<ms> load=<0..1>`
+lines that patch_render_load.py adds and the `NOTE i=<n> ...` markers the
+sketch prints.  Writes <out>/{load.csv,serial.log,meta.json}.
+
+A wedged/crashed board (prints stop early) is flagged in meta.json as
+serial_died_early; the next run's esptool handshake recovers it via DTR/RTS.
+Requires pyserial and an installed esp32:esp32 arduino core (for esptool).
+"""
+import argparse
+import csv
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+RL = re.compile(r"RENDER_LOAD ms=(\d+) load=([\d.]+)")
+NOTE = re.compile(r"NOTE i=(\d+) note=(\d+) ms=(\d+)")
+# A power-on reset or ROM-bootloader entry mid-capture means someone else
+# pulsed the board's reset lines (another harness sharing the bench) — the
+# trace is invalid.  A watchdog/panic reboot is NOT interference: that's the
+# commit under test crashing, which is a result (flagged board_crashed).
+RESET_SIG = re.compile(r"rst:0x1 |waiting for download")
+CRASH_SIG = re.compile(r"Guru Meditation|panic'ed|rst:0x[0-9a-f]+ \((?!POWERON)")
+ARDUINO15 = os.path.expanduser("~/Library/Arduino15")
+BENCH_LOCK = "/tmp/amyboard-bench.lock"
+
+
+def acquire_bench(port, timeout_s=900):
+    """Serialize bench access across processes/sessions.
+
+    Holds an flock on BENCH_LOCK for the rest of this process AND waits for
+    the serial port itself to be free (macOS cu.* devices are not exclusive,
+    so a lock alone doesn't protect against harnesses that don't take it).
+    """
+    import fcntl
+    fd = os.open(BENCH_LOCK, os.O_CREAT | os.O_RDWR, 0o666)
+    deadline = time.time() + timeout_s
+    waited = False
+    while True:
+        got_lock = False
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            got_lock = True
+        except OSError:
+            pass
+        holders = subprocess.run(
+            ["lsof", "-t", port, port.replace("/cu.", "/tty.")],
+            capture_output=True, text=True).stdout.strip()
+        if got_lock and not holders:
+            if waited:
+                print("[bench] free, proceeding")
+            return fd   # keep open: lock is held until process exit
+        if got_lock:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        if time.time() > deadline:
+            sys.exit(f"[bench] {port} still busy after {timeout_s}s "
+                     f"(lock={'ok' if got_lock else 'held'}, "
+                     f"holders={holders or 'none'})")
+        if not waited:
+            print(f"[bench] waiting for {port} "
+                  f"(lock={'ok' if got_lock else 'held elsewhere'}, "
+                  f"holder pids={holders or '?'})")
+            waited = True
+        time.sleep(5.0)
+
+
+def find_one(pattern, what):
+    cands = sorted(glob.glob(os.path.join(ARDUINO15, pattern)))
+    if not cands:
+        sys.exit(f"[flash] cannot find {what} under {ARDUINO15}")
+    return cands[-1]
+
+
+def upload(build_dir, port, baud):
+    esptool = find_one("packages/esp32/tools/esptool_py/*/esptool", "esptool")
+    boot_app0 = find_one("packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin",
+                         "boot_app0.bin")
+    app = glob.glob(os.path.join(build_dir, "*.ino.bin"))
+    if not app:
+        return f"no .ino.bin in {build_dir}"
+    base = app[0][:-len(".bin")]
+    cmd = [esptool, "--chip", "esp32s3", "--port", port, "--baud", str(baud),
+           "--before", "default-reset", "--after", "hard-reset",
+           "write-flash", "-z",
+           "--flash-mode", "keep", "--flash-freq", "keep", "--flash-size", "keep",
+           "0x0", base + ".bootloader.bin",
+           "0x8000", base + ".partitions.bin",
+           "0xe000", boot_app0,
+           "0x10000", base + ".bin"]
+    for attempt in (1, 2):
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=240)
+        if r.returncode == 0:
+            print(f"[flash] ok (attempt {attempt})")
+            return None
+        print(f"[flash] attempt {attempt} failed rc={r.returncode}")
+        time.sleep(2.0)
+    return (r.stdout or "")[-1500:] + (r.stderr or "")[-1500:]
+
+
+def run_reset_pulse(ser):
+    """Reset into normal run mode via the dongle (DTR deasserted, RTS pulse)."""
+    ser.dtr = False
+    ser.rts = True
+    time.sleep(0.15)
+    ser.rts = False
+
+
+def capture(port, baud, seconds):
+    import serial
+    ser = serial.Serial()
+    ser.port = port
+    ser.baudrate = baud
+    ser.timeout = 0.2
+    ser.dtr = False
+    ser.rts = False
+    ser.open()
+    ser.reset_input_buffer()
+    run_reset_pulse(ser)
+    t0 = time.time()
+    lines, buf = [], b""
+    while time.time() - t0 < seconds:
+        data = ser.read(4096)
+        if data:
+            buf += data
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                lines.append((time.time() - t0,
+                              line.decode("utf-8", "replace").rstrip("\r")))
+    ser.close()
+    return lines
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("build_dir", help="arduino-cli --build-path output dir")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--port", default="/dev/cu.usbserial-A5069RR4",
+                    help="debug-UART dongle (flash + stderr console)")
+    ap.add_argument("--flash-baud", type=int, default=921600)
+    ap.add_argument("--baud", type=int, default=115200, help="console baud")
+    ap.add_argument("--seconds", type=float, default=20.0)
+    ap.add_argument("--label", default=None)
+    ap.add_argument("--meta", default=None,
+                    help="JSON string of extra fields for meta.json")
+    args = ap.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    meta = {"label": args.label or os.path.basename(args.out.rstrip("/")),
+            "seconds": args.seconds, "errors": []}
+    if args.meta:
+        meta.update(json.loads(args.meta))
+
+    acquire_bench(args.port)
+
+    lines = None
+    for attempt in (1, 2):
+        err = upload(args.build_dir, args.port, args.flash_baud)
+        if err:
+            meta["errors"].append("upload failed")
+            meta["upload_tail"] = err
+            json.dump(meta, open(os.path.join(args.out, "meta.json"), "w"),
+                      indent=1)
+            sys.exit("[flash] upload failed twice")
+
+        time.sleep(1.0)   # let esptool's post-flash reset settle before re-open
+        print(f"[capture] {args.seconds:.0f}s on {args.port}")
+        lines = capture(args.port, args.baud, args.seconds)
+        if not any(RESET_SIG.search(l) and ts > 2.0 for ts, l in lines):
+            break
+        print("[capture] board was reset mid-capture (external interference?)"
+              f" — {'retrying' if attempt == 1 else 'giving up'}")
+        meta["errors"].append(f"interference on attempt {attempt}")
+    else:
+        with open(os.path.join(args.out, "serial.log"), "w") as f:
+            for ts, line in lines:
+                f.write(f"{ts:8.3f} {line}\n")
+        json.dump(meta, open(os.path.join(args.out, "meta.json"), "w"), indent=1)
+        sys.exit("[capture] interference on both attempts")
+
+    with open(os.path.join(args.out, "serial.log"), "w") as f:
+        for ts, line in lines:
+            f.write(f"{ts:8.3f} {line}\n")
+
+    rows, notes = [], []
+    for ts, line in lines:
+        m = RL.search(line)
+        if m:
+            rows.append((round(ts, 3), int(m.group(1)), float(m.group(2))))
+        m = NOTE.search(line)
+        if m:
+            notes.append({"t_s": round(ts, 3), "i": int(m.group(1)),
+                          "note": int(m.group(2)), "board_ms": int(m.group(3))})
+
+    with open(os.path.join(args.out, "load.csv"), "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["t_s", "board_ms", "load"])
+        w.writerows(rows)
+
+    meta["n_samples"] = len(rows)
+    meta["notes"] = notes
+    if any(CRASH_SIG.search(l) and ts > 2.0 for ts, l in lines):
+        meta["board_crashed"] = True
+        print("[result] board CRASHED during run (panic/watchdog reboot)")
+    if rows:
+        meta["load_max"] = max(r[2] for r in rows)
+        meta["last_sample_t"] = rows[-1][0]
+        final = [r[2] for r in rows if r[0] >= args.seconds - 3.0]
+        meta["load_final"] = round(sum(final) / len(final), 4) if final else None
+        if rows[-1][0] < args.seconds - 3.0:
+            meta["serial_died_early"] = True   # prints stopped: crash/wedge
+    else:
+        meta["errors"].append("no RENDER_LOAD lines captured")
+    print(f"[result] {len(rows)} samples, {len(notes)} notes, "
+          f"max={meta.get('load_max')}, final={meta.get('load_final')}"
+          f"{'  DIED EARLY' if meta.get('serial_died_early') else ''}")
+
+    json.dump(meta, open(os.path.join(args.out, "meta.json"), "w"), indent=1)
+    return 0 if rows else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/arduino_loadsweep/measure.py
+++ b/tools/arduino_loadsweep/measure.py
@@ -90,7 +90,7 @@ def upload(build_dir, port, baud):
                          "boot_app0.bin")
     app = glob.glob(os.path.join(build_dir, "*.ino.bin"))
     if not app:
-        return f"no .ino.bin in {build_dir}"
+        return f"no .ino.bin in {build_dir} - did you arduino-cli compile?"
     base = app[0][:-len(".bin")]
     cmd = [esptool, "--chip", "esp32s3", "--port", port, "--baud", str(baud),
            "--before", "default-reset", "--after", "hard-reset",
@@ -173,6 +173,7 @@ def main():
             meta["upload_tail"] = err
             json.dump(meta, open(os.path.join(args.out, "meta.json"), "w"),
                       indent=1)
+            print(err)
             sys.exit("[flash] upload failed twice")
 
         time.sleep(1.0)   # let esptool's post-flash reset settle before re-open

--- a/tools/arduino_loadsweep/patch_render_load.py
+++ b/tools/arduino_loadsweep/patch_render_load.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Inject a 2 Hz render-load stderr print into src/i2s.c.
+
+Ported from tulipcc's tools/amyboard_loadsweep (shorepine/tulipcc#1108).
+Two variants, chosen automatically:
+
+* Pre-#826 trees (no amy_overload_check in i2s.c): backport just the
+  render-load measurement from shorepine/amy#826 as a textual patch to
+  esp_fill_audio_buffer_task — time the render work (busy) vs the i2s DMA
+  write / update-sync wait (blocked), keep a 0.05-per-block smoothed
+  load = busy/(busy+blocked), and fprintf it to stderr twice per second:
+
+      RENDER_LOAD ms=<board_ms> load=<0..1>
+
+  The anchors were verified stable from 2026-03-30 (v1.2.4) through the
+  #826 merge — i2s.c's task body changed only once in that window and not
+  in this function.
+
+* Post-#826 trees (amy_overload_check present): AMY already keeps the same
+  0.05-smoothed load in amy_global.render_load, so just print that at 2 Hz
+  and pin config.overload_threshold to 0 so the failsafe can't reset the
+  synth mid-measurement.  Numbers are directly comparable to the backport
+  (same smoothing, same busy/period definition).
+
+Idempotent; fails loudly (exit != 0) if no anchor matches.
+
+Usage: patch_render_load.py <path-to-amy>/src/i2s.c
+"""
+import re
+import sys
+
+MARK = "/* rl-patch */"
+PRINT_US = 500000  # 2 Hz
+
+DECLS = """
+%s
+#include "esp_timer.h"
+#include <stdio.h>
+static float _rl_load = 0.0f;
+static int64_t _rl_last_print = 0;
+""" % MARK
+
+POST826 = """
+        %s
+        { int64_t _rl_now = esp_timer_get_time();
+          if (_rl_now - _rl_last_print > %d) {
+              _rl_last_print = _rl_now;
+              amy_global.config.overload_threshold = 0;  /* no failsafe during measurement */
+              fprintf(stderr, "RENDER_LOAD ms=%%lu load=%%.4f\\n",
+                      (unsigned long)(_rl_now/1000), amy_global.render_load);
+              fflush(stderr);
+          } }
+"""
+
+
+def patch_post826(src):
+    """Tree already measures load (amy#826): print amy_global.render_load."""
+    anchor = re.search(
+        r"(?m)^( *)amy_overload_check\(busy_us, busy_us \+ blocked_us\);", src)
+    if not anchor:
+        sys.exit("[patch] FAILED: post-826 tree but no "
+                 "'amy_overload_check(busy_us, busy_us + blocked_us);' anchor")
+    decls = ('\n%s\n#include "esp_timer.h"\n#include <stdio.h>\n'
+             "static int64_t _rl_last_print = 0;\n" % MARK)
+    src, n = re.subn(r"(?m)^(// Make AMY's FABT run forever.*\n)?"
+                     r"^void esp_fill_audio_buffer_task\(\) \{",
+                     decls + "void esp_fill_audio_buffer_task() {", src, count=1)
+    if n != 1:
+        sys.exit("[patch] FAILED: post-826: function head anchor not found")
+    inject = POST826 % (anchor.group(0).strip(), PRINT_US)
+    src = src.replace(anchor.group(0), inject.rstrip(), 1)
+    return src, ["post-826 render_load print"]
+
+
+def patch_pre826(src):
+    """Backport the measurement (identical to tulipcc#1108's patch)."""
+    subs = []
+
+    def sub(pattern, repl, label):
+        nonlocal src
+
+        def expand(m):
+            return re.sub(r"\\(\d)", lambda g: m.group(int(g.group(1))) or "", repl)
+
+        new, n = re.subn(pattern, expand, src, count=1)
+        if n != 1:
+            sys.exit(f"[patch] FAILED: anchor not found: {label}")
+        src = new
+        subs.append(label)
+
+    # 0) statics + includes before the task function
+    sub(r"(?m)^(// Make AMY's FABT run forever.*\n)?^void esp_fill_audio_buffer_task\(\) \{",
+        DECLS + "void esp_fill_audio_buffer_task() {",
+        "function head")
+
+    # 1) locals at top of the while loop + busy timer start after the
+    #    (blocked-time-tracked) audio-in read
+    sub(r"(void esp_fill_audio_buffer_task\(\) \{\n    while\(1\) \{\n)",
+        "\\1        int64_t _rl_t; uint32_t _rl_busy = 0, _rl_blocked = 0;\n",
+        "loop head")
+
+    sub(r"( *)if\(AMY_HAS_I2S && AMY_HAS_AUDIO_IN\) \{\n( *)esp_read_i2s_input\(\);\n(\s*)\}",
+        "\\1if(AMY_HAS_I2S && AMY_HAS_AUDIO_IN) {\n"
+        "\\2_rl_t = esp_timer_get_time();\n"
+        "\\2esp_read_i2s_input();\n"
+        "\\2_rl_blocked += (uint32_t)(esp_timer_get_time() - _rl_t);\n"
+        "\\3}\n"
+        "        _rl_t = esp_timer_get_time();",
+        "audio-in block")
+
+    # 2) busy time ends after amy_fill_buffer
+    sub(r"( *)(output_sample_type \*block = amy_fill_buffer\(\);)",
+        "\\1\\2\n\\1_rl_busy = (uint32_t)(esp_timer_get_time() - _rl_t);",
+        "fill buffer")
+
+    # 3) blocked time around the i2s write / sync wait, then smooth + 2 Hz print
+    sub(r"( *)(if \(AMY_HAS_I2S\) \{\n"
+        r" *amy_i2s_write\(\(uint8_t \*\)block, AMY_BLOCK_SIZE \* AMY_NCHANS \* sizeof\(int16_t\)\);\n"
+        r" *\} else \{\n"
+        r" *// Wait for update sync\.\n"
+        r" *ulTaskNotifyTake\(pdTRUE, portMAX_DELAY\);.*\n"
+        r" *\})\n",
+        "\\1_rl_t = esp_timer_get_time();\n"
+        "\\1\\2\n"
+        "\\1_rl_blocked += (uint32_t)(esp_timer_get_time() - _rl_t);\n"
+        "\\1if (_rl_busy + _rl_blocked > 0)\n"
+        "\\1    _rl_load += 0.05f * ((float)_rl_busy / (float)(_rl_busy + _rl_blocked) - _rl_load);\n"
+        "\\1{ int64_t _rl_now = esp_timer_get_time();\n"
+        "\\1  if (_rl_now - _rl_last_print > %d) {\n"
+        "\\1      _rl_last_print = _rl_now;\n"
+        "\\1      fprintf(stderr, \"RENDER_LOAD ms=%%lu load=%%.4f\\n\", (unsigned long)(_rl_now/1000), _rl_load);\n"
+        "\\1      fflush(stderr);\n"
+        "\\1  } }\n" % PRINT_US,
+        "i2s write block")
+
+    return src, subs
+
+
+def main(path):
+    src = open(path).read()
+    if MARK in src:
+        print(f"[patch] {path} already patched")
+        return 0
+    if "amy_overload_check(busy_us" in src:
+        src, subs = patch_post826(src)
+    else:
+        src, subs = patch_pre826(src)
+    open(path, "w").write(src)
+    print(f"[patch] OK: {', '.join(subs)} -> {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))

--- a/tools/arduino_loadsweep/plot.py
+++ b/tools/arduino_loadsweep/plot.py
@@ -54,8 +54,11 @@ def main():
     tmax = max((r[0] for c in commits for r in c["rows"]), default=20) + 1
     colors = cm.viridis(np.linspace(0.05, 0.95, n))
 
-    fig = plt.figure(figsize=(15, 18))
-    gs = fig.add_gridspec(3, 1, height_ratios=[1.1, 1.8, 0.9], hspace=0.35)
+    # size the small-multiples band by row count so titles never collide
+    sm_rows = int(np.ceil(n / 6))
+    fig = plt.figure(figsize=(15, 10 + 2.2 * sm_rows))
+    gs = fig.add_gridspec(3, 1, height_ratios=[4.5, 2.0 * sm_rows, 3.5],
+                          hspace=0.30)
 
     # overlay
     ax = fig.add_subplot(gs[0])
@@ -78,8 +81,8 @@ def main():
 
     # small multiples
     cols = 6
-    rows_n = int(np.ceil(n / cols))
-    sub = gs[1].subgridspec(rows_n, cols, hspace=0.6, wspace=0.25)
+    rows_n = sm_rows
+    sub = gs[1].subgridspec(rows_n, cols, hspace=1.0, wspace=0.25)
     for i, (c, col) in enumerate(zip(commits, colors)):
         axs = fig.add_subplot(sub[i // cols, i % cols])
         t = [r[0] for r in c["rows"]]

--- a/tools/arduino_loadsweep/plot.py
+++ b/tools/arduino_loadsweep/plot.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Graph a per-commit render-load sweep produced by sweep.py.
+
+Three views: all commits overlaid, per-commit small multiples, and a
+final-chord mean/max bar chart in commit order (the discontinuity view)
+with AMY version bumps marked.  Commits whose serial output died early
+(crash/wedge) are flagged.
+"""
+import argparse
+import csv
+import glob
+import json
+import os
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt          # noqa: E402
+import matplotlib.cm as cm               # noqa: E402
+import numpy as np                       # noqa: E402
+
+
+def load_commits(results):
+    commits = []
+    for d in sorted(glob.glob(os.path.join(results, "*/"))):
+        csvp = os.path.join(d, "load.csv")
+        if not os.path.exists(csvp):
+            continue
+        rows = [(float(r["t_s"]), float(r["load"]))
+                for r in csv.DictReader(open(csvp))]
+        meta = {}
+        mp = os.path.join(d, "meta.json")
+        if os.path.exists(mp):
+            meta = json.load(open(mp))
+        commits.append({"label": os.path.basename(d.rstrip("/")),
+                        "rows": rows, "meta": meta})
+    return commits
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--results",
+                    default=os.path.expanduser("~/amy-loadsweep/results"))
+    ap.add_argument("--out", default=None,
+                    help="output PNG (default <results>/render_load_sweep.png)")
+    ap.add_argument("--title",
+                    default="AMYboard render load per AMY commit (8-note held chord)")
+    args = ap.parse_args()
+    out = args.out or os.path.join(args.results, "render_load_sweep.png")
+
+    commits = load_commits(args.results)
+    if not commits:
+        raise SystemExit(f"no load.csv files under {args.results}")
+    n = len(commits)
+    tmax = max((r[0] for c in commits for r in c["rows"]), default=20) + 1
+    colors = cm.viridis(np.linspace(0.05, 0.95, n))
+
+    fig = plt.figure(figsize=(15, 18))
+    gs = fig.add_gridspec(3, 1, height_ratios=[1.1, 1.8, 0.9], hspace=0.35)
+
+    # overlay
+    ax = fig.add_subplot(gs[0])
+    for c, col in zip(commits, colors):
+        t = [r[0] for r in c["rows"]]
+        v = [r[1] for r in c["rows"]]
+        ax.plot(t, v, color=col, lw=1.2, alpha=0.8)
+    ax.axhline(0.98, color="red", ls=":", lw=1, alpha=0.6)
+    for i in range(8):
+        ax.axvline(2 + 2 * i + 1.0, color="gray", lw=0.5, alpha=0.3)
+    ax.text(0.2, 0.985, "overload threshold", color="red", fontsize=8,
+            va="bottom")
+    ax.set_xlim(0, tmax)
+    ax.set_ylim(0, 1.05)
+    ax.set_xlabel("seconds since boot (note added every 2s from t≈3s)")
+    ax.set_ylabel("AMY render load (0..1)")
+    ax.set_title(args.title + f"  —  {commits[0]['label'][4:]} … "
+                 f"{commits[-1]['label'][4:]} (color = commit order)")
+    ax.grid(alpha=0.25)
+
+    # small multiples
+    cols = 6
+    rows_n = int(np.ceil(n / cols))
+    sub = gs[1].subgridspec(rows_n, cols, hspace=0.6, wspace=0.25)
+    for i, (c, col) in enumerate(zip(commits, colors)):
+        axs = fig.add_subplot(sub[i // cols, i % cols])
+        t = [r[0] for r in c["rows"]]
+        v = [r[1] for r in c["rows"]]
+        axs.plot(t, v, color=col, lw=1.2)
+        axs.fill_between(t, v, color=col, alpha=0.25)
+        axs.set_xlim(0, tmax)
+        axs.set_ylim(0, 1.05)
+        axs.axhline(0.98, color="red", ls=":", lw=0.7, alpha=0.6)
+        died = " ⚠died" if c["meta"].get("serial_died_early") else ""
+        axs.set_title(c["label"][4:] + died, fontsize=6.5)
+        axs.tick_params(labelsize=6)
+        if i % cols:
+            axs.set_yticklabels([])
+
+    # final-chord summary in commit order
+    axb = fig.add_subplot(gs[2])
+    labels, means, maxes, died = [], [], [], []
+    for c in commits:
+        ss = [v for t, v in c["rows"] if t >= 16.5]   # all 8 notes sounding
+        labels.append(c["label"][4:])
+        means.append(np.mean(ss) if ss else 0)
+        maxes.append(max((v for t, v in c["rows"]), default=0))
+        died.append(c["meta"].get("serial_died_early", False))
+    x = np.arange(n)
+    axb.bar(x - 0.2, means, 0.4, color=list(colors),
+            label="mean load, full chord (t≥16.5s)")
+    axb.bar(x + 0.2, maxes, 0.4, color=list(colors), alpha=0.45,
+            label="max load")
+    for i, w in enumerate(died):
+        if w:
+            axb.text(i, (maxes[i] or 0.05) + 0.02, "died", ha="center",
+                     fontsize=6.5, color="red", rotation=90)
+    axb.axhline(0.98, color="red", ls=":", lw=1, alpha=0.6)
+    axb.set_xticks(x)
+    axb.set_xticklabels(labels, rotation=90, fontsize=5.5)
+    axb.set_ylim(0, 1.1)
+    axb.set_ylabel("render load")
+    axb.set_title("full-chord render load per commit (discontinuity view)")
+    axb.legend(fontsize=8)
+    axb.grid(axis="y", alpha=0.25)
+
+    prev = None
+    for i, c in enumerate(commits):
+        ver = c["meta"].get("version", "")
+        if prev is not None and ver != prev:
+            axb.axvline(i - 0.5, color="k", ls="--", lw=0.7, alpha=0.5)
+            axb.text(i - 0.45, 1.03, ver, fontsize=6, rotation=45)
+        prev = ver
+
+    fig.savefig(out, dpi=130, bbox_inches="tight")
+    print("wrote", out)
+    for c, m, mx in zip(commits, means, maxes):
+        print(f"{c['label']}  mean={m:.3f}  max={mx:.3f}"
+              f"{'  DIED' if c['meta'].get('serial_died_early') else ''}"
+              f"  {c['meta'].get('subject', '')[:60]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/arduino_loadsweep/sweep.py
+++ b/tools/arduino_loadsweep/sweep.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Per-commit AMY render-load regression sweep on real AMYboard hardware.
+
+The arduino-cli sibling of tulipcc's tools/amyboard_loadsweep (#1108): for
+every state of AMY `main` since a start date that changed .c/.h code, build
+the LoadTestChord sketch against that AMY (patched to print its render load
+— see patch_render_load.py), flash a connected AMYboard over the DTR/RTS
+flash dongle, capture 20s of load prints while the sketch stacks up an
+8-note held chord, and record the trace.  plot.py then graphs the traces to
+spot the commit a regression landed.
+
+    python3 sweep.py --commit origin/main   # single-commit smoke test
+    python3 sweep.py                        # the full sweep since --since
+    python3 plot.py --results ~/amy-loadsweep/results
+
+Commits are enumerated --first-parent on origin/main (each is a state main
+was actually in, in time order); --all-commits instead walks every non-merge
+commit touching .c/.h (includes intra-PR commits, unordered, some may not
+build).  Resumable: a commit whose results/<label>/load.csv exists is
+skipped, as are recorded failures (rerun those with --retry-failed).  Two
+consecutive flash failures abort the sweep (bench trouble, not code
+trouble).
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", ".."))
+SKETCH = "LoadTestChord"
+
+
+def git(repo, *a, check=True):
+    r = subprocess.run(["git", "-C", repo] + list(a), text=True,
+                       capture_output=True)
+    if check and r.returncode != 0:
+        raise RuntimeError(f"git {' '.join(a)}: {r.stderr.strip()[:500]}")
+    return (r.stdout or "").strip()
+
+
+def enumerate_commits(tree, args):
+    ref = "upstream-main"
+    walk = ["--first-parent"] if not args.all_commits else ["--no-merges"]
+    out = git(tree, "rev-list", "--reverse", *walk,
+              f"--since={args.since}", ref, "--", "*.c", "*.h")
+    shas = out.split() if out else []
+    commits = []
+    for i, sha in enumerate(shas):
+        date, subject = git(tree, "log", "-1", "--format=%cs%x00%s",
+                            sha).split("\0")
+        commits.append({"idx": i, "sha": sha, "date": date, "subject": subject,
+                        "label": f"{i:03d}_{date}_{sha[:7]}"})
+    return commits
+
+
+def init_workspace(work):
+    tree = os.path.join(work, "tree")
+    if not os.path.exists(os.path.join(tree, ".git")):
+        print(f"[ws] cloning {REPO} -> {tree}")
+        subprocess.run(["git", "clone", "-q", REPO, tree], check=True)
+    git(tree, "fetch", "-q", REPO,
+        "+refs/remotes/origin/main:refs/heads/upstream-main")
+    sb = os.path.join(work, "sketchbook")
+    os.makedirs(os.path.join(sb, "libraries"), exist_ok=True)
+    link = os.path.join(sb, "libraries", "AMY")
+    if os.path.islink(link):
+        os.unlink(link)
+    os.symlink(tree, link)
+    return tree, sb
+
+
+def build_commit(tree, sb, c, args):
+    """Checkout + patch + compile.  Returns (build_dir, sketch_dir) or None."""
+    git(tree, "checkout", "-q", "-f", c["sha"])
+    git(tree, "clean", "-fdq")
+    if not args.no_patch:
+        r = subprocess.run([sys.executable,
+                            os.path.join(HERE, "patch_render_load.py"),
+                            os.path.join(tree, "src", "i2s.c")],
+                           text=True, capture_output=True)
+        print(r.stdout.strip() or r.stderr.strip())
+        if r.returncode != 0:
+            return None, "patch"
+    # fresh copy of the sketch into the isolated sketchbook
+    sketch_dir = os.path.join(sb, SKETCH)
+    shutil.rmtree(sketch_dir, ignore_errors=True)
+    shutil.copytree(os.path.join(HERE, SKETCH), sketch_dir)
+
+    build_dir = os.path.join(args.work, "build", "current")
+    shutil.rmtree(build_dir, ignore_errors=True)
+    env = dict(os.environ, ARDUINO_DIRECTORIES_USER=sb)
+    # Force -O2 everywhere (core default is -Os): commits in the window differ
+    # in whether AMY carries its own optimize pragma, and comparing -Os builds
+    # to pragma-O2 builds would fake a load discontinuity.
+    r = subprocess.run(["arduino-cli", "compile", "--fqbn", args.fqbn,
+                        "--build-property",
+                        f"compiler.optimization_flags={args.opt}",
+                        "--build-path", build_dir, sketch_dir],
+                       text=True, capture_output=True, env=env, timeout=1800)
+    if r.returncode != 0:
+        return None, "build:" + (r.stdout + r.stderr)[-2000:]
+    return (build_dir, sketch_dir), None
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--since", default="2026-04-01")
+    ap.add_argument("--all-commits", action="store_true",
+                    help="every non-merge commit, not just main's spine")
+    ap.add_argument("--commit", default=None,
+                    help="test one ref only (smoke test)")
+    ap.add_argument("--limit", type=int, default=None)
+    ap.add_argument("--work", default=os.path.expanduser("~/amy-loadsweep"))
+    ap.add_argument("--results", default=None)
+    ap.add_argument("--fqbn", default="esp32:esp32:amyboard")
+    ap.add_argument("--opt", default="-O2",
+                    help="optimization flag forced on the whole build")
+    ap.add_argument("--port", default="/dev/cu.usbserial-A5069RR4")
+    ap.add_argument("--seconds", type=float, default=20.0)
+    ap.add_argument("--no-patch", action="store_true")
+    ap.add_argument("--retry-failed", action="store_true")
+    ap.add_argument("--list", action="store_true",
+                    help="just print the commit list and exit")
+    args = ap.parse_args()
+    results = args.results or os.path.join(args.work, "results")
+
+    os.makedirs(args.work, exist_ok=True)
+    tree, sb = init_workspace(args.work)
+
+    if args.commit:
+        sha = git(tree, "rev-parse", args.commit)
+        date, subject = git(tree, "log", "-1", "--format=%cs%x00%s",
+                            sha).split("\0")
+        commits = [{"idx": 999, "sha": sha, "date": date, "subject": subject,
+                    "label": f"smoke_{date}_{sha[:7]}"}]
+    else:
+        commits = enumerate_commits(tree, args)
+        if args.limit:
+            commits = commits[:args.limit]
+    print(f"[sweep] {len(commits)} commits to test")
+    if args.list:
+        for c in commits:
+            print(f"  {c['label']}  {c['subject'][:70]}")
+        return 0
+
+    flash_fails = 0
+    for c in commits:
+        outdir = os.path.join(results, c["label"])
+        failed_marker = os.path.join(outdir, "FAILED")
+        if os.path.exists(os.path.join(outdir, "load.csv")):
+            print(f"== {c['label']}: done, skipping")
+            continue
+        if os.path.exists(failed_marker) and not args.retry_failed:
+            print(f"== {c['label']}: previously failed, skipping")
+            continue
+        print(f"== {c['label']}: {c['subject'][:70]}")
+        os.makedirs(outdir, exist_ok=True)
+        if os.path.exists(failed_marker):
+            os.unlink(failed_marker)
+
+        built, err = build_commit(tree, sb, c, args)
+        version = git(tree, "show", "HEAD:library.properties",
+                      check=False).split("version=")[-1].split("\n")[0]
+        if not built:
+            kind = err.split(":", 1)[0]
+            print(f"== {c['label']}: {kind.upper()} FAILED")
+            with open(failed_marker, "w") as f:
+                f.write(err)
+            continue
+        build_dir, sketch_dir = built
+
+        meta = {"sha": c["sha"], "date": c["date"], "subject": c["subject"],
+                "version": version, "idx": c["idx"], "opt": args.opt}
+        r = subprocess.run([sys.executable, os.path.join(HERE, "measure.py"),
+                            build_dir, "--out", outdir, "--port", args.port,
+                            "--seconds", str(args.seconds),
+                            "--label", c["label"],
+                            "--meta", json.dumps(meta)])
+        if r.returncode != 0 and not os.path.exists(
+                os.path.join(outdir, "load.csv")):
+            flash_fails += 1
+            with open(failed_marker, "w") as f:
+                f.write("measure failed\n")
+            if flash_fails >= 2:
+                sys.exit("[sweep] two consecutive flash/measure failures — "
+                         "check the bench, then rerun (resumes automatically)")
+        else:
+            flash_fails = 0
+    print("[sweep] done")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
New tool for answering "which AMY commit made render load regress?" — the arduino-cli sibling of shorepine/tulipcc#1108: build a fixed test sketch against every state of `main` since a start date that changed `.c`/`.h` code, run it on a real AMYboard, and graph the measured render load per commit.

**How**

- `LoadTestChord` sketch: `reset`, `synth=1 num_voices=8 patch=1`, then one held note (`40+2i`, vel 0.2) every 2 s — 8 load steps, full chord from t≈16 s, with `NOTE` markers on stderr.
- `patch_render_load.py` injects a 2 Hz `RENDER_LOAD ms=… load=…` stderr print into `src/i2s.c`: pre-#826 trees get the measurement from #826 backported as a textual patch (anchors verified stable from v1.2.4 through the #826 merge); post-#826 trees print AMY's own `amy_global.render_load` (same smoothing, directly comparable) with the failsafe pinned off.
- `sweep.py` walks `--first-parent` states of `origin/main` (54 commits since 2026-04-01), builds each in a throwaway clone with **-O2 forced on the whole build** (the core default is -Os and amy.h's own O2 pragma only landed 2026-06-29, mid-window — comparing -Os builds to pragma-O2 builds would fake a discontinuity). Resumable: done/failed commits are skipped on rerun.
- `measure.py` flashes over a DTR/RTS-wired debug-UART dongle by invoking the esp32 core's esptool directly (`arduino-cli upload` can't be used: amyboard's 1200bps-touch + wait-for-upload-port makes it hop to the board's native USB port). Bench access is serialized via an flock on `/tmp/amyboard-bench.lock` + an lsof wait so other harnesses (e.g. tulipcc's amyboard_loadsweep) can share the board; a power-on reset mid-capture is detected as external interference and retried, while panic/watchdog reboots are recorded as `board_crashed` (that's the commit under test crashing — a result).
- `plot.py`: overlay, per-commit small multiples, and a full-chord mean/max bar chart in commit order with version bumps marked.

First results from the in-progress sweep: the 2026-04-01 tree (v1.2.4) holds the full 8-note chord at ~0.84, while current main pins at ~0.99 by ~6 notes — the regression this tool is built to localize is real. Full per-commit graph to follow.

Tools-only change — consider putting `[skip release]` in the merge commit message to avoid cutting a pointless release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)