### PR TITLE
AMY HW CI: run the bench harness from main, never the PR head

### DIFF
--- a/.github/workflows/amy-hwci.yml
+++ b/.github/workflows/amy-hwci.yml
@@ -81,11 +81,14 @@ jobs:
             core.setOutput('build_run_id', String(buildRunId));
             core.info(`bench: pr=${pr || '(from ctx.json)'} @ ${sha} (build run ${buildRunId})`);
 
-      # The harness scripts (measure.py, hwci_report.py) at the PR's own SHA —
-      # same-repo gated above, so this is maintainer code.
+      # The harness scripts (measure.py, hwci_report.py) from MAIN — never the
+      # PR head. Two reasons: nothing a PR controls executes on the bench (the
+      # firmware artifact is the only PR input, and that runs on the board, not
+      # the Pi), and a branch that predates the tooling (e.g. an old fork PR,
+      # benched via workflow_dispatch) still benches — checking out ITS head
+      # left the Pi with no scripts at all (bit PR #827). Harness changes take
+      # effect once merged, like the workflow itself.
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.ctx.outputs.sha }}
 
       - name: Download this PR's firmware (built by the build run)
         uses: actions/download-artifact@v4
@@ -143,6 +146,7 @@ jobs:
         id: report
         continue-on-error: true   # gate at the end, after commenting
         run: |
+          set -o pipefail   # a dead report script must not pass via tee's exit 0
           mkdir -p out
           BASE_ARG=""
           [ -d fw/base ] && BASE_ARG="--base out-base"
@@ -172,8 +176,8 @@ jobs:
           script: |
             const fs = require('fs');
             let report = '';
-            try { report = fs.readFileSync('report.md', 'utf8').trim(); }
-            catch (e) { report = '❌ **FAIL** — the bench run died before producing a report.'; }
+            try { report = fs.readFileSync('report.md', 'utf8').trim(); } catch (e) {}
+            if (!report) report = '❌ **FAIL** — the bench run died before producing a report.';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const marker = '<!-- amy-hwci -->';
             const body = [


### PR DESCRIPTION
Found by benching PR #827 (an older fork branch, via `workflow_dispatch`): the bench checked out the harness scripts at the **PR head SHA**, and on a branch that predates the tooling the Pi had no scripts at all — the measure step failed behind `continue-on-error`, and `python3 <missing> | tee report.md` still exited 0 via tee, producing a **green job with an empty comment and no firmware ever flashed**.

Fix:
- Check out the harness from **main** (drop `ref:`). Also defense in depth: nothing a PR controls ever executes on the Pi — the firmware artifact is the only PR input, and it runs on the board, not the runner. Harness changes take effect when merged, same as the workflow itself.
- `pipefail` on the report step so a dead report script can't pass through tee.
- Empty `report.md` renders the died-before-reporting ❌ FAIL comment instead of an empty section.

(Follow-up to #836, which merged while this was being written — the second half of its description belongs here; I've restored #836's body to just the cache fix.)

After merge: re-bench #827 with `gh workflow run "AMY HW CI" -f pr=827` — its firmware artifact is already built.

Suggest `[skip release]` on the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)