### PR TITLE
AMY HW CI: before/after render load — measure a merge-base baseline per PR

### DIFF
--- a/.github/workflows/amy-hwci-build.yml
+++ b/.github/workflows/amy-hwci-build.yml
@@ -8,6 +8,11 @@ name: AMY HW CI build
 # chains off this run via workflow_run and flashes it on the self-hosted
 # AMYboard bench Pi.
 #
+# PR builds also produce a BASELINE firmware — the same sketch built against
+# the merge ref's first parent (the current main tip the PR firmware was
+# merged with) — under fw/base/. The bench measures both back-to-back so the
+# PR comment shows before/after load and the delta the PR itself causes.
+#
 # The build runs here (ubuntu-latest, cached esp32 core) and NOT on the Pi so
 # the bench stays a dumb flash-and-listen box: even for a fork PR this job is
 # safe (sandboxed, no secrets), and the bench workflow's same-repo gate
@@ -38,9 +43,26 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2          # the merge commit AND its parents (baseline tree)
 
-      - name: Patch the 2 Hz render-load print into src/i2s.c
-        run: python3 tools/arduino_loadsweep/patch_render_load.py src/i2s.c
+      - name: Stage the baseline tree (the merge ref's first parent)
+        id: base
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          BASE_SHA=$(git rev-parse HEAD^1)
+          git worktree add ../base "$BASE_SHA"
+          echo "sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "baseline: $BASE_SHA"
+
+      - name: Patch the 2 Hz render-load print into src/i2s.c (both trees)
+        run: |
+          set -euo pipefail
+          python3 tools/arduino_loadsweep/patch_render_load.py src/i2s.c
+          if [ -d ../base ]; then
+            python3 tools/arduino_loadsweep/patch_render_load.py ../base/src/i2s.c
+          fi
 
       - uses: arduino/setup-arduino-cli@v2
 
@@ -56,28 +78,43 @@ jobs:
           arduino-cli core update-index
           arduino-cli core install esp32:esp32@${{ env.ESP32_CORE }}
 
-      - name: Build LoadTestChord against this PR's AMY
+      - name: Build LoadTestChord against this PR's AMY (and the baseline)
         # -O2 forced for the same reason as sweep.py: comparable numbers no
-        # matter what optimize pragma the tree carries.
+        # matter what optimize pragma the tree carries. Both builds use the
+        # PR's copy of the sketch (the test fixture) — only the AMY library
+        # differs.
         run: |
+          set -euo pipefail
           arduino-cli compile --fqbn esp32:esp32:amyboard \
             --library "$PWD" \
             --build-property compiler.optimization_flags=-O2 \
             --build-path "$PWD/build" \
             tools/arduino_loadsweep/LoadTestChord
+          if [ -d ../base ]; then
+            arduino-cli compile --fqbn esp32:esp32:amyboard \
+              --library "$(cd ../base && pwd)" \
+              --build-property compiler.optimization_flags=-O2 \
+              --build-path "$PWD/build-base" \
+              tools/arduino_loadsweep/LoadTestChord
+          fi
 
       - name: Assemble the firmware artifact
         # Everything measure.py needs to flash, self-contained: the three
         # sketch bins plus the core's boot_app0.bin (the bench has esptool but
         # no arduino core), and ctx.json telling the bench which PR to comment
-        # on.
+        # on. PR bins live at fw/ top level, the merge-base build under
+        # fw/base/ — each dir is a complete measure.py build_dir.
         run: |
           set -euo pipefail
           mkdir fw
-          cp build/*.ino.bin build/*.ino.bootloader.bin build/*.ino.partitions.bin fw/
-          cp "$(ls ~/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin | tail -1)" fw/
-          echo '{"pr": ${{ github.event.pull_request.number || 0 }}, "sha": "${{ github.event.pull_request.head.sha || github.sha }}"}' > fw/ctx.json
-          ls -l fw
+          BOOT_APP0="$(ls ~/.arduino15/packages/esp32/hardware/esp32/*/tools/partitions/boot_app0.bin | tail -1)"
+          cp build/*.ino.bin build/*.ino.bootloader.bin build/*.ino.partitions.bin "$BOOT_APP0" fw/
+          if [ -d build-base ]; then
+            mkdir fw/base
+            cp build-base/*.ino.bin build-base/*.ino.bootloader.bin build-base/*.ino.partitions.bin "$BOOT_APP0" fw/base/
+          fi
+          echo '{"pr": ${{ github.event.pull_request.number || 0 }}, "sha": "${{ github.event.pull_request.head.sha || github.sha }}", "base_sha": "${{ steps.base.outputs.sha }}"}' > fw/ctx.json
+          ls -lR fw
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/amy-hwci.yml
+++ b/.github/workflows/amy-hwci.yml
@@ -104,7 +104,25 @@ jobs:
           fi
           echo "PR=$PR" >> "$GITHUB_ENV"
 
-      - name: Flash + capture 20 s of render load
+      - name: Flash + capture the merge-base baseline (before)
+        # A failed baseline never fails CI — the report just loses its
+        # before/Δ columns. `|| true` rather than continue-on-error so the
+        # step shows green unless the runner itself breaks.
+        if: hashFiles('fw/base/*.ino.bin') != ''
+        run: |
+          set -o pipefail
+          mkdir -p out-base
+          BASE_SHA=$(python3 -c 'import json; print(json.load(open("fw/ctx.json")).get("base_sha", ""))')
+          ~/hwci-venv/bin/python tools/arduino_loadsweep/measure.py fw/base \
+            --out out-base \
+            --port /dev/amyboard-dongle \
+            --esptool ~/hwci-venv/bin/esptool \
+            --seconds 20 \
+            --label "pr${PR}-base" \
+            --meta "{\"pr\": ${PR}, \"sha\": \"${BASE_SHA}\"}" \
+            2>&1 | tee out-base/run.log || true
+
+      - name: Flash + capture 20 s of render load (this PR)
         id: measure
         continue-on-error: true   # the verdict is hwci_report.py's, below
         env:
@@ -126,7 +144,9 @@ jobs:
         continue-on-error: true   # gate at the end, after commenting
         run: |
           mkdir -p out
-          python3 tools/arduino_loadsweep/hwci_report.py out | tee report.md
+          BASE_ARG=""
+          [ -d fw/base ] && BASE_ARG="--base out-base"
+          python3 tools/arduino_loadsweep/hwci_report.py out $BASE_ARG | tee report.md
 
       - name: Upload artifacts (serial log, load trace, report)
         if: always()
@@ -139,6 +159,10 @@ jobs:
             out/load.csv
             out/meta.json
             out/run.log
+            out-base/serial.log
+            out-base/load.csv
+            out-base/meta.json
+            out-base/run.log
             report.md
 
       - name: Comment results on the PR
@@ -156,7 +180,7 @@ jobs:
               marker,
               '### 🎛️ AMY HW CI (AMYboard bench)',
               '',
-              "Flashed this PR's AMY (LoadTestChord: 8-voice Juno `patch=1`, one held note every 2 s) onto the physical AMYboard and measured the smoothed render load as the chord grows.",
+              "Flashed this PR's AMY (LoadTestChord: 8-voice Juno `patch=1`, one held note every 2 s) onto the physical AMYboard and measured the smoothed render load as the chord grows — back-to-back with the same sketch built at the PR's merge base, so Δ is this PR's own cost.",
               '',
               report,
               '',

--- a/tools/arduino_loadsweep/README.md
+++ b/tools/arduino_loadsweep/README.md
@@ -57,11 +57,13 @@ Two consecutive flash failures abort the sweep on the assumption the bench
 ## PR hardware CI
 
 The same sketch + patch + `measure.py` also power AMY's per-PR hardware CI
-(`.github/workflows/amy-hwci-build.yml` builds the firmware in the cloud;
-`amy-hwci.yml` flashes it on the self-hosted bench Pi and comments the
-render load at each chord size on the PR, formatted by `hwci_report.py`).
-CI **FAIL means only that the test couldn't run** — load values are
-informational there; regression *hunting* is this sweep's job.
+(`.github/workflows/amy-hwci-build.yml` builds the firmware in the cloud —
+the PR *and* a baseline at its merge base; `amy-hwci.yml` flashes both
+back-to-back on the self-hosted bench Pi and comments a before/after/Δ
+load table on the PR, formatted by `hwci_report.py`).
+CI **FAIL means only that the PR's test couldn't run** — load values and a
+failed baseline are informational there; regression *hunting* is this
+sweep's job.
 
 ## Sharing the bench
 

--- a/tools/arduino_loadsweep/hwci_report.py
+++ b/tools/arduino_loadsweep/hwci_report.py
@@ -1,26 +1,37 @@
 #!/usr/bin/env python3
-"""Turn one measure.py output dir into the AMY HW CI markdown report + verdict.
+"""Turn measure.py output dirs into the AMY HW CI markdown report + verdict.
 
 Reads <outdir>/{meta.json,load.csv} written by measure.py after a LoadTestChord
 run (one held Juno note added every 2 s until an 8-note chord) and prints a
 markdown report to stdout: the smoothed render load at each chord size, plus
-the settled full-chord load.
+the settled full-chord load.  With --base <dir> (a second measure.py run of
+the same sketch built against the PR's merge base) the table gains
+before/after columns and a delta, so the PR's own load cost is visible
+directly.
 
-Exit code is the HW CI verdict: 0 if the test RAN (flashed, all 8 notes were
-sent, load samples arrived for the whole capture), 1 if it couldn't run
-(flash/serial failure, board crash/wedge, capture interference).  The load
-VALUES never gate — they're informational; regressions are hunted with
-sweep.py/plot.py, not per-PR.
+Exit code is the HW CI verdict for the PR run only: 0 if the test RAN
+(flashed, all 8 notes were sent, load samples arrived for the whole capture),
+1 if it couldn't run (flash/serial failure, board crash/wedge, capture
+interference).  A failed BASELINE run never fails CI — it's reported and the
+table falls back to PR-only columns.  The load VALUES never gate either —
+they're informational; regression hunting across commits is
+sweep.py/plot.py's job, not per-PR CI's.
 
-Usage: hwci_report.py <outdir>
+Usage: hwci_report.py <outdir> [--base <outdir>]
 """
+import argparse
 import csv
 import json
 import os
 import sys
 
 
-def main(outdir):
+def analyze(outdir):
+    """Read one measure.py output dir -> {meta, rows, notes, loads, problems}.
+
+    loads maps note index i (0-based) -> the settled load for that chord
+    size: the last 2 Hz sample before the next note joins.
+    """
     problems = []
     meta, rows = {}, []
     try:
@@ -51,37 +62,85 @@ def main(outdir):
     if meta.get("serial_died_early"):
         problems.append("serial output stopped early (crash/wedge?)")
 
-    ok = not problems
+    loads = {}
+    for i, n in enumerate(notes):
+        end = notes[i + 1]["t_s"] if i + 1 < len(notes) else None
+        window = [l for t, l in rows if t >= n["t_s"] and
+                  (end is None or t < end)]
+        if window:
+            loads[n["i"]] = window[-1]
+    return {"meta": meta, "rows": rows, "notes": notes, "loads": loads,
+            "problems": list(dict.fromkeys(problems))}
 
-    # Load at each chord size: the last sample before the NEXT note joins
-    # (i.e. after ~2 s of this chord, the settled value), and for the full
-    # chord meta's load_final (mean of the capture's last 3 s).
+
+def fmt(v, signed=False):
+    if v is None:
+        return "—"
+    return f"{v:+.3f}" if signed else f"{v:.3f}"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("outdir", help="measure.py output dir for the PR build")
+    ap.add_argument("--base", default=None,
+                    help="measure.py output dir for the merge-base build; "
+                         "adds before/after columns")
+    args = ap.parse_args()
+
+    pr = analyze(args.outdir)
+    base = analyze(args.base) if args.base else None
+    ok = not pr["problems"]
+
+    base_sha = (base or {}).get("meta", {}).get("sha", "")
+    base_col = f"main @ {base_sha[:7]}" if base_sha else "before"
+    with_base = bool(base and base["loads"])
+
     lines = []
-    if rows and notes:
-        lines += ["| notes held | render load |", "|---:|---:|"]
-        for i, n in enumerate(notes):
-            end = notes[i + 1]["t_s"] if i + 1 < len(notes) else None
-            window = [l for t, l in rows if t >= n["t_s"] and
-                      (end is None or t < end)]
-            load = window[-1] if window else None
-            lines.append(f"| {n['i'] + 1} | "
-                         f"{f'{load:.3f}' if load is not None else '—'} |")
-        final = meta.get("load_final")
-        maxl = meta.get("load_max")
+    if pr["rows"] and pr["notes"]:
+        if with_base:
+            lines += [f"| notes held | {base_col} | this PR | Δ |",
+                      "|---:|---:|---:|---:|"]
+        else:
+            lines += ["| notes held | render load |", "|---:|---:|"]
+        for n in pr["notes"]:
+            after = pr["loads"].get(n["i"])
+            row = [str(n["i"] + 1)]
+            if with_base:
+                before = base["loads"].get(n["i"])
+                delta = (after - before
+                         if after is not None and before is not None else None)
+                row += [fmt(before), fmt(after), fmt(delta, signed=True)]
+            else:
+                row += [fmt(after)]
+            lines.append("| " + " | ".join(row) + " |")
+
+        final = pr["meta"].get("load_final")
+        maxl = pr["meta"].get("load_max")
         lines.append("")
-        lines.append(f"**Full chord settled load: "
-                     f"{f'{final:.3f}' if final is not None else '—'}**"
-                     f" (peak {f'{maxl:.3f}' if maxl is not None else '—'},"
-                     f" {meta.get('n_samples', 0)} samples)")
+        headline = f"**Full chord settled load: {fmt(final)}"
+        if with_base:
+            bfinal = base["meta"].get("load_final")
+            bdelta = (final - bfinal
+                      if final is not None and bfinal is not None else None)
+            headline += (f" (was {fmt(bfinal)}, Δ {fmt(bdelta, signed=True)})")
+        headline += (f"** (peak {fmt(maxl)}, "
+                     f"{pr['meta'].get('n_samples', 0)} samples)")
+        lines.append(headline)
+
+    if base and base["problems"]:
+        lines += ["", "_Baseline run "
+                  + ("had problems" if base["loads"] else "unavailable")
+                  + " (does not gate CI): "
+                  + "; ".join(base["problems"]) + "_"]
 
     if ok:
         verdict = "✅ **PASS** — the bench ran the test to completion."
     else:
         verdict = ("❌ **FAIL** — the bench could not run the test:\n" +
-                   "\n".join(f"- {p}" for p in dict.fromkeys(problems)))
+                   "\n".join(f"- {p}" for p in pr["problems"]))
     print("\n".join([verdict, ""] + lines))
     return 0 if ok else 1
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1]))
+    sys.exit(main())


### PR DESCRIPTION
## What

The bench comment now shows **the load change a PR causes**, not just the number it produces:

- **`amy-hwci-build.yml`**: PR builds also compile LoadTestChord against the merge ref's first parent (the current main tip the PR was merged with) into `fw/base/` — same patch, same `-O2`, same sketch fixture; only the AMY library differs. So Δ is attributable to the PR alone.
- **`amy-hwci.yml`**: the bench flashes baseline → 20 s capture → PR → 20 s capture (~90 s total on the board, runs back-to-back so bench drift cancels).
- **`hwci_report.py`**: renders `notes | main @ <sha> | this PR | Δ`, with the settled full-chord delta in the headline.

FAIL semantics unchanged: **only the PR-side run gates CI**. A failed baseline becomes an informational note and the table falls back to PR-only columns — same for artifacts without `fw/base` (e.g. `workflow_dispatch` builds, or pre-this-PR artifacts: PR bins stay at `fw/` top level, so the layout is compatible both directions).

## Verified

Ran `hwci_report.py` against the real artifacts from the two live bench runs (main @ 992b8a2 and PR #830):

| notes held | main @ 992b8a2 | this PR | Δ |
|---:|---:|---:|---:|
| 6 | 0.765 | 0.716 | -0.049 |
| 7 | 0.988 | 0.848 | **-0.140** |
| 8 | 0.988 | 0.986 | -0.001 |

(exactly the manual comparison from #830, now automatic — note the interesting delta lives mid-table because the 8-note chord saturates the board). PR-only and missing-baseline modes verified too.

The dual build is exercised by this PR's own build run; the bench side of this change goes live on the first PR after merge (workflow_run uses main's copy). Note: this PR's own bench run will use main's *current* single-measure workflow — expect the old-style table on this thread, which is itself the compatibility test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)