### PR TITLE
 Inline PIE asm in algorithms.c zero()/copy() [updated]

### DIFF
--- a/src/algorithms.c
+++ b/src/algorithms.c
@@ -74,13 +74,51 @@ const struct FmAlgorithm algorithms[33] = {
 
 // a = 0
 static inline void zero(SAMPLE* a) {
-    bzero((void *)a, AMY_BLOCK_SIZE * sizeof(SAMPLE));
+    const size_t nbytes = AMY_BLOCK_SIZE * sizeof(SAMPLE);
+#if defined(__XTENSA__) && defined(CONFIG_IDF_TARGET_ESP32S3)
+    // ESP32-S3 PIE: clear the FM-operator scratch block with a 128-bit vector
+    // store loop. This block clear/copy is the render path's one real PIE win
+    // (~10% on a 6-op FM voice); nothing else in AMY vectorizes (int32 SAMPLE has
+    // no 32-bit vector multiply, oscillators gather, filters recur). The scratch
+    // is 16-byte aligned (malloc_caps_block in algo_init) and nbytes is a compile
+    // -time multiple of 16, so the guard passes; anything unaligned falls to bzero.
+    if ((((uintptr_t)a | nbytes) & 15u) == 0) {
+        void *pp = a;  // ee.vst.128.ip post-increments the address register
+        __asm__ volatile(
+            "ee.xorq q0, q0, q0\n\t"
+            "loopnez %1, .Lamy_zero%=\n\t"
+            "ee.vst.128.ip q0, %0, 16\n"
+            ".Lamy_zero%=:"
+            : "+&r"(pp)
+            : "r"(nbytes / 16)
+            : "memory");
+        return;
+    }
+#endif
+    bzero((void *)a, nbytes);
 }
 
 
-// b = a 
+// b = a
 static inline void copy(SAMPLE* a, SAMPLE* b) {
-    bcopy((void *)a, (void *)b, AMY_BLOCK_SIZE * sizeof(SAMPLE));
+    const size_t nbytes = AMY_BLOCK_SIZE * sizeof(SAMPLE);
+#if defined(__XTENSA__) && defined(CONFIG_IDF_TARGET_ESP32S3)
+    // ESP32-S3 PIE: copy the block with paired 128-bit vector load/store (see zero()).
+    if ((((uintptr_t)a | (uintptr_t)b | nbytes) & 15u) == 0) {
+        const void *s = a;
+        void *d = b;
+        __asm__ volatile(
+            "loopnez %2, .Lamy_copy%=\n\t"
+            "ee.vld.128.ip q0, %1, 16\n\t"
+            "ee.vst.128.ip q0, %0, 16\n"
+            ".Lamy_copy%=:"
+            : "+&r"(d), "+&r"(s)
+            : "r"(nbytes / 16)
+            : "memory");
+        return;
+    }
+#endif
+    bcopy((void *)a, (void *)b, nbytes);
 }
 
 SAMPLE render_mod(SAMPLE *in, SAMPLE* out, uint16_t osc, SAMPLE feedback_level, uint16_t algo_osc, SAMPLE amp) {
@@ -143,7 +181,8 @@ void algo_init() {
     for(uint16_t i=0;i<AMY_CORES;i++) {
         scratch[i] = malloc_caps(sizeof(SAMPLE*)*3, amy_global.config.ram_caps_fbl);
         for(uint16_t j=0;j<3;j++) {
-            scratch[i][j] = malloc_caps(sizeof(SAMPLE)*AMY_BLOCK_SIZE, amy_global.config.ram_caps_fbl);
+            // 16-byte aligned so zero()/copy() take the ESP32-S3 PIE vector path.
+            scratch[i][j] = malloc_caps_block(sizeof(SAMPLE)*AMY_BLOCK_SIZE, amy_global.config.ram_caps_fbl);
         }
     }
 

--- a/src/algorithms.c
+++ b/src/algorithms.c
@@ -82,6 +82,14 @@ static inline void zero(SAMPLE* a) {
     // no 32-bit vector multiply, oscillators gather, filters recur). The scratch
     // is 16-byte aligned (malloc_caps_block in algo_init) and nbytes is a compile
     // -time multiple of 16, so the guard passes; anything unaligned falls to bzero.
+    //
+    // The aligned inner loop is the same one esp-dsp uses in dsps_memset_aes3.S /
+    // dsps_memcpy_aes3.S (Apache-2.0) - credit there for the approach. This is not
+    // a clean-room copy of those kernels, though: it carries none of their scalar
+    // head/tail machinery for unaligned buffers (which is most of their length),
+    // taking the vector path only for whole aligned blocks and deferring anything
+    // else to libc. Written compactly as original code (no lines copied), so it
+    // needs no separate .S file and keeps this source MIT with no vendored asm.
     if ((((uintptr_t)a | nbytes) & 15u) == 0) {
         void *pp = a;  // ee.vst.128.ip post-increments the address register
         __asm__ volatile(

--- a/src/algorithms.c
+++ b/src/algorithms.c
@@ -174,26 +174,23 @@ void algo_note_on(uint16_t osc, float freq) {
     }
 }
 
-SAMPLE *** scratch;
+// One contiguous allocation of AMY_CORES * 3 sample blocks (BUS_ONE, BUS_TWO,
+// SCRATCH per core), replacing a pointer-array-of-pointer-arrays. One malloc
+// instead of 1 + AMY_CORES * 4, and render_algo() reaches its buffers with
+// constant offsets instead of two dependent pointer loads.
+SAMPLE * scratch;
+
+#define SCRATCH_BLOCKS_PER_CORE 3
 
 void algo_deinit() {
-    for(uint16_t i=0;i<AMY_CORES;i++) {
-        for(uint16_t j=0;j<3;j++) free(scratch[i][j]);
-        free(scratch[i]);
-    }
     free(scratch);
 }
 
 void algo_init() {
-    scratch = malloc_caps(sizeof(SAMPLE**)*AMY_CORES, amy_global.config.ram_caps_fbl);
-    for(uint16_t i=0;i<AMY_CORES;i++) {
-        scratch[i] = malloc_caps(sizeof(SAMPLE*)*3, amy_global.config.ram_caps_fbl);
-        for(uint16_t j=0;j<3;j++) {
-            // 16-byte aligned so zero()/copy() take the ESP32-S3 PIE vector path.
-            scratch[i][j] = malloc_caps_block(sizeof(SAMPLE)*AMY_BLOCK_SIZE, amy_global.config.ram_caps_fbl);
-        }
-    }
-
+    // 16-byte aligned so zero()/copy() take the ESP32-S3 PIE vector path; each
+    // block stays aligned because AMY_BLOCK_SIZE*sizeof(SAMPLE) is a multiple of 16.
+    scratch = malloc_caps_block(sizeof(SAMPLE)*AMY_BLOCK_SIZE*SCRATCH_BLOCKS_PER_CORE*AMY_CORES,
+                                amy_global.config.ram_caps_fbl);
 }
 
 SAMPLE render_algo(SAMPLE* buf, uint16_t osc, uint8_t core) {
@@ -204,12 +201,12 @@ SAMPLE render_algo(SAMPLE* buf, uint16_t osc, uint8_t core) {
     SAMPLE* in_buf;
     SAMPLE* out_buf = NULL;
 
-    SAMPLE* const BUS_ONE = scratch[core][0];
-    SAMPLE* const BUS_TWO = scratch[core][1];
-    SAMPLE* const SCRATCH = scratch[core][2];
+    SAMPLE* const BUS_ONE = scratch + (SCRATCH_BLOCKS_PER_CORE * core) * AMY_BLOCK_SIZE;
+    SAMPLE* const BUS_TWO = BUS_ONE + AMY_BLOCK_SIZE;
+    SAMPLE* const SCRATCH = BUS_TWO + AMY_BLOCK_SIZE;
 
-    //for (int i = 0; i < 3; ++i)
-    //    zero(scratch[core][i]);
+    //for (int i = 0; i < SCRATCH_BLOCKS_PER_CORE; ++i)
+    //    zero(BUS_ONE + i * AMY_BLOCK_SIZE);
     
     SAMPLE amp = SHIFTR(F2S(msynth[osc]->amp), 2);  // Arbitrarily divide FM voice output by 4 to make it more in line with other oscs.
     for(uint8_t op=0;op<MAX_ALGO_OPS;op++) {

--- a/src/amy.c
+++ b/src/amy.c
@@ -199,6 +199,22 @@ output_sample_type * output_block;
     //fprintf(stderr, "malloc(%ld) @0x%lx\n", size, result);
     return result;
   }
+
+  // 16-byte-aligned allocator for the sample-block buffers the ESP32-S3 PIE
+  // clear/copy path walks (the FM-operator scratch used by zero()/copy() in
+  // algorithms.c). Alignment lets those take the 128-bit vector path instead of
+  // the bzero/bcopy fallback; it is a speed matter, never a correctness one.
+  // Kept separate from malloc_caps() because most AMY allocations are small
+  // structs and aligned allocation over-allocates per block. free(p) is
+  // unchanged: under IDF free() == heap_caps_free(), the correct deallocator
+  // for heap_caps_aligned_alloc (heap_caps_aligned_free is deprecated).
+  void * malloc_caps_block(uint32_t size, uint32_t flags) {
+  #if defined(ESP_PLATFORM) && defined(CONFIG_IDF_TARGET_ESP32S3)
+    return heap_caps_aligned_alloc(16, (size + 15u) & ~15u, flags);
+  #else
+    return malloc_caps(size, flags);
+  #endif
+  }
 #endif
 
 

--- a/src/amy.h
+++ b/src/amy.h
@@ -924,6 +924,7 @@ float portamento_ms_to_alpha(uint16_t portamento_ms);
 uint16_t alpha_to_portamento_ms(float alpha);
 int8_t check_init(amy_err_t (*fn)(), const char *name);
 void * malloc_caps(uint32_t size, uint32_t flags);
+void * malloc_caps_block(uint32_t size, uint32_t flags);
 void config_reverb(uint8_t bus, float level, float liveness, float damping, float xover_hz);
 void config_chorus(uint8_t bus, float level, uint16_t max_delay, float lfo_freq, float depth);
 void config_echo(uint8_t bus, float level, float delay_ms, float max_delay_ms, float feedback, float filter_coef);


### PR DESCRIPTION
### Update a96d574 following review

Hope this alligns with expressed intent.

- Scratch allocation flattened (suggested by @dpwe): `scratch` is now one
  contiguous 16-byte-aligned allocation of `AMY_CORES * 3` sample blocks
  instead of a `SAMPLE***` pointer-array-of-pointer-arrays. One malloc instead
  of `1 + AMY_CORES * 4`, `algo_deinit()` is a single `free()`, and
  `render_algo()` derives `BUS_ONE`/`BUS_TWO`/`SCRATCH` with constant offsets
  instead of two dependent pointer loads. Each interior block stays 16-byte
  aligned because `AMY_BLOCK_SIZE * sizeof(SAMPLE)` is a multiple of 16, so
  the PIE vector path is unaffected.

- Allocation count: on dual-core, algo scratch drops from 9 heap allocations
  to 1. Fewer per-block heap headers, and aligned allocation over-allocates
  per call, so one aligned block means less padding.
- Fragmentation: S3 is notorious for heap fragmentation.
  One long-lived block claimed at init instead of nine small
  ones interleaved with whatever else allocates at startup - friendlier to
  heap.

*Note about IDF allocator quirk*
> **The "Largest Heap First" Allocator Flaw**
>A known quirk in the ESP-IDF capability allocator exacerbates this issue. By default, standard malloc calls aggressively target the largest available free block first. If your application makes dozens of small allocations (like a single string or JSON token), they are placed directly into your primary 200 KB pool instead of filling up the 20 KB or 32 KB pools first. This rapidly shreds the only block capable of handling large buffers.


- Lifecycle: `algo_deinit()` is a single `free()` - no partial-teardown
  states..
- Shape: `SAMPLE*` with constant offsets instead of `SAMPLE***` - the
  layout (`BUS_ONE | BUS_TWO | SCRATCH` per core, contiguous) is visible in
  the code, and the single base alignment guarantee covers every block.

---

### Original


Implements the ESP32-S3 PIE block clear/copy from #889, in the inline shape we
agreed on there: inline asm inside `algorithms.c`'s `zero()`/`copy()`, gated on
`__XTENSA__ && CONFIG_IDF_TARGET_ESP32S3`, falling back to `bzero`/`bcopy`
everywhere else. No new source files, no `.S`, no vendored assembly.

**What**
- `zero()`/`copy()`: 128-bit `ee.vst.128` / `ee.vld.128` loop for the FM
  operator scratch on the S3; libc fallback for unaligned or non-S3.
- `malloc_caps_block()` (in `amy.c`): 16-byte-aligned allocator so the scratch
  takes the vector path. Aligned-only by design - unaligned just uses libc.


**Provenance**: the aligned inner loop follows esp-dsp's
`dsps_memset_aes3.S` / `dsps_memcpy_aes3.S` approach, but is original code (no
lines copied) and omits their scalar head/tail handling entirely - so it needs
no `.S` file no extra apache license.

*(Though I would love if someone more experienced with licenses
could take a look to be sure - the comment above the inline asm
lays out the specifics)*

---

240 MHz · fixed · 48000 Hz / block 256 · free pacing · 5 captures/side · 3 passes · block budget 5333 us

| Scene | A cyc | B cyc | delta | noise | headroom | verdict |
|---|---:|---:|---:|---:|---|---|
| juno6 | 1,159,437 | 1,157,434 | -0.17% | ±0.01% | 9.4% -> 9.6% | small |
| dx76 | 765,569 | 688,524 | **-10.06%** | ±0.01% | 40.2% -> 46.2% | IMPROVEMENT |
| saw_lpf6 | 442,455 | 442,322 | -0.03% | ±0.01% | 65.4% -> 65.5% | small |
| fx_sine8 | 386,551 | 386,941 | +0.10% | ±0.00% | 69.8% -> 69.8% | small |
| sine8 | 162,846 | 163,735 | **+0.55%** | ±0.01% | 87.3% -> 87.2% | REGRESSION(Layout) | 
| pcm4 | 141,812 | 141,886 | +0.05% | ±0.02% | 88.9% -> 88.9% | small |
| idle | 34,967 | 34,964 | -0.01% | ±0.00% | 97.3% -> 97.3% | small |

**7 scenes: 1 improved, 1 regressed(layout variance), 5 inconclusive** (within noise, below threshold, or unjudgeable).

