### PR TITLE
Add amy_external_midi_output_hook to catch AMY's MIDI out

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -183,6 +183,7 @@ Hook fields in `amy_config_t`:
 | `amy_external_coef_hook` | `float (uint16_t channel)` | — | Provide external coefficient values (e.g. CV input). |
 | `amy_external_block_done_hook` | `void (void)` | — | Called after each audio block is rendered. |
 | `amy_external_midi_input_hook` | `void (uint8_t *bytes, uint16_t len, uint8_t is_sysex)` | — | Called when MIDI bytes are received. |
+| `amy_external_midi_output_hook` | `void (uint8_t *bytes, uint16_t len)` | — | Called with every run of bytes AMY sends over MIDI out (notes, clock, sysex responses), before — and regardless of — any device interface configured in `midi`. Use it to forward AMY's MIDI output to a transport AMY doesn't drive itself, e.g. BLE MIDI. May be called from the render/sequencer task; keep it fast. |
 | `amy_external_sequencer_hook` | `void (uint32_t tick_count)` | — | Called on each sequencer tick. |
 | `amy_external_fopen_hook` | `uint32_t (char *filename, const char *mode)` | `zT`, `zD`, `zF` | Open a file on host disk. Returns opaque handle. |
 | `amy_external_fwrite_hook` | `uint32_t (uint32_t fptr, uint8_t *bytes, uint32_t len)` | `zT` | Write bytes to a file opened via fopen hook. |

--- a/src/amy.h
+++ b/src/amy.h
@@ -734,6 +734,11 @@ typedef struct  {
     float (*amy_external_coef_hook)(uint16_t channel);
     void (*amy_external_block_done_hook)(void);
     void (*amy_external_midi_input_hook)(uint8_t *bytes, uint16_t len, uint8_t is_sysex);
+    // Called with every run of bytes AMY sends out over MIDI, before (and
+    // regardless of) any device interface configured in `midi`, so hosts can
+    // forward AMY's MIDI output to transports AMY doesn't drive itself (e.g.
+    // BLE MIDI).  May be called from the render/sequencer task; keep it fast.
+    void (*amy_external_midi_output_hook)(uint8_t *bytes, uint16_t len);
     void (*amy_external_sequencer_hook)(uint32_t tick_count);
     uint32_t (*amy_external_fopen_hook)(char *filename, const char *mode);
     uint32_t (*amy_external_fwrite_hook)(uint32_t fptr, uint8_t *bytes, uint32_t len);

--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -445,6 +445,16 @@ void amy_external_midi_output(uint8_t * data, uint32_t len) {
     midi_out(data, len);
 }
 
+// Deliver outgoing MIDI bytes to the host's output hook, if set. Every
+// midi_out() implementation (including host-owned ones like macos_midi.m)
+// calls this first, so the hook sees everything AMY sends even when no
+// device interface is configured in amy_global.config.midi.
+void midi_out_external_hook(uint8_t * bytes, uint16_t len) {
+    if(amy_global.config.amy_external_midi_output_hook != NULL) {
+        amy_global.config.amy_external_midi_output_hook(bytes, len);
+    }
+}
+
 
 ///// Per platform MIDI in and out stuff
 ///////////////////////////////////////////////
@@ -459,6 +469,7 @@ void stop_midi() {
 }
 
 void midi_out(uint8_t * bytes, uint16_t len) {
+    midi_out_external_hook(bytes, len);
     EM_ASM(
             if(midiOutputDevice != null) {
                 midiOutputDevice.send(HEAPU8.subarray($0, $0 + $1));
@@ -709,6 +720,7 @@ void run_midi() {
 #endif
 
 void midi_out(uint8_t * bytes, uint16_t len) {
+    midi_out_external_hook(bytes, len);
 
 // Is there USB gadget midi? Send it
 #if defined TUD_USB_GADGET

--- a/src/amy_midi.h
+++ b/src/amy_midi.h
@@ -84,6 +84,9 @@ extern int16_t midi_queue_tail;
 extern int16_t midi_queue_head;
 
 void midi_out(uint8_t * bytes, uint16_t len);
+// Calls amy_config's amy_external_midi_output_hook if set; every midi_out()
+// implementation calls this first so hosts can catch AMY's MIDI output.
+void midi_out_external_hook(uint8_t * bytes, uint16_t len);
 void midi_local(uint8_t * bytes, uint16_t len);
 void amy_send_midi_note_off(uint16_t osc);
 void amy_send_midi_note_on(uint16_t osc);

--- a/src/api.c
+++ b/src/api.c
@@ -24,6 +24,7 @@ amy_config_t amy_default_config() {
     c.amy_external_coef_hook = NULL;
     c.amy_external_block_done_hook = NULL;
     c.amy_external_midi_input_hook = NULL;
+    c.amy_external_midi_output_hook = NULL;
     c.amy_external_sequencer_hook = NULL;
     c.amy_external_fopen_hook = NULL;
     c.amy_external_fwrite_hook = NULL;

--- a/src/macos_midi.m
+++ b/src/macos_midi.m
@@ -43,6 +43,7 @@ static uint8_t midi_status_len(uint8_t status) {
 
 
 void midi_out(uint8_t * bytes, uint16_t len) {
+    midi_out_external_hook(bytes, len);
     if (@available(macOS 11, *))  {
         MIDIPacketList pl;
         MIDIPacket *p;


### PR DESCRIPTION
Fixes #895

Adds `amy_config.amy_external_midi_output_hook`, mirroring the existing `amy_external_midi_input_hook`, so hosts can catch everything AMY sends over MIDI out and forward it to transports AMY doesn't drive itself — e.g. BLE MIDI on a custom ESP32-S3 board, as requested in the issue.

```c
void my_midi_out_hook(uint8_t *bytes, uint16_t len) {
    // e.g. forward to BT MIDI out
}

amy_config_t amy_config = amy_default_config();
amy_config.amy_external_midi_output_hook = my_midi_out_hook;
amy_start(amy_config);
```

## How it works

- New `midi_out_external_hook()` helper in `amy_midi.c` (platform-neutral section) calls the config hook if set.
- Every in-repo `midi_out()` implementation calls it first, **before — and regardless of — any device interface configured in `config.midi`**: the MCU/device layer (UART / USB gadget), the emscripten/WebMIDI build, and `macos_midi.m`. So the hook fires even with no serial MIDI out pin configured, per the issue.
- The hook sees all of AMY's MIDI output: note on/off forwarding, realtime clock (0xF8/0xFA/0xFC), and sysex responses (`zD` dumps, transfer frames).
- Hosts that own the whole MIDI layer (`AMY_HOST_MIDI`, e.g. the VCV plugin) define their own `midi_out` and can call the helper themselves; nothing changes for them by default.
- Defaults to `NULL` in `amy_default_config()`; documented in `docs/api.md`. Godot builds are unaffected (`amy_midi.c`/`macos_midi.m` are excluded there and nothing in the stubs references the helper).

Verified with a clean macOS desktop build (`make`), which compiles the neutral `amy_midi.c` section, `macos_midi.m`, and the new config field together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)