### PR TITLE
HWCI: understand both RENDER_LOAD formats; pre-land the ARDUINO_SPEEDTEST hook for #866

### DIFF
--- a/.github/workflows/amy-hwci.yml
+++ b/.github/workflows/amy-hwci.yml
@@ -4,8 +4,8 @@ name: AMY HW CI
 # tulipcc bench: flash THIS PR's LoadTestChord firmware (built and uploaded as
 # an artifact by "AMY HW CI build") onto the physical AMYboard on the
 # self-hosted bench Pi (amyboardci), capture 20 s of its debug UART while the
-# sketch stacks up an 8-note held Juno chord, and comment the measured render
-# load at each chord size back on the PR.
+# sketch stacks up a held Juno chord, and comment the measured render cost
+# at each chord size back on the PR.
 #
 # PASS/FAIL semantics: FAIL means only that the bench COULD NOT RUN the test
 # (flash/serial failure, board crash, capture interference). The load values
@@ -184,7 +184,7 @@ jobs:
               marker,
               '### 🎛️ AMY HW CI (AMYboard bench)',
               '',
-              "Flashed this PR's AMY (LoadTestChord: 8-voice Juno `patch=1`, one held note every 2 s) onto the physical AMYboard and measured the smoothed render load as the chord grows — back-to-back with the same sketch built at the PR's merge base, so Δ is this PR's own cost.",
+              "Flashed this PR's AMY (LoadTestChord: 8-voice Juno `patch=1`, one held note every 2 s) onto the physical AMYboard and measured the smoothed render cost as the chord grows — back-to-back with the same sketch built at the PR's merge base, so Δ is this PR's own cost.",
               '',
               report,
               '',

--- a/src/i2s.c
+++ b/src/i2s.c
@@ -313,6 +313,14 @@ void esp_read_i2s_input() {
 }
 
 // Make AMY's FABT run forever , as a FreeRTOS task
+
+#ifdef ARDUINO_SPEEDTEST
+#include "esp_timer.h"
+#include <stdio.h>
+static int64_t _rl_last_print = 0;
+static int32_t _rl_render_us = 0;
+#endif // ARDUINO_SPEEDTEST
+
 void esp_fill_audio_buffer_task() {
     while(1) {
         int64_t t;
@@ -324,6 +332,9 @@ void esp_fill_audio_buffer_task() {
             blocked_us += (uint32_t)(amy_get_us() - t);
 	}
         t = amy_get_us();
+#ifdef ARDUINO_SPEEDTEST
+        int64_t _rl_start_t = esp_timer_get_time();
+#endif // ARDUINO_SPEEDTEST
         // Get ready to render
         amy_execute_deltas();
 
@@ -340,6 +351,19 @@ void esp_fill_audio_buffer_task() {
         // Notify amy_update() that a block is ready (so it can return from amy_render_audio).
         if (amy_update_handle)
             xTaskNotifyGive(amy_update_handle);  // to amy_render_audio
+
+#ifdef ARDUINO_SPEEDTEST
+        {
+            int64_t _rl_now = esp_timer_get_time();
+            int32_t _rl_render_us_unsmooth = (int32_t)(_rl_now - _rl_start_t);
+            _rl_render_us += (_rl_render_us_unsmooth - _rl_render_us) >> 5;  // 0.03125 * delta, settle time ~30 steps
+            if (_rl_now - _rl_last_print > 500000) {
+                _rl_last_print = _rl_now;
+                fprintf(stderr, "RENDER_LOAD ms=%lu render_us=%d\n", (unsigned long)(_rl_now/1000), _rl_render_us);
+                fflush(stderr);
+            }
+        }
+#endif // ARDUINO_SPEEDTEST
 
         t = amy_get_us();
         if (AMY_HAS_I2S) {

--- a/tools/arduino_loadsweep/hwci_report.py
+++ b/tools/arduino_loadsweep/hwci_report.py
@@ -2,20 +2,22 @@
 """Turn measure.py output dirs into the AMY HW CI markdown report + verdict.
 
 Reads <outdir>/{meta.json,load.csv} written by measure.py after a LoadTestChord
-run (one held Juno note added every 2 s until an 8-note chord) and prints a
-markdown report to stdout: the smoothed render load at each chord size, plus
-the settled full-chord load.  With --base <dir> (a second measure.py run of
-the same sketch built against the PR's merge base) the table gains
-before/after columns and a delta, so the PR's own load cost is visible
+run (one held Juno note added every 2 s until the full chord) and prints a
+markdown report to stdout: the smoothed render cost at each chord size, plus
+the settled full-chord value.  Measurements are either a 0..1 load fraction
+(patch_render_load.py-era builds) or microseconds per block
+(-DARDUINO_SPEEDTEST builds); meta.json's "unit" says which.  With --base
+<dir> (a second measure.py run of the same sketch built against the PR's
+merge base) the table gains before/after columns and a delta — omitted if
+the two runs measured in different units — so the PR's own cost is visible
 directly.
 
 Exit code is the HW CI verdict for the PR run only: 0 if the test RAN
-(flashed, all 8 notes were sent, load samples arrived for the whole capture),
+(flashed, the chord was sent, samples arrived for the whole capture),
 1 if it couldn't run (flash/serial failure, board crash/wedge, capture
 interference).  A failed BASELINE run never fails CI — it's reported and the
-table falls back to PR-only columns.  The load VALUES never gate either —
-they're informational; regression hunting across commits is
-sweep.py/plot.py's job, not per-PR CI's.
+table falls back to PR-only columns.  The measured VALUES never gate either —
+they're informational.
 
 Usage: hwci_report.py <outdir> [--base <outdir>]
 """
@@ -55,8 +57,8 @@ def analyze(outdir):
     notes = meta.get("notes", [])
     if not rows and not any("RENDER_LOAD" in p for p in problems):
         problems.append("no RENDER_LOAD lines captured")
-    if rows and len(notes) < 8:
-        problems.append(f"only {len(notes)}/8 notes were played")
+    if rows and len(notes) < 6:   # the sketch plays 6 notes (was 8 pre-#866)
+        problems.append(f"only {len(notes)} notes were played (expected >= 6)")
     if meta.get("board_crashed"):
         problems.append("board crashed during the run (panic/watchdog reboot)")
     if meta.get("serial_died_early"):
@@ -70,12 +72,15 @@ def analyze(outdir):
         if window:
             loads[n["i"]] = window[-1]
     return {"meta": meta, "rows": rows, "notes": notes, "loads": loads,
+            "unit": meta.get("unit", "load"),
             "problems": list(dict.fromkeys(problems))}
 
 
-def fmt(v, signed=False):
+def fmt(v, unit="load", signed=False):
     if v is None:
         return "—"
+    if unit == "render_us":
+        return f"{v:+,.0f}" if signed else f"{v:,.0f}"
     return f"{v:+.3f}" if signed else f"{v:.3f}"
 
 
@@ -93,7 +98,10 @@ def main():
 
     base_sha = (base or {}).get("meta", {}).get("sha", "")
     base_col = f"main @ {base_sha[:7]}" if base_sha else "before"
-    with_base = bool(base and base["loads"])
+    unit = pr["unit"]
+    unit_label = "render µs/block" if unit == "render_us" else "render load"
+    units_differ = bool(base and base["loads"] and base["unit"] != unit)
+    with_base = bool(base and base["loads"] and not units_differ)
 
     lines = []
     if pr["rows"] and pr["notes"]:
@@ -101,7 +109,7 @@ def main():
             lines += [f"| notes held | {base_col} | this PR | Δ |",
                       "|---:|---:|---:|---:|"]
         else:
-            lines += ["| notes held | render load |", "|---:|---:|"]
+            lines += [f"| notes held | {unit_label} |", "|---:|---:|"]
         for n in pr["notes"]:
             after = pr["loads"].get(n["i"])
             row = [str(n["i"] + 1)]
@@ -109,24 +117,31 @@ def main():
                 before = base["loads"].get(n["i"])
                 delta = (after - before
                          if after is not None and before is not None else None)
-                row += [fmt(before), fmt(after), fmt(delta, signed=True)]
+                row += [fmt(before, unit), fmt(after, unit),
+                        fmt(delta, unit, signed=True)]
             else:
-                row += [fmt(after)]
+                row += [fmt(after, unit)]
             lines.append("| " + " | ".join(row) + " |")
 
         final = pr["meta"].get("load_final")
         maxl = pr["meta"].get("load_max")
         lines.append("")
-        headline = f"**Full chord settled load: {fmt(final)}"
+        headline = f"**Full chord settled {unit_label}: {fmt(final, unit)}"
         if with_base:
             bfinal = base["meta"].get("load_final")
             bdelta = (final - bfinal
                       if final is not None and bfinal is not None else None)
-            headline += (f" (was {fmt(bfinal)}, Δ {fmt(bdelta, signed=True)})")
-        headline += (f"** (peak {fmt(maxl)}, "
+            headline += (f" (was {fmt(bfinal, unit)}, "
+                         f"Δ {fmt(bdelta, unit, signed=True)})")
+        headline += (f"** (peak {fmt(maxl, unit)}, "
                      f"{pr['meta'].get('n_samples', 0)} samples)")
         lines.append(headline)
 
+    if units_differ:
+        lines += ["", "_Baseline was measured in different units "
+                  f"({base['unit']} vs {unit}) — before/Δ omitted. "
+                  "Merge main into this branch to rebuild the baseline "
+                  "with matching instrumentation._"]
     if base and base["problems"]:
         lines += ["", "_Baseline run "
                   + ("had problems" if base["loads"] else "unavailable")

--- a/tools/arduino_loadsweep/measure.py
+++ b/tools/arduino_loadsweep/measure.py
@@ -8,9 +8,11 @@ makes arduino-cli hop to the board's native USB port instead of the dongle.
 The dongle's DTR/RTS lines drive the board's auto-reset circuit, so esptool
 enters the ROM bootloader by itself (no BOOT/RST pressing) and recovers a
 wedged board.  After flashing, pulses RTS to restart the board at a known
-t=0, then tails the same UART for the `RENDER_LOAD ms=<ms> load=<0..1>`
-lines that patch_render_load.py adds and the `NOTE i=<n> ...` markers the
-sketch prints.  Writes <out>/{load.csv,serial.log,meta.json}.
+t=0, then tails the same UART for the RENDER_LOAD lines — either
+`RENDER_LOAD ms=<ms> load=<0..1>` (patch_render_load.py-era builds) or
+`RENDER_LOAD ms=<ms> render_us=<µs>` (-DARDUINO_SPEEDTEST builds) — and the
+`NOTE i=<n> ...` markers the sketch prints.  Which unit was seen is recorded
+as meta.json's "unit".  Writes <out>/{load.csv,serial.log,meta.json}.
 
 A wedged/crashed board (prints stop early) is flagged in meta.json as
 serial_died_early; the next run's esptool handshake recovers it via DTR/RTS.
@@ -26,7 +28,7 @@ import subprocess
 import sys
 import time
 
-RL = re.compile(r"RENDER_LOAD ms=(\d+) load=([\d.]+)")
+RL = re.compile(r"RENDER_LOAD ms=(\d+) (load|render_us)=([\d.]+)")
 NOTE = re.compile(r"NOTE i=(\d+) note=(\d+) ms=(\d+)")
 # A power-on reset or ROM-bootloader entry mid-capture means someone else
 # pulsed the board's reset lines (another harness sharing the bench) — the
@@ -157,7 +159,7 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("build_dir", help="arduino-cli --build-path output dir")
     ap.add_argument("--out", required=True)
-    ap.add_argument("--port", default="/dev/cu.usbserial-A5069RR4",
+    ap.add_argument("--port", default="/dev/cu.usbserial-0001",
                     help="debug-UART dongle (flash + stderr console)")
     ap.add_argument("--flash-baud", type=int, default=921600)
     ap.add_argument("--esptool", default=None,
@@ -208,11 +210,15 @@ def main():
         for ts, line in lines:
             f.write(f"{ts:8.3f} {line}\n")
 
-    rows, notes = [], []
+    rows, notes, units = [], [], set()
     for ts, line in lines:
         m = RL.search(line)
         if m:
-            rows.append((round(ts, 3), int(m.group(1)), float(m.group(2))))
+            units.add(m.group(2))
+            v = float(m.group(3))
+            if m.group(2) == "render_us":
+                v = int(v)
+            rows.append((round(ts, 3), int(m.group(1)), v))
         m = NOTE.search(line)
         if m:
             notes.append({"t_s": round(ts, 3), "i": int(m.group(1)),
@@ -225,6 +231,11 @@ def main():
 
     meta["n_samples"] = len(rows)
     meta["notes"] = notes
+    if len(units) == 1:
+        meta["unit"] = units.pop()
+    elif units:
+        meta["unit"] = "mixed"
+        meta["errors"].append("mixed RENDER_LOAD units in one capture")
     if any(CRASH_SIG.search(l) and ts > 2.0 for ts, l in lines):
         meta["board_crashed"] = True
         print("[result] board CRASHED during run (panic/watchdog reboot)")
@@ -232,7 +243,12 @@ def main():
         meta["load_max"] = max(r[2] for r in rows)
         meta["last_sample_t"] = rows[-1][0]
         final = [r[2] for r in rows if r[0] >= args.seconds - 3.0]
-        meta["load_final"] = round(sum(final) / len(final), 4) if final else None
+        if not final:
+            meta["load_final"] = None
+        elif meta.get("unit") == "render_us":
+            meta["load_final"] = round(sum(final) / len(final))
+        else:
+            meta["load_final"] = round(sum(final) / len(final), 4)
         if rows[-1][0] < args.seconds - 3.0:
             meta["serial_died_early"] = True   # prints stopped: crash/wedge
     else:


### PR DESCRIPTION
#866's bench run failed with 0 samples on both the PR and baseline captures. Two causes, both structural:

1. The bench Pi always runs `measure.py`/`hwci_report.py` from **main** (by design — fork code never executes on the self-hosted runner), so main's parser saw #866's new `RENDER_LOAD ms=... render_us=...` lines and matched nothing.
2. The baseline firmware is built at the merge base, which has neither #866's `#ifdef ARDUINO_SPEEDTEST` block nor the `patch_render_load.py` patching that #866 deletes — so it printed no `RENDER_LOAD` lines at all.

This PR lands the compatibility half on main first, so the bench understands both worlds before (and after) #866 merges:

- **measure.py**: parse `load=<0..1>` *or* `render_us=<µs>`, record which as `unit` in meta.json; round `render_us` aggregates to ints; adopt #866's `--port` default.
- **hwci_report.py**: unit-aware table/headline; before/Δ columns only when both runs measured in the same unit (clear note otherwise, non-gating); accept #866's 6-note sketch as well as the current 8-note one.
- **src/i2s.c**: #866's inert `#ifdef ARDUINO_SPEEDTEST` render-time print, minus its `/* rl-patch */` marker — the marker would make `patch_render_load.py` think the file was already patched and silently skip, breaking main's own bench builds. (Verified the patch script still applies cleanly on top of this.) Once this is in merge bases, `-DARDUINO_SPEEDTEST` baseline builds print real data and the Δ column comes back.

Verified by replaying #866's actual bench serial logs through the new tools — old+old (today's steady state, output unchanged), new+new (post-#866 steady state), new+missing-baseline (#866's exact case, passes with a note), and new+old-unit-baseline (passes, Δ omitted with a note). FAIL-only-if-the-test-couldn't-run semantics are unchanged.

After this merges: merge main into `remove_sweep_report_microseconds` so #866's next build picks up an instrumented merge base, and its bench run goes green with a full before/after table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)