### PR TITLE
Cleaned up behavior of amy.send(synth=X, bus=Y) and reporting bus for yield_synth_commands().

### DIFF
--- a/amy/test.py
+++ b/amy/test.py
@@ -1212,6 +1212,31 @@ class TestCopyingSynthConfig(AmyTest):
     amy.send(time=1900, synth=3, note=67, vel=0)
 
 
+class TestGetSynthCommandsGetsBus(AmyTest):
+
+  def test(self):
+    _amy.stop()
+    _amy.start(0)
+    amy.send(time=0, synth=1, num_voices=4, oscs_per_voice=2)
+    amy.send(time=0, synth=1, osc=0, wave=amy.SINE, freq=110, chained_osc=1)
+    amy.send(time=0, synth=1, osc=1, wave=amy.SAW_UP, freq=500)
+    amy.send(time=0, bus=2, volume=0.1)
+    amy.send(time=0, synth=1, bus=2)
+    amy.send(time=0, synth=1, echo=0.5)
+    amy.render(1)  # Let the events execute.
+    commands = amy.get_synth_commands(1)
+    expected = """v0f110.000c1Z
+v1w3f500.000Z
+y2V0.100x0.000,0.000,0.000M0.500,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z"""
+    if commands != expected:
+      is_ok = False
+      message = self.__class__.__name__ + ': get_synth_commands mismatch: expected:\n++\n%s\n--\n;saw:\n++\n%s\n--;' % (expected, commands)
+    else:
+      is_ok = True
+      message = self.__class__.__name__ + ' : ok'
+    return is_ok, message
+
+
 class TestGetSynthCommandsGetsMidiCcs(AmyTest):
 
   def test(self):
@@ -1226,15 +1251,15 @@ class TestGetSynthCommandsGetsMidiCcs(AmyTest):
     commands = amy.get_synth_commands(1)
     expected = """v0f110.000c1Z
 v1w3f500.000Z
-V1.000x0.000,0.000,0.000M0.000,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z
+y0V1.000x0.000,0.000,0.000M0.000,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z
 ic5,0,0.000,10.000,0.000,helloZ
 ic10,1,1.000,100.000,1.000,i%id%vZ"""
     if commands != expected:
       is_ok = False
-      message = 'TestGetSynthCommandsGetsMidiCcs: get_synth_commands mismatch: expected:\n++\n%s\n--\n;saw:\n++\n%s\n--;' % (expected, commands)
+      message = self.__class__.__name__ + ': get_synth_commands mismatch: expected:\n++\n%s\n--\n;saw:\n++\n%s\n--;' % (expected, commands)
     else:
       is_ok = True
-      message = 'TestGetSynthCommandsGetsMidiCcs : ok'
+      message = self.__class__.__name__ + ' : ok'
     return is_ok, message
 
 
@@ -1255,13 +1280,13 @@ class TestClearMidiCCs(AmyTest):
     commands = amy.get_synth_commands(1)
     expected = """v0f999.000c1Z
 v1w3f500.000Z
-V1.000x0.000,0.000,0.000M0.000,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z"""
+y0V1.000x0.000,0.000,0.000M0.000,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z"""
     if commands != expected:
       is_ok = False
-      message = 'TestClearMidiCcs : get_synth_commands mismatch: expected:\n++\n%s\n--\n;saw:\n++\n%s\n--;' % (expected, commands)
+      message = self.__class__.__name__ + ' : get_synth_commands mismatch: expected:\n++\n%s\n--\n;saw:\n++\n%s\n--;' % (expected, commands)
     else:
       is_ok = True
-      message = 'TestClearMidiCcs : ok'
+      message = self.__class__.__name__ + ' : ok'
     return is_ok, message
 
 class TestClearOneMidiCC(AmyTest):
@@ -1280,14 +1305,14 @@ class TestClearOneMidiCC(AmyTest):
     commands = amy.get_synth_commands(1)
     expected = """v0f999.000c1Z
 v1w3f500.000Z
-V1.000x0.000,0.000,0.000M0.000,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z
+y0V1.000x0.000,0.000,0.000M0.000,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z
 ic10,1,1.000,100.000,1.000,i%id%vZ"""
     if commands != expected:
       is_ok = False
-      message = 'TestClearOneMidiCC : get_synth_commands mismatch: expected:\n++\n%s\n--\n;saw:\n++\n%s\n--;' % (expected, commands)
+      message = self.__class__.__name__ + ' : get_synth_commands mismatch: expected:\n++\n%s\n--\n;saw:\n++\n%s\n--;' % (expected, commands)
     else:
       is_ok = True
-      message = 'TestClearOneMidiCC : ok'
+      message = self.__class__.__name__ + ' : ok'
     return is_ok, message
 
 
@@ -1376,7 +1401,9 @@ class TestBuses(AmyTest):
   def run(self):
     amy.send(time=0, synth=1, num_voices=4, patch=22, bus=0, pan=0.2)  # A37 Pizzicato
     amy.send(time=0, bus=0, reverb=1, echo=0)
-    amy.send(time=0, synth=2, num_voices=4, patch=22, bus=1, pan=0.8)
+    #amy.send(time=0, synth=2, num_voices=4, patch=22, bus=1, pan=0.8)
+    amy.send(time=0, synth=2, num_voices=4, patch=22)
+    amy.send(time=0, synth=2, bus=1, pan=0.8)
     amy.send(time=0, bus=1, reverb=0, echo='1,100,,0.5,0.5')
     amy.send(time=0, volume='2,0.5')  # Mixdown for buses 0 and 1.
     amy.send(time=100, synth=1, note=60, vel=5)

--- a/amy/test.py
+++ b/amy/test.py
@@ -1225,7 +1225,8 @@ class TestGetSynthCommandsGetsBus(AmyTest):
     amy.send(time=0, synth=1, echo=0.5)
     amy.render(1)  # Let the events execute.
     commands = amy.get_synth_commands(1)
-    expected = """v0f110.000c1Z
+    expected = """iv4in2Z
+v0f110.000c1Z
 v1w3f500.000Z
 y2V0.100x0.000,0.000,0.000M0.500,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z"""
     if commands != expected:
@@ -1249,7 +1250,8 @@ class TestGetSynthCommandsGetsMidiCcs(AmyTest):
     amy.send_raw('i1ic10,1,1,100,1,i%id%v')
     amy.render(1)  # Let the events execute.
     commands = amy.get_synth_commands(1)
-    expected = """v0f110.000c1Z
+    expected = """iv4in2Z
+v0f110.000c1Z
 v1w3f500.000Z
 y0V1.000x0.000,0.000,0.000M0.000,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z
 ic5,0,0.000,10.000,0.000,helloZ
@@ -1278,7 +1280,8 @@ class TestClearMidiCCs(AmyTest):
     amy.send_raw('i1ic255v0f999')
     amy.render(1)  # Let the events execute.
     commands = amy.get_synth_commands(1)
-    expected = """v0f999.000c1Z
+    expected = """iv4in2Z
+v0f999.000c1Z
 v1w3f500.000Z
 y0V1.000x0.000,0.000,0.000M0.000,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z"""
     if commands != expected:
@@ -1303,7 +1306,8 @@ class TestClearOneMidiCC(AmyTest):
     amy.send_raw('i1ic5v0f999')
     amy.render(1)  # Let the events execute.
     commands = amy.get_synth_commands(1)
-    expected = """v0f999.000c1Z
+    expected = """iv4in2Z
+v0f999.000c1Z
 v1w3f500.000Z
 y0V1.000x0.000,0.000,0.000M0.000,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z
 ic10,1,1.000,100.000,1.000,i%id%vZ"""

--- a/src/amy.c
+++ b/src/amy.c
@@ -584,13 +584,19 @@ void amy_event_to_deltas_queue(amy_event *e, uint16_t base_osc, struct delta **q
 
     // If this is a bus-directed event, use d->osc to store the bus number instead.
     bool bus_directed_command = false;
-    if (AMY_IS_SET(e->eq_l) || AMY_IS_SET(e->eq_m) || AMY_IS_SET(e->eq_h)
+    bool any_volume_set = false;
+    for (int b = 0; b < AMY_NUM_BUSES; ++b) {
+        any_volume_set |= AMY_IS_SET(e->volume[b]);
+    }
+    if (any_volume_set
+        || AMY_IS_SET(e->eq_l) || AMY_IS_SET(e->eq_m) || AMY_IS_SET(e->eq_h)
         || AMY_IS_SET(e->echo_level) || AMY_IS_SET(e->echo_delay_ms) || AMY_IS_SET(e->echo_max_delay_ms) || AMY_IS_SET(e->echo_feedback) || AMY_IS_SET(e->echo_filter_coef)
         || AMY_IS_SET(e->chorus_level) || AMY_IS_SET(e->chorus_max_delay) || AMY_IS_SET(e->chorus_lfo_freq) || AMY_IS_SET(e->chorus_depth) 
         || AMY_IS_SET(e->reverb_level) || AMY_IS_SET(e->reverb_liveness) || AMY_IS_SET(e->reverb_damping) || AMY_IS_SET(e->reverb_xover_hz)) {
         if (AMY_IS_SET(e->osc))  fprintf(stderr, "** osc %d specific for bus-directed command, ignoring\n", e->osc);  // Can't at this moment be more specific about which command.
-        // Store the target bus in d.osc.
-        d.osc = AMY_IS_SET(e->bus) ? e->bus : AMY_DEFAULT_BUS;
+        // Store the target bus in d.osc.  Either bus is specified, or synth is specified and has a bus, or default.
+        d.osc = AMY_IS_SET(e->bus) ? e->bus :
+            ((AMY_IS_SET(e->synth) && instrument_get_bus(e->synth) >= 0) ? instrument_get_bus(e->synth) : AMY_DEFAULT_BUS);
         bus_directed_command = true;
         if (d.osc > amy_global.highest_bus) amy_global.highest_bus = d.osc;
     } else {
@@ -626,10 +632,14 @@ void amy_event_to_deltas_queue(amy_event *e, uint16_t base_osc, struct delta **q
     }
 
     // Everything else only added to queue if set
+    int bus = 0;
     if (!bus_directed_command) {
         EVENT_TO_DELTA_I(bus, BUS)
-        if (AMY_IS_SET(e->bus) && e->bus > amy_global.highest_bus)
-            amy_global.highest_bus = e->bus;
+        if (AMY_IS_SET(e->bus)) {
+            bus = e->bus;
+            if(bus > amy_global.highest_bus)
+                amy_global.highest_bus = e->bus;
+        }
     }
     EVENT_TO_DELTA_I(wave, WAVE)
     EVENT_TO_DELTA_I(preset, PRESET)
@@ -672,8 +682,8 @@ void amy_event_to_deltas_queue(amy_event *e, uint16_t base_osc, struct delta **q
     EVENT_TO_DELTA_I(eg_type[0], EG0_TYPE)
     EVENT_TO_DELTA_I(eg_type[1], EG1_TYPE)
 
-    for (int bus = 0; bus < AMY_NUM_BUSES; ++bus)
-        EVENT_TO_DELTA_F(volume[bus], VOLUME_BASE + bus)
+    for (int b = bus; b < AMY_NUM_BUSES; ++b)
+        EVENT_TO_DELTA_F(volume[b], VOLUME_BASE + b)  // Even though the actual volume param being set depends on bus, we set the relative DELTA here, and add bus in play_delta().
 
     bool algo_ops_set = false;
     for (int i = 0; i < MAX_ALGO_OPS; ++i) {
@@ -1377,7 +1387,7 @@ void play_delta(struct delta *d) {
     }
     // for global changes, just make the change, no need to update the per-osc synth
     uint8_t bus = d->osc;  // We assume d.osc was hijacked in amy_event_to_deltas_queue
-    if(d->param >= VOLUME_BASE && d->param < (VOLUME_BASE + AMY_NUM_BUSES)) amy_global.volume[d->param - VOLUME_BASE] = d->data.f;
+    if(d->param >= VOLUME_BASE && (d->param - VOLUME_BASE + bus) < AMY_NUM_BUSES) amy_global.volume[d->param - VOLUME_BASE + bus] = d->data.f;
     if(d->param == PITCH_BEND) amy_global.pitch_bend = d->data.f;
     if(d->param == LATENCY) amy_global.latency_ms = d->data.i;
     if(d->param == TEMPO) { amy_global.tempo = d->data.f; sequencer_recompute(); }

--- a/src/amy.h
+++ b/src/amy.h
@@ -1076,6 +1076,7 @@ extern void patches_event_has_voices(amy_event *e, struct delta **queue);
 extern void patches_reset_patch(int patch_number);
 extern void patches_reset();
 extern int sprint_event(amy_event *e, char *s, size_t len, bool wirecode);
+extern void fprintf_event_stderr(amy_event *e);
 extern void *yield_synth_events(uint8_t synth, struct amy_event *event, bool include_fx, void *state);
 extern void *yield_synth_commands(uint8_t synth, char *s, size_t len, bool include_fx, void *state);
 extern int size_of_amy_event(void);

--- a/src/patches.c
+++ b/src/patches.c
@@ -692,18 +692,18 @@ void *yield_synth_events(uint8_t instr_num, struct amy_event *event, bool includ
     int state_val = (intptr_t)state;
     //fprintf(stderr, "yield_synth_events(%d) voice=%d num_oscs=%d state_val=%d\n", instr_num, voice, num_oscs, (int)state_val);
     amy_clear_event(event);
-    int first_osc_state_val = 0;
-    int last_osc_state_val = num_oscs;
-    // Bus is specified in set_event_for_bus_fx, no need to include here.
-    if (flags != 0 /* || bus != 0 */) {
-        ++first_osc_state_val;
-        ++last_osc_state_val;
-        if (state_val == 0) {
-            if (flags != 0)  event->synth_flags = flags;
-            //if (bus != 0)  event->bus = bus;
-        }
-    }
-    if (state_val >= first_osc_state_val && state_val < last_osc_state_val) {
+    // Always use first output (state val 0) as preamble.
+    int first_osc_state_val = 1;
+    int last_osc_state_val = num_oscs + 1;
+    if (state_val == 0) {
+    // Always emit a preamble with num_voices and oscs_per_voice
+    // We could include the patch but we don't, because we're going to set the values by hand.
+        event->num_voices = instrument_get_num_voices(instr_num, NULL);
+        event->oscs_per_voice = instrument_get_oscs_per_voice(instr_num);
+        if (flags != 0)  event->synth_flags = flags;
+        // Bus is specified in set_event_for_bus_fx, no need to include here.
+        //if (bus != 0)  event->bus = bus;
+    } else if (state_val >= first_osc_state_val && state_val < last_osc_state_val) {
         event->osc = state_val - first_osc_state_val;
         //fprintf(stderr, "2 base_osc %d, event->osc %d, state_val %d first_osc_state_val %d last_osc_state_val %d\n",
         //    base_osc, event->osc, state_val, first_osc_state_val, last_osc_state_val);

--- a/src/patches.c
+++ b/src/patches.c
@@ -395,11 +395,13 @@ bool event_addresses_oscs(amy_event *e, bool *p_is_empty) {
     _RET_TRUE_IF_SET(oscs_per_voice);
     _RET_TRUE_IF_SET_SEQ(sequence, 3); // tick, period, tag
     //
+    _RET_TRUE_IF_SET(bus);
+    //
     //_RET_TRUE_IF_SET(status, "status");
     _RET_TRUE_IF_SET(reset_osc);
     // Global effects
     bool is_empty = true;
-    is_empty &= AMY_IS_UNSET(e->bus);
+    //is_empty &= AMY_IS_UNSET(e->bus);
     for (int b = 0; b < AMY_NUM_BUSES; ++b) is_empty &= _TRUE_IF_F_UNSET(e->volume[b]);
     is_empty &= _TRUE_IF_5_F_UNSET(e->eq_l, e->eq_m, e->eq_h, AMY_UNSET_FLOAT, AMY_UNSET_FLOAT);
     is_empty &= _TRUE_IF_5_F_UNSET(e->echo_level, e->echo_delay_ms, e->echo_max_delay_ms, e->echo_feedback, e->echo_filter_coef);
@@ -948,23 +950,15 @@ void patches_event_has_voices(amy_event *e, struct delta **queue) {
         if (!addresses_oscs) {
             if (!is_empty) {
                 // does contain FX-facing events, must strip instr/voices, set bus.
-                if (AMY_IS_SET(e->synth)) {
-                    if (AMY_IS_SET(e->bus)) {
-                        // We are setting the bus for this synth.
-                        instrument_set_bus(e->synth, e->bus);
-                        addresses_oscs = true;  // Make sure the bus gets set for all the oscs too.
-                    } else {
-                        // We infer the current bus for this synth.
-                        e->bus = instrument_get_bus(e->synth);
-                    }
+                if (AMY_IS_SET(e->synth) && AMY_IS_UNSET(e->bus)) {
+                    // We infer the current bus for this synth.
+                    e->bus = instrument_get_bus(e->synth);
                 }
-                if (!addresses_oscs) {  // May have been changed
-                    AMY_UNSET(e->synth);
-                    AMY_UNSET(e->voices[0]);
-                    amy_event_to_deltas_queue(e, 0 /* base_osc, should be ignored */, queue);
-                }
+                AMY_UNSET(e->synth);
+                AMY_UNSET(e->voices[0]);
+                amy_event_to_deltas_queue(e, 0 /* base_osc, should be ignored */, queue);
             }
-            if (!addresses_oscs)  return;  // Early exit.
+            return;  // Early exit.
         }
     }
     uint16_t voices[MAX_VOICES_PER_INSTRUMENT];

--- a/src/patches.c
+++ b/src/patches.c
@@ -282,7 +282,6 @@ int sprint_event(amy_event *e, char *s, size_t len, bool wirecode) {
     _EPRINT_COEF(pan_coefs, "pan_coefs", "Q");
     _EPRINT_F(feedback, "feedback", "b");
     _EPRINT_F(trigger_phase, "phase", "P");
-    _EPRINT_F_SEQ(volume, "volume", AMY_NUM_BUSES, "V");  // NOT osc-dep
     _EPRINT_F(pitch_bend, "pitch_bend", "s");  // NOT osc-dep
     _EPRINT_F(tempo, "tempo", "j");  // NOT osc-dep
     _EPRINT_I(latency_ms, "latency_ms", "N");  // NOT osc-dep
@@ -316,6 +315,8 @@ int sprint_event(amy_event *e, char *s, size_t len, bool wirecode) {
     //_EPRINT_I(status, "status");
     _EPRINT_I(reset_osc, "reset_osc", "S");
     // Global effects
+    _EPRINT_I(bus, "bus", "y");
+    _EPRINT_F_SEQ(volume, "volume", AMY_NUM_BUSES, "V");
     _EPRINT_VALS_5(e->eq_l, e->eq_m, e->eq_h, AMY_UNSET_FLOAT, AMY_UNSET_FLOAT, "eq_{l,m,h}", "x");
     _EPRINT_VALS_5(e->echo_level, e->echo_delay_ms, e->echo_max_delay_ms, e->echo_feedback, e->echo_filter_coef, "echo_{level,delay,max,fb,filt}", "M");
     _EPRINT_VALS_5(e->chorus_level, e->chorus_max_delay, e->chorus_lfo_freq, e->chorus_depth, AMY_UNSET_FLOAT, "chorus_{level,delay,lfo,depth}", "k");
@@ -325,6 +326,12 @@ int sprint_event(amy_event *e, char *s, size_t len, bool wirecode) {
 
     assert( ((size_t)(s - s_entry)) < len);  // if we corrupted memory, at least we'll abort.
     return s - s_entry;
+}
+
+void fprintf_event_stderr(amy_event *e) {
+    char s[1024];
+    sprint_event(e, s, 1024, /* wirecode */ false);
+    fprintf(stderr, "%s\n", s);
 }
 
 #define _RET_TRUE_IF_SET(FIELD) if (AMY_IS_SET(e->FIELD)) return true;
@@ -337,6 +344,8 @@ int sprint_event(amy_event *e, char *s, size_t len, bool wirecode) {
         _RET_TRUE_IF_SET_SEQ(TFIELD, MAX_BPS)        \
         _RET_TRUE_IF_SET_SEQ(VFIELD, MAX_BPS)        \
     }
+#define _TRUE_IF_F_UNSET(VAL1)  \
+    AMY_IS_UNSET((float)(VAL1))
 #define _TRUE_IF_5_F_UNSET(VAL1, VAL2, VAL3, VAL4, VAL5)  \
     (AMY_IS_UNSET((float)(VAL1)) && AMY_IS_UNSET((float)(VAL2)) && AMY_IS_UNSET((float)(VAL3)) && AMY_IS_UNSET((float)(VAL4)) && AMY_IS_UNSET((float)(VAL5)))
 
@@ -356,7 +365,6 @@ bool event_addresses_oscs(amy_event *e, bool *p_is_empty) {
     _RET_TRUE_IF_SET_COEF(pan_coefs);
     _RET_TRUE_IF_SET(feedback);
     _RET_TRUE_IF_SET(trigger_phase);
-    _RET_TRUE_IF_SET_SEQ(volume, AMY_NUM_BUSES);  // NOT osc-dep
     _RET_TRUE_IF_SET(pitch_bend);  // NOT osc-dep
     _RET_TRUE_IF_SET(tempo);  // NOT osc-dep
     _RET_TRUE_IF_SET(latency_ms);  // NOT osc-dep
@@ -391,6 +399,8 @@ bool event_addresses_oscs(amy_event *e, bool *p_is_empty) {
     _RET_TRUE_IF_SET(reset_osc);
     // Global effects
     bool is_empty = true;
+    is_empty &= AMY_IS_UNSET(e->bus);
+    for (int b = 0; b < AMY_NUM_BUSES; ++b) is_empty &= _TRUE_IF_F_UNSET(e->volume[b]);
     is_empty &= _TRUE_IF_5_F_UNSET(e->eq_l, e->eq_m, e->eq_h, AMY_UNSET_FLOAT, AMY_UNSET_FLOAT);
     is_empty &= _TRUE_IF_5_F_UNSET(e->echo_level, e->echo_delay_ms, e->echo_max_delay_ms, e->echo_feedback, e->echo_filter_coef);
     is_empty &= _TRUE_IF_5_F_UNSET(e->chorus_level, e->chorus_max_delay, e->chorus_lfo_freq, e->chorus_depth, AMY_UNSET_FLOAT);
@@ -473,6 +483,7 @@ struct delta *deltas_to_event(struct delta *queue, struct amy_event *event) {
       _CASE_I(eg_type[0], EG0_TYPE)
       _CASE_I(eg_type[1], EG1_TYPE)
       _CASE_F(velocity, VELOCITY)
+      _CASE_I(bus, BUS)
     default:  // blocks, not handled by case
       _TEST_COEFS(amp_coefs, AMP)
       _TEST_FREQ_COEFS(freq_coefs, FREQ)
@@ -625,8 +636,8 @@ void set_event_for_bus_fx(amy_event *event, uint8_t bus, global_state_t *state) 
     // Always emit all FX fields so saved patches are fully self-describing.
     // Set the bus
     event->bus = bus;
-    // Volume for this bus alone.
-    event->volume[bus] = state->volume[bus];
+    // Volume for this bus alone, confusingly sits in slot 0 because bus=X volume=Y writes volume[X] = Y.
+    event->volume[0] = state->volume[bus];
     // EQ
     event->eq_l = lin_to_db(S2F(state->bus[bus]->eq.eq[0]));
     event->eq_m = lin_to_db(S2F(state->bus[bus]->eq.eq[1]));
@@ -673,6 +684,7 @@ void *yield_synth_events(uint8_t instr_num, struct amy_event *event, bool includ
         return NULL;  // instrument not allocated.
     }
     uint32_t flags = instrument_get_flags(instr_num);
+    //uint8_t bus = instrument_get_bus(instr_num);
     uint16_t voice = voices[0];
     uint16_t base_osc = voice_to_base_osc[voice];
     int num_oscs = num_oscs_for_voice(voice);
@@ -682,11 +694,13 @@ void *yield_synth_events(uint8_t instr_num, struct amy_event *event, bool includ
     amy_clear_event(event);
     int first_osc_state_val = 0;
     int last_osc_state_val = num_oscs;
-    if (flags != 0) {
+    // Bus is specified in set_event_for_bus_fx, no need to include here.
+    if (flags != 0 /* || bus != 0 */) {
         ++first_osc_state_val;
         ++last_osc_state_val;
         if (state_val == 0) {
-            event->synth_flags = flags;
+            if (flags != 0)  event->synth_flags = flags;
+            //if (bus != 0)  event->bus = bus;
         }
     }
     if (state_val >= first_osc_state_val && state_val < last_osc_state_val) {
@@ -697,7 +711,7 @@ void *yield_synth_events(uint8_t instr_num, struct amy_event *event, bool includ
     } else if (include_fx && (state_val == last_osc_state_val)) {
         // optional final event contains the global/bus settings (volume, eq, chorus, echo, reverb).
         // The bus is determined by the bus value on the base_osc, probably OK.
-        set_event_for_bus_fx(event, synth[base_osc]->bus, &amy_global);
+        set_event_for_bus_fx(event, instrument_get_bus(instr_num), &amy_global);
     }
     ++state_val;
     if (state_val == last_osc_state_val + (include_fx ? 1 : 0))  state_val = 0;  // Indicate this is the final event.
@@ -930,17 +944,27 @@ void patches_event_has_voices(amy_event *e, struct delta **queue) {
     peek_stack("has_voices");
     {
         bool is_empty = true;
-        if (!event_addresses_oscs(e, &is_empty)) {
+        bool addresses_oscs = event_addresses_oscs(e, &is_empty);
+        if (!addresses_oscs) {
             if (!is_empty) {
                 // does contain FX-facing events, must strip instr/voices, set bus.
-                if (AMY_IS_UNSET(e->bus) && AMY_IS_SET(e->synth)) {
-                    e->bus = instrument_get_bus(e->synth);
+                if (AMY_IS_SET(e->synth)) {
+                    if (AMY_IS_SET(e->bus)) {
+                        // We are setting the bus for this synth.
+                        instrument_set_bus(e->synth, e->bus);
+                        addresses_oscs = true;  // Make sure the bus gets set for all the oscs too.
+                    } else {
+                        // We infer the current bus for this synth.
+                        e->bus = instrument_get_bus(e->synth);
+                    }
                 }
-                AMY_UNSET(e->synth);
-                AMY_UNSET(e->voices[0]);
-                amy_event_to_deltas_queue(e, 0 /* base_osc, should be ignored */, queue);
+                if (!addresses_oscs) {  // May have been changed
+                    AMY_UNSET(e->synth);
+                    AMY_UNSET(e->voices[0]);
+                    amy_event_to_deltas_queue(e, 0 /* base_osc, should be ignored */, queue);
+                }
             }
-            return;  // Early exit.
+            if (!addresses_oscs)  return;  // Early exit.
         }
     }
     uint16_t voices[MAX_VOICES_PER_INSTRUMENT];


### PR DESCRIPTION
There were bugs: Setting the bus for a synth only worked if you did it as part of a "load patch" command, and yeild_synth_commands didn't include the bus information.  Added/updated tests.  Change semantics of `amy.send(bus=X, volume=Y)` to write element X of the volume vector (so volume can be set per-bus, like echo etc.)