### PR TITLE
juno.py: fix from_patch_number AttributeError

### DIFF
--- a/amy/juno.py
+++ b/amy/juno.py
@@ -250,7 +250,7 @@ class JunoPatch:
   @staticmethod
   def from_patch_number(patch_number):
     patch = JunoPatch()
-    patch.init_from_patch_number(patch_number)
+    patch._init_from_patch_number(patch_number)
     return patch
 
   @classmethod


### PR DESCRIPTION
e2049ca renamed the patch-number initializer to `_init_from_patch_number` but left the static constructor `JunoPatch.from_patch_number` calling the old name `init_from_patch_number`, so any caller of the static constructor raises:

```
AttributeError: 'JunoPatch' object has no attribute 'init_from_patch_number'
```

Tulip's `juno6` app hits this on startup (via `amy/juno.py` line 253), breaking the app on current Tulip firmware.

The synth's own `setPatch` path calls the underscored name directly, which is why `make test` didn't catch it. With this fix, `from_patch_number` also correctly applies the new `_PATCH_GAIN_MODS` level trims.

Verified: `JunoPatch.from_patch_number(12)` returns a patch with the gain mod applied; `make test` passes (103 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)