### PR TITLE
AMY HW CI robustness: warm-cache config init + run bench harness from main

### DIFF
--- a/.github/workflows/amy-hwci-build.yml
+++ b/.github/workflows/amy-hwci-build.yml
@@ -73,8 +73,11 @@ jobs:
           key: arduino15-esp32-${{ env.ESP32_CORE }}
 
       - name: Install the esp32 arduino core
+        # --overwrite: a warm ~/.arduino15 cache already contains the config
+        # file from the run that saved it, and a plain `config init` hard-fails
+        # on it (bit the second build of PR #830).
         run: |
-          arduino-cli config init --additional-urls https://espressif.github.io/arduino-esp32/package_esp32_index.json
+          arduino-cli config init --overwrite --additional-urls https://espressif.github.io/arduino-esp32/package_esp32_index.json
           arduino-cli core update-index
           arduino-cli core install esp32:esp32@${{ env.ESP32_CORE }}
 


### PR DESCRIPTION
`arduino-cli config init` hard-fails if the config file already exists — and the cached `~/.arduino15` contains the one written by whichever run saved the cache. All runs so far were cache misses (caches are scoped per PR merge ref), so this only surfaced on the *second* build of PR #830, which was the first warm hit. One-line fix: `--overwrite`.

(830 itself was unblocked by deleting its stale cache and re-running; this prevents recurrence for every PR's second push.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)