### PR TITLE
Add MIDI clock OUT: external_midi_sync=2 makes AMY the realtime clock master

### DIFF
--- a/docs/midi.md
+++ b/docs/midi.md
@@ -43,15 +43,19 @@ For example, to send the wire message `v0f440l1` (sine wave, 440Hz, note on) to 
 
 ## Others
 
-AMY supports MIDI realtime transport for the internal sequencer:
+AMY supports MIDI realtime transport for the internal sequencer, in both directions:
 
 - `0xF8` (Timing Clock): advances the sequencer from external clock input.
 - `0xFA` (Start): starts sequencer playback from tick 0 in external clock mode.
 - `0xFC` (Stop): stops sequencer playback.
 
-External realtime sync is **off by default** — AMY ignores incoming clock/start/stop and keeps its own tempo. Enable it with the C API `amy_external_midi_sync(1)`, or over the wire with `amy.send(external_midi_sync=1)` (wire command `zC1`). Set it back to 0 to return to the internal clock.
+External realtime sync is **off by default** — AMY ignores incoming clock/start/stop and keeps its own tempo. The sync mode is set with the C API `amy_external_midi_sync(mode)`, or over the wire with `amy.send(external_midi_sync=mode)` (wire command `zC`):
 
-MIDI Timing Clock is 24 PPQ. AMY's sequencer runs at 48 PPQ, so AMY advances two sequencer ticks per one MIDI clock pulse.
+- `0` (default): internal clock; incoming realtime messages are ignored and none are sent.
+- `1`: **follow** — the sequencer is slaved to incoming `0xF8`/`0xFA`/`0xFC`.
+- `2`: **send** — AMY is the clock master: it sends `0xF8` at 24 PPQ derived from AMY's own `tempo` out the configured MIDI interface, plus `0xFA`/`0xFC` when the sequencer transport starts or stops (e.g. via `sequencer_run` / `zY`). Clock keeps flowing while the transport is stopped, so downstream gear stays tempo-locked and ready for the next Start.
+
+MIDI Timing Clock is 24 PPQ. AMY's sequencer runs at 48 PPQ, so AMY advances two sequencer ticks per one MIDI clock pulse in follow mode, and sends one clock pulse per two sequencer ticks in send mode.
 
 You can also start and stop the sequencer transport directly, independent of MIDI clock sync, with `amy.send(sequencer_run=1)` / `amy.send(sequencer_run=0)` (wire command `zY1` / `zY0`). 
 

--- a/godot/src/amy_platform_stubs.c
+++ b/godot/src/amy_platform_stubs.c
@@ -28,7 +28,12 @@ void amy_send_midi_note_off(uint8_t channel, uint8_t note, uint8_t velocity) {
 // Called from parse.c zD handler; no MIDI output on Godot so this is a no-op.
 void midi_out(uint8_t *bytes, uint16_t len) { (void)bytes; (void)len; }
 // Called from parse.c zC handler; no MIDI input on Godot so this is a no-op.
-void amy_external_midi_sync(uint8_t enabled) { (void)enabled; }
+void amy_external_midi_sync(uint8_t mode) { (void)mode; }
+// Called from sequencer.c; no MIDI output on Godot so clock out stays off.
+uint8_t midi_clock_out_enabled(void) { return 0; }
+void midi_clock_out_tick(void) {}
+void midi_clock_out_start(void) {}
+void midi_clock_out_stop(void) {}
 
 // --- examples.c stubs ---
 void delay_ms(uint32_t ms) { (void)ms; }

--- a/setup_godot.sh
+++ b/setup_godot.sh
@@ -420,7 +420,12 @@ size_t amy_i2s_write(const uint8_t *buffer, size_t nbytes) {
 
 // --- MIDI stubs (amy_midi.c / macos_midi.m) ---
 void midi_out(uint8_t *bytes, uint16_t len) { (void)bytes; (void)len; }
-void amy_external_midi_sync(uint8_t enabled) { (void)enabled; }
+void amy_external_midi_sync(uint8_t mode) { (void)mode; }
+// Called from sequencer.c; no MIDI output on Godot so clock out stays off.
+uint8_t midi_clock_out_enabled(void) { return 0; }
+void midi_clock_out_tick(void) {}
+void midi_clock_out_start(void) {}
+void midi_clock_out_stop(void) {}
 void midi_local(uint8_t *bytes, uint16_t len) { (void)bytes; (void)len; }
 void run_midi(void) {}
 void stop_midi(void) {}

--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -32,13 +32,77 @@ extern void mp_usbd_task(void);
 uint8_t current_midi_message[3] = {0,0,0};
 uint8_t midi_message_slot = 0;
 uint8_t sysex_flag = 0;
-static uint8_t external_midi_sync_enabled = 0;
+static uint8_t external_midi_sync_mode = AMY_MIDI_SYNC_OFF;
 
-void amy_external_midi_sync(uint8_t enabled) {
-    external_midi_sync_enabled = enabled ? 1 : 0;
-    // Turning sync off must restore internal clocking, otherwise the sequencer
-    // stays latched to a (now silent) external clock and never ticks again.
-    if (!external_midi_sync_enabled) sequencer_external_clock_disable();
+void amy_external_midi_sync(uint8_t mode) {
+    if (mode > AMY_MIDI_SYNC_SEND) mode = AMY_MIDI_SYNC_SEND;
+    external_midi_sync_mode = mode;
+    // Any mode other than "follow" must restore internal clocking, otherwise
+    // the sequencer stays latched to a (now silent) external clock and never
+    // ticks again.
+    if (mode != AMY_MIDI_SYNC_FOLLOW) sequencer_external_clock_disable();
+}
+
+// --- MIDI realtime clock OUT (AMY as clock master, AMY_MIDI_SYNC_SEND) ---
+
+// Counts sequencer ticks (AMY_SEQUENCER_PPQ) down to MIDI clock rate
+// (MIDI_SEQUENCER_PPQ, 24 PPQ).
+static uint8_t clock_out_phase = 0;
+
+#ifdef __EMSCRIPTEN__
+// The sequencer ticks in the AudioWorklet render thread, but midi_out()'s
+// EM_ASM can only reach the page's midiOutputDevice from the browser main
+// thread (the same constraint as amy_sequencer_js_hook). Queue realtime bytes
+// here and flush them from main_loop__em().
+#define CLOCK_OUT_QUEUE_LEN 64
+static volatile uint8_t clock_out_queue[CLOCK_OUT_QUEUE_LEN];
+static volatile uint8_t clock_out_write = 0;
+static volatile uint8_t clock_out_read = 0;
+
+void midi_clock_out_flush() {
+    while (clock_out_read != clock_out_write) {
+        uint8_t byte = clock_out_queue[clock_out_read];
+        clock_out_read = (clock_out_read + 1) % CLOCK_OUT_QUEUE_LEN;
+        midi_out(&byte, 1);
+    }
+}
+#endif
+
+static void midi_realtime_out(uint8_t byte) {
+#ifdef __EMSCRIPTEN__
+    uint8_t next = (clock_out_write + 1) % CLOCK_OUT_QUEUE_LEN;
+    if (next == clock_out_read) return;  // queue full; drop rather than block audio
+    clock_out_queue[clock_out_write] = byte;
+    clock_out_write = next;
+#else
+    midi_out(&byte, 1);
+#endif
+}
+
+uint8_t midi_clock_out_enabled() {
+    return external_midi_sync_mode == AMY_MIDI_SYNC_SEND;
+}
+
+// Called once per sequencer tick while on the internal clock; emits MIDI
+// Timing Clock (0xF8) at 24 PPQ, i.e. every AMY_SEQUENCER_PPQ/MIDI_SEQUENCER_PPQ
+// ticks. The sequencer keeps calling this while the transport is stopped so
+// downstream slaves stay tempo-locked between Start messages.
+void midi_clock_out_tick() {
+    if (!midi_clock_out_enabled()) return;
+    if (clock_out_phase == 0) midi_realtime_out(0xF8);
+    clock_out_phase = (clock_out_phase + 1) % (AMY_SEQUENCER_PPQ / MIDI_SEQUENCER_PPQ);
+}
+
+void midi_clock_out_start() {
+    if (!midi_clock_out_enabled()) return;
+    // The first clock after Start marks the downbeat for slaves.
+    clock_out_phase = 0;
+    midi_realtime_out(0xFA);
+}
+
+void midi_clock_out_stop() {
+    if (!midi_clock_out_enabled()) return;
+    midi_realtime_out(0xFC);
 }
 
 #if 0
@@ -156,10 +220,10 @@ void amy_event_midi_message_received(uint8_t * data, uint32_t len, uint8_t sysex
         else if(status == 0xC0) amy_received_program_change(channel+1, data[1], time);
         else if(status == 0xE0) amy_received_pitch_bend(channel+1, data[1], data[2], time);
         // MIDI transport (Start/Stop) only drives the sequencer when the user
-        // has opted into external sync; otherwise a connected DAW's transport
-        // would hijack the AMYboard's own internal sequence.
-        else if(status_byte == 0xFA) { if(external_midi_sync_enabled) sequencer_midi_start(); }
-        else if(status_byte == 0xFC) { if(external_midi_sync_enabled) sequencer_midi_stop(); }
+        // has opted into following external sync; otherwise a connected DAW's
+        // transport would hijack the AMYboard's own internal sequence.
+        else if(status_byte == 0xFA) { if(external_midi_sync_mode == AMY_MIDI_SYNC_FOLLOW) sequencer_midi_start(); }
+        else if(status_byte == 0xFC) { if(external_midi_sync_mode == AMY_MIDI_SYNC_FOLLOW) sequencer_midi_stop(); }
     }
     midi_message_handler_to_queue(data, len, sysex, time, NULL, NULL);
 
@@ -179,7 +243,7 @@ void amy_event_midi_message_received(uint8_t * data, uint32_t len, uint8_t sysex
 
 
 void midi_clock_received() {
-    if (external_midi_sync_enabled) {
+    if (external_midi_sync_mode == AMY_MIDI_SYNC_FOLLOW) {
         sequencer_midi_clock_tick();
     }
 }

--- a/src/amy_midi.h
+++ b/src/amy_midi.h
@@ -15,7 +15,22 @@
 void convert_midi_bytes_to_messages(uint8_t * data, size_t len, uint8_t usb);
 void amy_process_single_midi_byte(uint8_t byte, uint8_t from_web_or_usb);
 void amy_external_midi_output(uint8_t * data, uint32_t len);
-void amy_external_midi_sync(uint8_t enabled);
+
+// Modes for amy_external_midi_sync() (wire command zC / external_midi_sync=).
+#define AMY_MIDI_SYNC_OFF 0     // internal clock; ignore and don't send realtime messages (default)
+#define AMY_MIDI_SYNC_FOLLOW 1  // sequencer follows incoming 0xF8/0xFA/0xFC
+#define AMY_MIDI_SYNC_SEND 2    // sequencer sends 0xF8/0xFA/0xFC (AMY is the clock master)
+void amy_external_midi_sync(uint8_t mode);
+
+// MIDI clock out, driven by the sequencer when in AMY_MIDI_SYNC_SEND mode.
+// Stubbed in godot/src/amy_platform_stubs.c (amy_midi.c is excluded there).
+uint8_t midi_clock_out_enabled();
+void midi_clock_out_tick();
+void midi_clock_out_start();
+void midi_clock_out_stop();
+#ifdef __EMSCRIPTEN__
+void midi_clock_out_flush();  // called from the browser main loop
+#endif
 
 
 #define MAX_MIDI_BYTES_TO_PARSE 1024

--- a/src/libminiaudio-audio.c
+++ b/src/libminiaudio-audio.c
@@ -44,6 +44,9 @@ void main_loop__em()
     // Ticks are counted in the render loop (AudioWorklet thread); replay them
     // to the page's amy_sequencer_js_hook from the main thread here.
     sequencer_check_and_call_js_hook();
+    // Same story for outgoing MIDI realtime clock: the worklet queues the
+    // bytes, and only the main thread can reach the page's midiOutputDevice.
+    midi_clock_out_flush();
     amy_web_cv_1 = EM_ASM_DOUBLE({ 
         if(typeof cv_1_voltage != 'undefined') { return cv_1_voltage; } else { return 0; }
     });

--- a/src/parse.c
+++ b/src/parse.c
@@ -622,11 +622,13 @@ uint16_t amy_parse_transfer_layer_message(char *message) {
     }
     else if (cmd == 'C') {
         // zC: external MIDI clock sync. zC1 makes the sequencer follow incoming
-        // MIDI realtime clock/start/stop (0xF8/0xFA/0xFC); zC0 (the default)
-        // ignores them and uses the internal clock. Same switch as the C API's
-        // amy_external_midi_sync(), reachable over the wire so hosts that only
-        // speak the wire protocol (web builds, sysex) can flip it.
-        amy_external_midi_sync(atoi(message) ? 1 : 0);
+        // MIDI realtime clock/start/stop (0xF8/0xFA/0xFC); zC2 makes AMY the
+        // clock master, sending those messages out (0xF8 at 24 PPQ from the
+        // internal tempo, 0xFA/0xFC on transport start/stop); zC0 (the default)
+        // neither follows nor sends and uses the internal clock. Same switch as
+        // the C API's amy_external_midi_sync(), reachable over the wire so hosts
+        // that only speak the wire protocol (web builds, sysex) can flip it.
+        amy_external_midi_sync((uint8_t)atoi(message));
         return 1;
     }
     else fprintf(stderr, "Unrecognized transfer-level command '%s'\n", message - 1);

--- a/src/sequencer.c
+++ b/src/sequencer.c
@@ -76,6 +76,7 @@ void sequencer_recompute() {
 
 static void sequencer_process_tick(void) {
     amy_global.sequencer_tick_count++;
+    midi_clock_out_tick();  // no-op unless in AMY_MIDI_SYNC_SEND mode
     // Scan through LL looking for matches
     for (int32_t tag = 0; tag <= highest_tag; ++tag) {
         if (sequences[tag].deltas != NULL) {
@@ -146,10 +147,12 @@ void sequencer_midi_start() {
     // catch up all the ticks that elapsed while stopped.
     amy_global.next_amy_tick_us = (uint64_t)amy_sysclock() * 1000L;
     sequencer_running = true;
+    midi_clock_out_start();  // tell downstream slaves, if we're the clock master
 }
 
 void sequencer_midi_stop() {
     sequencer_running = false;
+    midi_clock_out_stop();  // tell downstream slaves, if we're the clock master
 }
 
 void sequencer_midi_clock_tick() {
@@ -209,7 +212,11 @@ uint8_t sequencer_add_event(amy_event *e) {
 // AMY time in any rendering context (live, offline, tests).
 void sequencer_check_and_fill() {
     if (sequences == NULL) return;  // sequencer_init hasn't run
-    if (!sequencer_running || sequencer_external_clock) return;
+    if (sequencer_external_clock) return;
+    // When we're the MIDI clock master, realtime clock keeps flowing even while
+    // the transport is stopped so slaves stay tempo-locked; otherwise a stopped
+    // sequencer has nothing to do.
+    if (!sequencer_running && !midi_clock_out_enabled()) return;
     // If we've fallen behind by more than 1 second (e.g. sequencer was stopped
     // and restarted, or a long blocking operation occurred), skip ahead instead
     // of processing hundreds of backed-up ticks at once.
@@ -219,7 +226,8 @@ void sequencer_check_and_fill() {
     }
     // The while is in case the timer fires later than a tick; (on esp this would be due to SPI or wifi ops)
     while(now_us >= amy_global.next_amy_tick_us) {
-        sequencer_process_tick();
+        if (sequencer_running) sequencer_process_tick();
+        else midi_clock_out_tick();  // transport stopped: clock only, no sequence events
         amy_global.next_amy_tick_us = amy_global.next_amy_tick_us + (uint64_t)amy_global.us_per_tick;
     }
 }


### PR DESCRIPTION
## What

AMY could already *follow* MIDI realtime clock (`external_midi_sync=1`, wire `zC1`) but had no way to *send* it. This PR extends the same switch with a third mode:

- `0` (default): internal clock; realtime messages neither followed nor sent — unchanged
- `1`: follow incoming `0xF8`/`0xFA`/`0xFC` — unchanged
- `2` (**new**): AMY is the clock master — sends `0xF8` at 24 PPQ derived from AMY's own `tempo` (one pulse per two 48 PPQ sequencer ticks), plus `0xFA`/`0xFC` when the sequencer transport starts/stops (`zY1`/`zY0`, `sequencer_run=`, or the C API)

Per the MIDI spec recommendation, clock keeps flowing while the transport is stopped, so downstream slaves stay tempo-locked and start cleanly on the next `0xFA` (the first `0xF8` after Start marks the downbeat; the phase counter resets on Start).

Usable from C (`amy_external_midi_sync(2)`), Python (`amy.send(external_midi_sync=2)`), the wire/sysex (`zC2`), and JS — no `_KW_MAP_LIST` change needed since the kwarg already existed.

## How

- Emission lives in `src/amy_midi.c` (`midi_clock_out_tick/start/stop/enabled`), called from the sequencer's internal tick path. In follow or off mode they're no-ops, so the external-clock path can't echo clock back out.
- `sequencer_check_and_fill()` now keeps the tick timer running while the transport is stopped **only** when clock-out is enabled, emitting clock without processing sequence events; behavior in modes 0/1 is unchanged.
- **Web:** the sequencer ticks in the AudioWorklet thread, where `EM_ASM` can't reach the page's `midiOutputDevice`. Realtime bytes are queued in a small ring and flushed from `main_loop__em()` — the same main-thread split as `amy_sequencer_js_hook`.
- **Godot:** `amy_midi.c` is excluded there, so the new functions get no-op stubs in both `godot/src/amy_platform_stubs.c` and the embedded copy in `setup_godot.sh`.
- Docs updated in `docs/midi.md`.

## Verification

- Offline C harness capturing `midi_out()` bytes over rendered audio: `0xF8` arrives at 24 PPQ (43/sec at 108 bpm, measured over 2s running + 1s stopped + 1s restarted), exactly one `0xFA`/`0xFC` per transport edge, nothing but realtime bytes in the stream, nothing at all sent in modes 0/1, and follow mode still advances two sequencer ticks per injected `0xF8`.
- `make test`: all 109 WAV tests pass bit-exact.
- `emcc` compile of `amy_midi.c` and `libminiaudio-audio.c` clean; Godot stub file compiles standalone.

Timing note: clock is emitted from the block-rate sequencer check, so F8 jitter is bounded by one render block (~5.8 ms at 44.1k/256) — the same quantization the sequencer itself has. On web it's additionally quantized to the main-loop frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)