### PR TITLE
Shrink AMYboard sysex copy-slot ring from 32 to 8 slots (frees 384KB SPIRAM)

### DIFF
--- a/src/amy_midi.h
+++ b/src/amy_midi.h
@@ -29,13 +29,17 @@ extern uint8_t *sysex_buffer;
 // Only AMYBOARD creates and reads these slots (see parse_sysex()): the ring
 // exists for the SPSS z* sketch-transfer bursts over USB-gadget MIDI, which
 // only AMYboard receives. Size the ring to 0 everywhere else so we don't
-// malloc SYSEX_COPY_SLOTS x MAX_SYSEX_BYTES (32 x 16KB = 512KB): that alone
-// would exhaust e.g. the rp2350's 520KB of SRAM, and on Tulip ESP32-S3 it ate
-// a third of the free SPIRAM. With 0 slots, parse_sysex() finds a NULL slot
-// and the scheduled callback ACKs SPSS messages without processing them;
-// non-SPSS sysex is unaffected.
+// malloc SYSEX_COPY_SLOTS x MAX_SYSEX_BYTES: that alone would exhaust e.g.
+// the rp2350's 520KB of SRAM, and on Tulip ESP32-S3 it ate a third of the
+// free SPIRAM. With 0 slots, parse_sysex() finds a NULL slot and the
+// scheduled callback ACKs SPSS messages without processing them; non-SPSS
+// sysex is unaffected.
+// 8 slots (128KB SPIRAM) is enough on AMYboard: the sender is flow-controlled
+// (the ACK is sent only after a slot is drained, see parse_sysex()), so it
+// can never run more than the ring depth ahead. 32 slots cost 512KB of
+// SPIRAM better spent on memorypcm samples.
 #if defined(AMYBOARD)
-#define SYSEX_COPY_SLOTS 32
+#define SYSEX_COPY_SLOTS 8
 #else
 #define SYSEX_COPY_SLOTS 0
 #endif


### PR DESCRIPTION
## What

Reduces `SYSEX_COPY_SLOTS` on AMYboard from 32 to 8 in `src/amy_midi.h`, freeing 24 × 16KB = **384KB of SPIRAM** for memorypcm samples. Free-after-boot SPIRAM goes from ~2.95MB to ~3.34MB, raising `amy.load_sample()` capacity from ~33s to ~38s of 44.1kHz mono.

## Why 8 is safe

The copy-slot ring exists to buffer SPSS z* sketch-transfer bursts over USB-gadget MIDI while messages wait on the deferred `mp_sched` callback. The sender is flow-controlled: the ACK is sent from the callback only **after** a slot is drained (see `parse_sysex()` / `tulip_amy_send_sysex`), so the sender can never run more than the ring depth ahead. Depth only sets burst tolerance, not correctness — a full ring just delays the transfer, it can't drop data.

All ring users (`amy_midi.c` alloc/free/wrap loops, tulipcc `modtulip.c` read-index wrap) go through the macro, so nothing else assumed 32.

## Context

While accounting for AMYboard's boot-time SPIRAM (8MB total): ~2.3MB firmware text+rodata copied to PSRAM (`CONFIG_SPIRAM_FETCH_INSTRUCTIONS`/`RODATA`), 2MB MicroPython heap, and 528KB of sysex buffers — this ring was the cheapest recovery. Worth a hardware SPSS transfer test after the tulipcc submodule pin picks this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)