### PR TITLE
Soft-float libcalls are afraid of f´s (sometimes). Added some in the render path to keep them away. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ HEADERS_BUILD := $(filter-out src/patches.h,$(HEADERS))
 PYTHONS = $(wildcard *.py)
 
 src/patches.h: $(PYTHONS) $(HEADERS_BUILD)
-	cat src/amy.h  | sed -e 's@^//.*@@' | egrep 'define +[^ ]+ +[.0-9-]+' | sed -e 's/\([.0-9]\)f$$/\1/' | awk '{print $$2 "=" $$3}' > amy/constants.py
+	cat src/amy.h  | sed -e 's@^//.*@@' | egrep 'define +[^ ]+ +[.0-9-]+' | sed -e 's/\([.0-9]\)f\([ 	]\|$$\)/\1\2/' | awk '{print $$2 "=" $$3}' > amy/constants.py
 	${PYTHON} -m amy.headers
 
 %.o: %.c $(HEADERS) src/patches.h

--- a/src/amy.c
+++ b/src/amy.c
@@ -263,7 +263,7 @@ void config_echo(uint8_t bus, float level, float delay_ms, float max_delay_ms, f
     amy_global.bus[bus]->echo.level = F2S(level);
     amy_global.bus[bus]->echo.delay_samples = delay_samples;
     // Filter is IIR [1, filter_coef] normalized for filter_coef > 0 (LPF), or FIR [1, filter_coef] normalized for filter_coef < 0 (HPF).
-    if (filter_coef > 0.99)  filter_coef = 0.99;  // Avoid unstable filters.
+    if (filter_coef > 0.99f)  filter_coef = 0.99f;  // Avoid unstable filters.
     amy_global.bus[bus]->echo.filter_coef = F2S(filter_coef);
     // FIR filter potentially has gain > 1 for high frequencies, so discount the loop feedback to stop things exploding.
     if (filter_coef < 0)  feedback /= 1.f - filter_coef;
@@ -1598,7 +1598,7 @@ void hold_and_modify(uint16_t osc) {
     float filter_logfreq = combine_controls(ctrl_inputs, synth[osc]->filter_logfreq_coefs);
     if (filter_logfreq < MIN_FILTER_LOGFREQ)  filter_logfreq = MIN_FILTER_LOGFREQ;
     if (AMY_IS_SET(msynth[osc]->last_filter_logfreq)) {
-        #define MAX_DELTA_FILTER_LOGFREQ_DOWN 3.0
+        #define MAX_DELTA_FILTER_LOGFREQ_DOWN 3.0f
         float last_logfreq = msynth[osc]->last_filter_logfreq;
         if (filter_logfreq < (last_logfreq - (MAX_DELTA_FILTER_LOGFREQ_DOWN / synth[osc]->resonance))) {
             // Filter cutoff downward slew-rate limit.

--- a/src/amy.h
+++ b/src/amy.h
@@ -205,7 +205,7 @@ extern void amy_set_gamma9001_pcm(const int16_t * data);
 
 // D is how close the sample gets to the clip limit before the nonlinearity engages.  
 // So D=0.1 means output is linear for -0.9..0.9, then starts clipping.
-#define CLIP_D 0.1
+#define CLIP_D 0.1f
 
 #define MAX_VOLUME 11.0
 
@@ -232,12 +232,12 @@ extern void amy_set_gamma9001_pcm(const int16_t * data);
 typedef int16_t output_sample_type;
 
 // Magic value for "0 Hz" in log-scale.
-#define ZERO_HZ_LOG_VAL -99.0
+#define ZERO_HZ_LOG_VAL -99.0f
 // Frequency of Midi note 0, used to make logfreq scales.
 // Have 0 be midi 69, A4, 440.0
-#define ZERO_LOGFREQ_IN_HZ 440.0  // 261.63
+#define ZERO_LOGFREQ_IN_HZ 440.0f  // 261.63
 #define ZERO_MIDI_NOTE 69  // 60
-#define MIN_FILTER_LOGFREQ -2.75  // -2.0  // LPF cutoff cannot go below w = 0.01 rad/samp in filters.c = 72 Hz, so clip it here at ~65 Hz.
+#define MIN_FILTER_LOGFREQ -2.75f  // -2.0  // LPF cutoff cannot go below w = 0.01 rad/samp in filters.c = 72 Hz, so clip it here at ~65 Hz.
 
 #define NUM_COMBO_COEFS 9  // 9 control-mixing params: const, note, velocity, env1, env2, mod, pitchbend, ext0, ext1
 enum coefs{

--- a/src/amy_fixedpoint.h
+++ b/src/amy_fixedpoint.h
@@ -245,8 +245,8 @@ static inline SAMPLE F2S_nofpu(float f) {
 // Convert between PHASOR and float
 // 1 << P_FRAC_BITS is 1 << 31 which actually flips to (-2^31).
 // So make the constant one less and do the last power of 2 in float.
-#define P2F(s) ((float)(s) / (2.0 * (float)(1 << (P_FRAC_BITS - 1))))
-#define F2P(f) ((PHASOR)((f) * 2.0 * (float)(1 << (P_FRAC_BITS - 1))))
+#define P2F(s) ((float)(s) / (2.0f * (float)(1 << (P_FRAC_BITS - 1))))
+#define F2P(f) ((PHASOR)((f) * 2.0f * (float)(1 << (P_FRAC_BITS - 1))))
 
 // Fixed-point multiply routines
 

--- a/src/envelope.c
+++ b/src/envelope.c
@@ -55,7 +55,7 @@ SAMPLE compute_breakpoint_scale(uint16_t osc, uint8_t bp_set, uint16_t sample_of
     int8_t bp_r = 0;
     t0 = 0; v0 = 0;
     // exp2(4.328085) = exp(3.0)
-    #define EXP_RATE_VAL -4.328085
+    #define EXP_RATE_VAL -4.328085f
     const SAMPLE exponential_rate = F2S(EXP_RATE_VAL);
     // We have to aim to overshoot to the desired gap so that we hit the target by exponential_rate time.
     const SAMPLE exponential_rate_overshoot_factor = F2S(1.0f / (1.0f - exp2f(EXP_RATE_VAL)));
@@ -150,7 +150,7 @@ SAMPLE compute_breakpoint_scale(uint16_t osc, uint8_t bp_set, uint16_t sample_of
         if(eg_type == ENVELOPE_LINEAR) {
             scale = v0 + MUL4_SS(v1 - v0, F2S(time_ratio));
         } else if(eg_type == ENVELOPE_TRUE_EXPONENTIAL || eg_type == ENVELOPE_DX7) {
-#define BREAKPOINT_EPS 0.0002
+#define BREAKPOINT_EPS 0.0002f
             v0 = MAX(v0, F2S(BREAKPOINT_EPS));
             v1 = MAX(v1, F2S(BREAKPOINT_EPS));
             if (eg_type == ENVELOPE_DX7) {
@@ -161,10 +161,10 @@ SAMPLE compute_breakpoint_scale(uint16_t osc, uint8_t bp_set, uint16_t sample_of
             if (eg_type == ENVELOPE_DX7 && (v1 > v0)) {
                 // Somewhat complicated relationship, see https://colab.research.google.com/drive/1qZmOw4r24IDijUFlel_eSoWEf3L5VSok#scrollTo=F5zkeACrOlum
                 // in SAMPLE version, DX7 levels are div 8 i.e. 0 to 12.375 instead of 0 to 99.
-#define LINEAR_SAMP_TO_DX7_LEVEL(samp) (S2F(log2_lut(MAX(F2S(BREAKPOINT_EPS), samp))) + 12.375)
-#define DX7_LEVEL_TO_LINEAR_SAMP(level) (exp2_lut(F2S(level - 12.375)))
-#define MIN_LEVEL_S 4.25
-#define ATTACK_RANGE_S 9.375
+#define LINEAR_SAMP_TO_DX7_LEVEL(samp) (S2F(log2_lut(MAX(F2S(BREAKPOINT_EPS), samp))) + 12.375f)
+#define DX7_LEVEL_TO_LINEAR_SAMP(level) (exp2_lut(F2S(level - 12.375f)))
+#define MIN_LEVEL_S 4.25f
+#define ATTACK_RANGE_S 9.375f
 #define MAP_ATTACK_LEVEL_S(level) (1 - MAX(level - MIN_LEVEL_S, 0) / ATTACK_RANGE_S)
                 SAMPLE mapped_current_level = F2S(MAP_ATTACK_LEVEL_S(LINEAR_SAMP_TO_DX7_LEVEL(v0)));
                 SAMPLE mapped_target_level = F2S(MAP_ATTACK_LEVEL_S(LINEAR_SAMP_TO_DX7_LEVEL(v1)));

--- a/src/filters.c
+++ b/src/filters.c
@@ -13,7 +13,7 @@
 
 
 // Filters tend to get weird under this ratio -- this corresponds to 4.4Hz 
-#define LOWEST_RATIO 0.0001
+#define LOWEST_RATIO 0.0001f
 
 #define FILT_NUM_DELAYS  4    // Need 4 memories for DFI filters, if used (only 2 for DFII).
 
@@ -36,11 +36,11 @@ int8_t dsps_biquad_gen_lpf_f32(SAMPLE *coeffs, float f, float qFactor)
 {
     //qFactor = sqrtf(qFactor);
     
-    if (qFactor < 0.51) {
-        qFactor = 0.51;
+    if (qFactor < 0.51f) {
+        qFactor = 0.51f;
     }
-    if (f > 0.45) {
-        f = 0.45;
+    if (f > 0.45f) {
+        f = 0.45f;
     }
     float Fs = 1;
 
@@ -49,7 +49,7 @@ int8_t dsps_biquad_gen_lpf_f32(SAMPLE *coeffs, float f, float qFactor)
     //float c = cosf(w0);
     //float s = sinf(w0);
     float w0 = f / Fs;
-    w0 = MAX(0.01f / (2 * M_PI) , w0);  // so f >= Fs * 0.01 / (2 pi) = 70.2 Hz
+    w0 = MAX(0.01f / (2 * (float)M_PI) , w0);  // so f >= Fs * 0.01 / (2 pi) = 70.2 Hz
     float c = cos2pi(w0);
     float s = sin2pi(w0);
 
@@ -71,7 +71,7 @@ int8_t dsps_biquad_gen_lpf_f32(SAMPLE *coeffs, float f, float qFactor)
     if (false && a2 > 0) { 
         printf("before: r %f a %f %f %f\n", sqrtf(a2 / a0), a0, a1, a2);
         // Limit how close complex poles can get to the unit circle.
-        r = MIN(0.99, sqrtf(a2 / a0));
+        r = MIN(0.99f, sqrtf(a2 / a0));
         float alphadash = (1 - r * r) / (1 + r * r);
         float cosww = c / sqrtf(1 - alphadash * alphadash);
         if (fabs(cosww) < 1.0) {
@@ -98,11 +98,11 @@ int8_t dsps_biquad_gen_lpf_f32(SAMPLE *coeffs, float f, float qFactor)
 
 int8_t dsps_biquad_gen_hpf_f32(SAMPLE *coeffs, float f, float qFactor)
 {
-    if (qFactor <= 0.0001) {
-        qFactor = 0.0001;
+    if (qFactor <= 0.0001f) {
+        qFactor = 0.0001f;
     }
-    if (f > 0.45) {
-        f = 0.45;
+    if (f > 0.45f) {
+        f = 0.45f;
     }
     float Fs = 1;
 
@@ -132,11 +132,11 @@ int8_t dsps_biquad_gen_hpf_f32(SAMPLE *coeffs, float f, float qFactor)
 
 int8_t dsps_biquad_gen_bpf_f32(SAMPLE *coeffs, float f, float qFactor)
 {
-    if (qFactor <= 0.0001) {
-        qFactor = 0.0001;
+    if (qFactor <= 0.0001f) {
+        qFactor = 0.0001f;
     }
-    if (f > 0.45) {
-        f = 0.45;
+    if (f > 0.45f) {
+        f = 0.45f;
     }
     float Fs = 1;
 

--- a/src/interp_partials.c
+++ b/src/interp_partials.c
@@ -143,7 +143,7 @@ float _logfreq_of_midi_cents(float midi_cents) {
 }
 
 float _env_lin_of_db(float db) {
-    float lin =  powf(10.f, MIN(20.f, (db - 100.f)) / 20.f) - 0.001;
+    float lin =  powf(10.f, MIN(20.f, (db - 100.f)) / 20.f) - 0.001f;
     if (lin < 0)  return 0;
     return lin;
 }

--- a/src/oscillators.c
+++ b/src/oscillators.c
@@ -49,7 +49,7 @@ const LUT *choose_from_lutset(float period, const LUT *lutset) {
         // proportionately.
         float interp_bandwidth = lut_bandwidth * lut_hop;
         //printf("period=%f freq=%f lut_size=%d interp_bandwidth=%f\n", period, ((float)AMY_SAMPLE_RATE)/period, lut_size, interp_bandwidth);
-        if (interp_bandwidth < 0.9) {
+        if (interp_bandwidth < 0.9f) {
             // No aliasing, even with a 10% buffer (i.e., 19.8 kHz).
             break;
         }
@@ -316,7 +316,7 @@ void pulse_mod_trigger(uint16_t osc) {
 SAMPLE compute_mod_pulse(uint16_t osc) {
     // do BW pulse gen at SR=44100/64
     SAMPLE sample;
-    if(msynth[osc]->duty < 0.001f || msynth[osc]->duty > 0.999) msynth[osc]->duty = 0.5;
+    if(msynth[osc]->duty < 0.001f || msynth[osc]->duty > 0.999f) msynth[osc]->duty = 0.5;
     if(synth[osc]->phase >= F2P(msynth[osc]->duty)) {
         sample = F2S(1.0f);
     } else {

--- a/src/parse.c
+++ b/src/parse.c
@@ -300,7 +300,7 @@ void parse_voices(char *message, uint16_t *vals) {
 uint32_t ms_to_samples(uint32_t ms) {
     uint32_t samps = 0;
     if (AMY_IS_UNSET(ms)) return AMY_UNSET_VALUE(samps);
-    samps = (uint32_t)(((float)ms / 1000.0) * (float)AMY_SAMPLE_RATE);
+    samps = (uint32_t)(((float)ms / 1000.0f) * (float)AMY_SAMPLE_RATE);
     return samps;
 }
 


### PR DESCRIPTION
# Suffix float literals to keep FP64 soft-float out of the render path
Follow up to #877. Surfaced during that pass. But required proper verification.

# What this changes

Adds `f` suffixes to float literals whose expressions were being evaluated in
`double`, plus one `(float)` cast on `M_PI`. No functional changes intended -
all 109 reference tests produce byte-identical error figures before and after.

Keeps FP64 libcall out of every `osc`

## Why

An unsuffixed literal like `2.0` promotes its expression to `double`. GCC can
usually fold the constant back to float, but not when the expression ends in
an integer cast - then the arithmetic stays in FP64, which on ESP32-class
targets means soft-float library calls.

The case that matters is in the fixed-point phasor conversions
(`amy_fixedpoint.h`):

```c
#define F2P(f) ((PHASOR)((f) * 2.0 * (float)(1 << (P_FRAC_BITS - 1))))
```

`PHASOR` is an integer, so the multiply chain runs in double:
`__extendsfdf2` + `__adddf3` + `__muldf3` + `__fixdfsi` on every use. Since
`AMY_USE_FIXEDPOINT` is the default build, this reached `render_sine`,
`render_fm_sine`, `render_lpf_lut`, `render_pcm`, `play_delta` and most of the
`compute_mod_*` family. The comment above the macro shows float was the intent
all along - the `2.0` is only there to avoid `1 << 31` overflowing an `int`.

The other edits are the same pattern in smaller doses:

| file | literals |
| --- | --- |
| `filters.c` | biquad clamps `0.0001`, `0.45`, `0.51`, `0.99`; `(float)M_PI` |
| `amy.h` | `ZERO_LOGFREQ_IN_HZ`, `ZERO_HZ_LOG_VAL`, `MIN_FILTER_LOGFREQ`, `CLIP_D` |
| `envelope.c` | `12.375`, `MIN_LEVEL_S`, `ATTACK_RANGE_S`, `BREAKPOINT_EPS`, `EXP_RATE_VAL` |
| `amy.c` | `MAX_DELTA_FILTER_LOGFREQ_DOWN`, the `0.99` filter-coef clamp |
| `oscillators.c` | `0.9`, `0.999` |
| `parse.c` | `1000.0` in `ms_to_samples` |
| `interp_partials.c` | `0.001` dB offset |

On `M_PI`: libc defines it as a `double`, so the `#ifndef M_PI` float fallback
in `filters.c` never fires and `0.01f / (2 * M_PI)` was evaluated in FP64.
That's the LPF residue noted in #877.

## Measured effect

Counting functions that call FP64 soft-float helpers, whole tree, built with
`xtensa-esp32s3-elf-gcc -O2 -DAMY_USE_FIXEDPOINT` (gcc 15.2.0):

**42 before, 10 after.**

The 10 remaining are all `__extendsfdf2` alone next to `printf`/`snprintf` -
the standard varargs float-to-double promotion, not arithmetic. No FP64
arithmetic remains in the audio path.


## Correctness

All 109 reference tests produce byte-identical error figures against an
unmodified build.

## Why the Makefile is included

The `src/patches.h` rule scrapes `#define`s from `src/amy.h` into
`amy/constants.py`, and its sed only strips a trailing `f` at end of line. A
suffixed define followed by a comment
(`#define ZERO_LOGFREQ_IN_HZ 440.0f  // 261.63`) would leak `440.0f` into
Python and break the build, so the sed now also handles a suffix followed by
whitespace.
