### PR TITLE
sin/cos_lut in the hpf and bpf coefficient generators too

### DIFF
--- a/src/filters.c
+++ b/src/filters.c
@@ -106,9 +106,13 @@ int8_t dsps_biquad_gen_hpf_f32(SAMPLE *coeffs, float f, float qFactor)
     }
     float Fs = 1;
 
-    float w0 = 2 * M_PI * f / Fs;
-    float c = cosf(w0);
-    float s = sinf(w0);
+    //float w0 = 2 * M_PI * f / Fs;
+    //float c = cosf(w0);
+    //float s = sinf(w0);
+    float w0 = f / Fs;
+    float c = cos2pi(w0);
+    float s = sin2pi(w0);
+
     float alpha = s / (2 * qFactor);
 
     float b0 = (1 + c) / 2;
@@ -136,9 +140,13 @@ int8_t dsps_biquad_gen_bpf_f32(SAMPLE *coeffs, float f, float qFactor)
     }
     float Fs = 1;
 
-    float w0 = 2 * M_PI * f / Fs;
-    float c = cosf(w0);
-    float s = sinf(w0);
+    //float w0 = 2 * M_PI * f / Fs;
+    //float c = cosf(w0);
+    //float s = sinf(w0);
+    float w0 = f / Fs;
+    float c = cos2pi(w0);
+    float s = sin2pi(w0);
+
     float alpha = s / (2 * qFactor);
 
     float b0 = s / 2;


### PR DESCRIPTION
Follow-on to #875 (avoid_transcendentals) + Issue #783

## What

That PR redefined the `sin2pi`/`cos2pi` macros in `filters.c` to go through the
new `sin_lut`/`cos_lut` from `log2_exp2.c`, and rewired
`dsps_biquad_gen_lpf_f32` to use them. The high-pass and band-pass generators
were left on the old path: `dsps_biquad_gen_hpf_f32` and
`dsps_biquad_gen_bpf_f32` still called `cosf(w0)`/`sinf(w0)` directly.

This routes both of them through the same macros, in the same shape as the LPF
change: `w0` is computed in turns rather than radians, and the old lines are
left commented out next to the new ones.

## Why it matters

`filter_process()` recomputes biquad coefficients on every block, per
oscillator, dispatching on filter type:

```c
if (filter_type == FILTER_LPF || filter_type == FILTER_LPF24)
    dsps_biquad_gen_lpf_f32(coeffs, ratio, resonance);   // LUT since #875
else if (filter_type == FILTER_BPF)
    dsps_biquad_gen_bpf_f32(coeffs, ratio, resonance);   // still libm
else if (filter_type == FILTER_HPF)
    dsps_biquad_gen_hpf_f32(coeffs, ratio, resonance);   // still libm
```

So after #875 a patch with a low-pass filter got the speedup and an otherwise
identical patch with a high-pass or band-pass filter did not: it kept paying two
libm calls per oscillator per block. The parametric EQ is affected too, since
`parametric_eq_process()` builds its three bands from one LPF, one BPF and one HPF.

Computing `w0` in turns has a second effect. `M_PI` resolves to a `double`, so
`2 * M_PI * f` promoted `f` to double, multiplied, and truncated back. Dropping
that expression removes the soft-float double helpers as well, not just the trig calls.

## Evidence

Measured per-function on `xtensa-esp32s3-elf-gcc 15.2` at the flags AMY ships
with (`-O2 -DAMY_USE_FIXEDPOINT -DNDEBUG -mlongcalls`), using
[asmdiff](https://www.github.com/rt-rtos/asmdiff/), which compiles a source and reports
each function's instruction count and outgoing calls. The whole 27-file source
tree was swept in one pass and filtered for transcendental callees, which is how the asymmetry surfaced.

Before (upstream `main`, 1.2.52):

| generator | calls |
| --- | --- |
| `dsps_biquad_gen_lpf_f32` | `cos_lut`, `sin_lut`, `__divsf3`, `__extendsfdf2`, `__gtdf2`, `__ltdf2` |
| `dsps_biquad_gen_hpf_f32` | **`cosf`, `sinf`**, **`__muldf3`**, **`__truncdfsf2`**, `__divsf3`, `__extendsfdf2`, `__gtdf2`, `__ledf2` |
| `dsps_biquad_gen_bpf_f32` | **`cosf`, `sinf`**, **`__muldf3`**, **`__truncdfsf2`**, `__divsf3`, `__extendsfdf2`, `__gtdf2`, `__ledf2` |

After:

| generator | calls |
| --- | --- |
| `dsps_biquad_gen_lpf_f32` | `cos_lut`, `sin_lut`, `__divsf3`, `__extendsfdf2`, `__gtdf2`, `__ltdf2` |
| `dsps_biquad_gen_hpf_f32` | `cos_lut`, `sin_lut`, `__divsf3`, `__extendsfdf2`, `__gtdf2`, `__ledf2` |
| `dsps_biquad_gen_bpf_f32` | `cos_lut`, `sin_lut`, `__divsf3`, `__extendsfdf2`, `__gtdf2`, `__ledf2` |

`sinf`, `cosf`, `__muldf3` and `__truncdfsf2` are gone from both, and the two
generators now have the same residual call profile as the LPF. The remaining
`__extendsfdf2`/`__gtdf2`/`__ledf2` come from the `qFactor` and `f` clamp
comparisons against double literals, which the LPF also has - out of scope for this PR.

The same sweep confirms the rest of the per-sample render path is already clean
after #875. The oscillators go through `render_lut`/`render_lpf_lut`, and
`amp_combine_controls`, `compute_breakpoint_scale` and `freq_of_logfreq` all
reach `exp2_lut`/`log2_lut`. The transcendental calls that remain in the tree
(`powf` in `play_delta` and `parse.c`, `exp2f` in `patches.c`, `log2f` in
`pcm.c`, `expf`/`logf` in `midi_mappings.c`) are all on event, parse, patch-load
or note-on paths rather than per-block, so they do not cost steady-state CPU.
These filter generators were the last per-block transcendental users.

> Edit: For full disclosure, the change is not bit-identical: swapping `sinf`/`cosf` for
> the LUTs shifts six tests that exercise an HPF, a BPF, or the parametric EQ