### PR TITLE
HW CI: average 3 capture runs per build to cut bench noise

### DIFF
--- a/.github/workflows/amy-hwci.yml
+++ b/.github/workflows/amy-hwci.yml
@@ -3,9 +3,10 @@ name: AMY HW CI
 # Hardware half of AMY's CI, replacing the old cross-repo dispatch to the
 # tulipcc bench: flash THIS PR's LoadTestChord firmware (built and uploaded as
 # an artifact by "AMY HW CI build") onto the physical AMYboard on the
-# self-hosted bench Pi (amyboardci), capture 20 s of its debug UART while the
+# self-hosted bench Pi (amyboardci), capture three 20 s runs of its debug
+# UART (flash once, reset between runs) while the
 # sketch stacks up an 8-note held Juno chord, and comment the measured render
-# load at each chord size back on the PR.
+# load at each chord size — averaged across the runs — back on the PR.
 #
 # PASS/FAIL semantics: FAIL means only that the bench COULD NOT RUN the test
 # (flash/serial failure, board crash, capture interference). The load values
@@ -119,11 +120,12 @@ jobs:
             --port /dev/amyboard-dongle \
             --esptool ~/hwci-venv/bin/esptool \
             --seconds 20 \
+            --runs 3 \
             --label "pr${PR}-base" \
             --meta "{\"pr\": ${PR}, \"sha\": \"${BASE_SHA}\"}" \
             2>&1 | tee out-base/run.log || true
 
-      - name: Flash + capture 20 s of render load (this PR)
+      - name: Flash + capture 3 x 20 s of render load (this PR)
         id: measure
         continue-on-error: true   # the verdict is hwci_report.py's, below
         env:
@@ -136,6 +138,7 @@ jobs:
             --port /dev/amyboard-dongle \
             --esptool ~/hwci-venv/bin/esptool \
             --seconds 20 \
+            --runs 3 \
             --label "pr${PR}" \
             --meta "{\"pr\": ${PR}, \"sha\": \"${SHA}\"}" \
             2>&1 | tee out/run.log
@@ -157,12 +160,12 @@ jobs:
           name: amy-hwci-pr${{ env.PR }}
           if-no-files-found: warn
           path: |
-            out/serial.log
-            out/load.csv
+            out/serial*.log
+            out/load*.csv
             out/meta.json
             out/run.log
-            out-base/serial.log
-            out-base/load.csv
+            out-base/serial*.log
+            out-base/load*.csv
             out-base/meta.json
             out-base/run.log
             report.md
@@ -182,7 +185,7 @@ jobs:
               marker,
               '### 🎛️ AMY HW CI (AMYboard bench)',
               '',
-              "Flashed this PR's AMY (LoadTestChord: 6-voice Juno `patch=1`, one held note every 2 s) onto the physical AMYboard and measured the smoothed render load as the chord grows — back-to-back with the same sketch built at the PR's merge base, so Δ is this PR's own cost.",
+              "Flashed this PR's AMY (LoadTestChord: 6-voice Juno `patch=1`, one held note every 2 s) onto the physical AMYboard and measured the smoothed render load as the chord grows — back-to-back with the same sketch built at the PR's merge base, so Δ is this PR's own cost. Each build is flashed once and captured 3 times (board reset between runs); the numbers are per-run means.",
               '',
               report,
               '',

--- a/tools/arduino_loadsweep/README.md
+++ b/tools/arduino_loadsweep/README.md
@@ -23,6 +23,11 @@ The root-level amy/Makefile has a `speedtest` rule that:
  * Write `results/<idx>_<date>_<sha>/` with `load.csv`, `serial.log`,
    `meta.json`.
 
+`measure.py --runs N` flashes once, then resets the board and re-captures N
+times (`loadK.csv`/`serialK.log` for runs 2+); `meta.json` records per-run
+stats under `runs` and the top-level numbers become the cross-run mean, to
+average out run-to-run noise.
+
 ## Usage
 
 ```sh
@@ -42,7 +47,8 @@ Two consecutive flash failures abort the sweep on the assumption the bench
 The same sketch + `measure.py` also power AMY's per-PR hardware CI
 (`.github/workflows/amy-hwci-build.yml` builds the firmware in the cloud —
 the PR *and* a baseline at its merge base; `amy-hwci.yml` flashes both
-back-to-back on the self-hosted bench Pi and comments a before/after/Δ
+back-to-back on the self-hosted bench Pi — each with `--runs 3`, so every
+number is a 3-run mean — and comments a before/after/Δ
 load table on the PR, formatted by `hwci_report.py`).
 CI **FAIL means only that the PR's test couldn't run** — load values and a
 failed baseline are informational there; regression *hunting* is this

--- a/tools/arduino_loadsweep/hwci_report.py
+++ b/tools/arduino_loadsweep/hwci_report.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """Turn measure.py output dirs into the AMY HW CI markdown report + verdict.
 
-Reads <outdir>/{meta.json,load.csv} written by measure.py after a LoadTestChord
-run (one held Juno note added every 2 s until an 8-note chord) and prints a
-markdown report to stdout: the smoothed render load at each chord size, plus
-the settled full-chord load.  With --base <dir> (a second measure.py run of
-the same sketch built against the PR's merge base) the table gains
-before/after columns and a delta, so the PR's own load cost is visible
-directly.
+Reads <outdir>/{meta.json,load*.csv} written by measure.py after a
+LoadTestChord run (one held Juno note added every 2 s until an 8-note chord)
+and prints a markdown report to stdout: the smoothed render load at each
+chord size, plus the settled full-chord load.  When measure.py captured
+several runs (--runs N: flash once, reset + re-capture), each chord size's
+load is the MEAN across the clean runs and the report also shows the per-run
+full-chord values so run-to-run noise is visible.  With --base <dir> (a
+second measure.py run of the same sketch built against the PR's merge base)
+the table gains before/after columns and a delta, so the PR's own load cost
+is visible directly.
 
 Exit code is the HW CI verdict for the PR run only: 0 if the test RAN
 (flashed, all 8 notes were sent, load samples arrived for the whole capture),
@@ -26,42 +29,18 @@ import os
 import sys
 
 
-def analyze(outdir):
-    """Read one measure.py output dir -> {meta, rows, notes, loads, problems}.
-
-    loads maps note index i (0-based) -> the settled load for that chord
-    size: the last 2 Hz sample before the next note joins.
-    """
-    problems = []
-    meta, rows = {}, []
+def read_rows(outdir, name):
     try:
-        meta = json.load(open(os.path.join(outdir, "meta.json")))
-    except (OSError, ValueError):
-        problems.append("no meta.json — measure.py died before writing results")
-    try:
-        with open(os.path.join(outdir, "load.csv")) as f:
-            rows = [(float(r["t_s"]), int(r["load"]))
+        with open(os.path.join(outdir, name)) as f:
+            return [(float(r["t_s"]), int(r["load"]))
                     for r in csv.DictReader(f)]
     except OSError:
-        pass
+        return []
 
-    errors = meta.get("errors", [])
-    for e in errors:
-        # "interference on attempt 1" alone means the retry succeeded
-        if (e == "interference on attempt 1" and rows
-                and "interference on attempt 2" not in errors):
-            continue
-        problems.append(e)
-    notes = meta.get("notes", [])
-    if not rows and not any("RENDER_LOAD" in p for p in problems):
-        problems.append("no RENDER_LOAD lines captured")
-    if rows and len(notes) < 6:
-        problems.append(f"only {len(notes)}/6 notes were played")
-    if meta.get("board_crashed"):
-        problems.append("board crashed during the run (panic/watchdog reboot)")
-    if meta.get("serial_died_early"):
-        problems.append("serial output stopped early (crash/wedge?)")
 
+def settled_loads(rows, notes):
+    """note index i (0-based) -> the settled load for that chord size:
+    the last 2 Hz sample before the next note joins."""
     loads = {}
     for i, n in enumerate(notes):
         end = notes[i + 1]["t_s"] if i + 1 < len(notes) else None
@@ -69,7 +48,69 @@ def analyze(outdir):
                   (end is None or t < end)]
         if window:
             loads[n["i"]] = window[-1]
-    return {"meta": meta, "rows": rows, "notes": notes, "loads": loads,
+    return loads
+
+
+def run_problems(run, rows):
+    """Problems for one capture run (run: per-run dict from meta.json,
+    or a pre---runs meta.json acting as its own single run)."""
+    problems = []
+    errors = run.get("errors", [])
+    for e in errors:
+        # "interference on attempt 1" alone means the retry succeeded
+        if (e == "interference on attempt 1" and rows
+                and "interference on attempt 2" not in errors):
+            continue
+        problems.append(e)
+    notes = run.get("notes", [])
+    if not rows and not any("RENDER_LOAD" in p for p in problems):
+        problems.append("no RENDER_LOAD lines captured")
+    if rows and len(notes) < 6:
+        problems.append(f"only {len(notes)}/6 notes were played")
+    if run.get("board_crashed"):
+        problems.append("board crashed during the run (panic/watchdog reboot)")
+    if run.get("serial_died_early"):
+        problems.append("serial output stopped early (crash/wedge?)")
+    return problems
+
+
+def analyze(outdir):
+    """Read one measure.py output dir -> {meta, notes, loads, finals,
+    has_rows, problems}.
+
+    measure.py may have captured several runs of the flashed build (--runs:
+    flash once, reset + re-capture); loads then maps note index i -> the MEAN
+    settled load across the clean runs, and finals lists each clean run's
+    full-chord settled load.
+    """
+    problems = []
+    meta = {}
+    try:
+        meta = json.load(open(os.path.join(outdir, "meta.json")))
+    except (OSError, ValueError):
+        problems.append("no meta.json — measure.py died before writing results")
+    run_metas = meta.get("runs") or [meta]   # old meta = its own single run
+    multi = len(run_metas) > 1
+
+    per_run_loads, finals, has_rows = [], [], False
+    for k, rm in enumerate(run_metas):
+        rows = read_rows(outdir, rm.get("load_csv", "load.csv"))
+        has_rows = has_rows or bool(rows)
+        pfx = f"run {k + 1}: " if multi else ""
+        problems += [pfx + p for p in run_problems(rm, rows)]
+        if rm.get("interfered"):
+            continue                    # trace invalid — keep out of the means
+        loads = settled_loads(rows, rm.get("notes", []))
+        if loads:
+            per_run_loads.append(loads)
+        if rm.get("render_us_final") is not None:
+            finals.append(rm["render_us_final"])
+
+    loads = {i: round(sum(lk[i] for lk in per_run_loads if i in lk) /
+                      sum(1 for lk in per_run_loads if i in lk))
+             for i in {i for lk in per_run_loads for i in lk}}
+    return {"meta": meta, "has_rows": has_rows, "notes": meta.get("notes", []),
+            "loads": loads, "finals": finals,
             "problems": list(dict.fromkeys(problems))}
 
 
@@ -102,7 +143,7 @@ def main():
     with_base = bool(base and base["loads"])
 
     lines = []
-    if pr["rows"] and pr["notes"]:
+    if pr["has_rows"] and pr["notes"]:
         if with_base:
             lines += [f"| notes held | {base_col} | this PR | Δ |",
                       "|---:|---:|---:|---:|"]
@@ -130,8 +171,18 @@ def main():
                       if final is not None and bfinal is not None else None)
             headline += (f" (was {fmt(bfinal)}, Δ {fmtpct(bdelta, signed=True)})")
         headline += (f"** (peak {fmt(maxl)}, "
-                     f"{pr['meta'].get('n_samples', 0)} samples)")
+                     f"{pr['meta'].get('n_samples', 0)} samples"
+                     + (f", mean of {len(pr['finals'])} runs"
+                        if len(pr["finals"]) > 1 else "") + ")")
         lines.append(headline)
+
+        if len(pr["finals"]) > 1:
+            sub = ("<sub>per-run full-chord &mu;s — this PR: "
+                   + " / ".join(str(v) for v in pr["finals"]))
+            if with_base and len(base["finals"]) > 1:
+                sub += (f" · {base_col}: "
+                        + " / ".join(str(v) for v in base["finals"]))
+            lines += ["", sub + "</sub>"]
 
     if base and base["problems"]:
         lines += ["", "_Baseline run "

--- a/tools/arduino_loadsweep/measure.py
+++ b/tools/arduino_loadsweep/measure.py
@@ -12,6 +12,13 @@ t=0, then tails the same UART for the `RENDER_LOAD ms=<ms> load=<0..1>`
 lines that patch_render_load.py adds and the `NOTE i=<n> ...` markers the
 sketch prints.  Writes <out>/{load.csv,serial.log,meta.json}.
 
+With --runs N (default 1) the board is flashed ONCE, then reset and
+re-captured N times, to average out run-to-run noise.  Run 1 writes
+load.csv/serial.log as before; runs 2..N add loadK.csv/serialK.log.
+meta.json gains a "runs" list with each run's stats, and the top-level
+render_us_final/render_us_max/n_samples become the cross-run mean / max /
+total over the clean (non-interfered) runs.
+
 A wedged/crashed board (prints stop early) is flagged in meta.json as
 serial_died_early; the next run's esptool handshake recovers it via DTR/RTS.
 Requires pyserial and an installed esp32:esp32 arduino core (for esptool).
@@ -165,6 +172,9 @@ def main():
                          "esp32 core)")
     ap.add_argument("--baud", type=int, default=115200, help="console baud")
     ap.add_argument("--seconds", type=float, default=20.0)
+    ap.add_argument("--runs", type=int, default=1,
+                    help="capture runs to average: flash once, then reset "
+                         "the board and re-capture this many times")
     ap.add_argument("--label", default=None)
     ap.add_argument("--meta", default=None,
                     help="JSON string of extra fields for meta.json")
@@ -178,8 +188,7 @@ def main():
 
     acquire_bench(args.port)
 
-    lines = None
-    for attempt in (1, 2):
+    def flash_or_die():
         err = upload(args.build_dir, args.port, args.flash_baud, args.esptool)
         if err:
             meta["errors"].append("upload failed")
@@ -188,61 +197,96 @@ def main():
                       indent=1)
             print(err)
             sys.exit("[flash] upload failed twice")
-
         time.sleep(1.0)   # let esptool's post-flash reset settle before re-open
-        print(f"[capture] {args.seconds:.0f}s on {args.port}")
-        lines = capture(args.port, args.baud, args.seconds)
-        if not any(RESET_SIG.search(l) and ts > 2.0 for ts, l in lines):
-            break
-        print("[capture] board was reset mid-capture (external interference?)"
-              f" — {'retrying' if attempt == 1 else 'giving up'}")
-        meta["errors"].append(f"interference on attempt {attempt}")
-    else:
-        with open(os.path.join(args.out, "serial.log"), "w") as f:
+
+    flash_or_die()
+
+    runs = []
+    for k in range(args.runs):
+        tag = "" if k == 0 else str(k + 1)
+        run = {"run": k + 1, "load_csv": f"load{tag}.csv",
+               "serial_log": f"serial{tag}.log", "errors": []}
+        for attempt in (1, 2):
+            print(f"[capture] run {k + 1}/{args.runs}: "
+                  f"{args.seconds:.0f}s on {args.port}")
+            lines = capture(args.port, args.baud, args.seconds)
+            if not any(RESET_SIG.search(l) and ts > 2.0 for ts, l in lines):
+                break
+            print("[capture] board was reset mid-capture (external "
+                  "interference?) — "
+                  f"{'retrying' if attempt == 1 else 'giving up'}")
+            run["errors"].append(f"interference on attempt {attempt}")
+            if attempt == 1:
+                flash_or_die()   # the interferer may have reflashed the board
+        # A doubly-interfered run's trace is invalid: keep its logs but drop
+        # it from the averages (hwci_report still surfaces the errors).
+        run["interfered"] = "interference on attempt 2" in run["errors"]
+
+        with open(os.path.join(args.out, run["serial_log"]), "w") as f:
             for ts, line in lines:
                 f.write(f"{ts:8.3f} {line}\n")
-        json.dump(meta, open(os.path.join(args.out, "meta.json"), "w"), indent=1)
-        sys.exit("[capture] interference on both attempts")
 
-    with open(os.path.join(args.out, "serial.log"), "w") as f:
+        rows, notes = [], []
         for ts, line in lines:
-            f.write(f"{ts:8.3f} {line}\n")
+            m = RL.search(line)
+            if m:
+                rows.append((round(ts, 3), int(m.group(1)), int(m.group(2))))
+            m = NOTE.search(line)
+            if m:
+                notes.append({"t_s": round(ts, 3), "i": int(m.group(1)),
+                              "note": int(m.group(2)),
+                              "board_ms": int(m.group(3))})
 
-    rows, notes = [], []
-    for ts, line in lines:
-        m = RL.search(line)
-        if m:
-            rows.append((round(ts, 3), int(m.group(1)), int(m.group(2))))
-        m = NOTE.search(line)
-        if m:
-            notes.append({"t_s": round(ts, 3), "i": int(m.group(1)),
-                          "note": int(m.group(2)), "board_ms": int(m.group(3))})
+        with open(os.path.join(args.out, run["load_csv"]), "w",
+                  newline="") as f:
+            w = csv.writer(f)
+            w.writerow(["t_s", "board_ms", "load"])
+            w.writerows(rows)
 
-    with open(os.path.join(args.out, "load.csv"), "w", newline="") as f:
-        w = csv.writer(f)
-        w.writerow(["t_s", "board_ms", "load"])
-        w.writerows(rows)
+        run["n_samples"] = len(rows)
+        run["notes"] = notes
+        if any(CRASH_SIG.search(l) and ts > 2.0 for ts, l in lines):
+            run["board_crashed"] = True
+            print("[result] board CRASHED during run (panic/watchdog reboot)")
+        if rows:
+            run["render_us_max"] = max(r[2] for r in rows)
+            run["last_sample_t"] = rows[-1][0]
+            final = [r[2] for r in rows if r[0] >= args.seconds - 3.0]
+            run["render_us_final"] = (round(sum(final) / len(final))
+                                      if final else None)
+            if rows[-1][0] < args.seconds - 3.0:
+                run["serial_died_early"] = True   # prints stopped: crash/wedge
+        else:
+            run["errors"].append("no RENDER_LOAD lines captured")
+        print(f"[result] run {k + 1}: {len(rows)} samples, {len(notes)} notes,"
+              f" max={run.get('render_us_max')},"
+              f" final={run.get('render_us_final')}"
+              f"{'  DIED EARLY' if run.get('serial_died_early') else ''}")
+        runs.append(run)
 
-    meta["n_samples"] = len(rows)
-    meta["notes"] = notes
-    if any(CRASH_SIG.search(l) and ts > 2.0 for ts, l in lines):
+    # Top-level fields keep their single-run meaning, now over the clean runs:
+    # mean final, max peak, total samples, first good run's note markers.
+    meta["runs"] = runs
+    good = [r for r in runs if not r["interfered"]]
+    meta["notes"] = next((r["notes"] for r in good if r["notes"]), [])
+    meta["n_samples"] = sum(r["n_samples"] for r in good)
+    for key, agg in (("render_us_max", max),
+                     ("render_us_final", lambda v: round(sum(v) / len(v)))):
+        vals = [r[key] for r in good if r.get(key) is not None]
+        meta[key] = agg(vals) if vals else None
+    if any(r.get("board_crashed") for r in runs):
         meta["board_crashed"] = True
-        print("[result] board CRASHED during run (panic/watchdog reboot)")
-    if rows:
-        meta["render_us_max"] = max(r[2] for r in rows)
-        meta["last_sample_t"] = rows[-1][0]
-        final = [r[2] for r in rows if r[0] >= args.seconds - 3.0]
-        meta["render_us_final"] = round(sum(final) / len(final)) if final else None
-        if rows[-1][0] < args.seconds - 3.0:
-            meta["serial_died_early"] = True   # prints stopped: crash/wedge
-    else:
-        meta["errors"].append("no RENDER_LOAD lines captured")
-    print(f"[result] {len(rows)} samples, {len(notes)} notes, "
-          f"max={meta.get('render_us_max')}, final={meta.get('render_us_final')}"
-          f"{'  DIED EARLY' if meta.get('serial_died_early') else ''}")
+    if any(r.get("serial_died_early") for r in runs):
+        meta["serial_died_early"] = True
+    meta["errors"] += [e if args.runs == 1 else f"run {r['run']}: {e}"
+                       for r in runs for e in r["errors"]]
+    if args.runs > 1:
+        finals = [str(r.get("render_us_final")) for r in good]
+        print(f"[result] mean final over {len(good)} clean runs: "
+              f"{meta['render_us_final']}  ({'/'.join(finals) or '-'})")
 
     json.dump(meta, open(os.path.join(args.out, "meta.json"), "w"), indent=1)
-    return 0 if rows else 1
+    return 0 if all(r["n_samples"] and not r["interfered"] for r in runs) else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Back-to-back HW CI runs of effectively no-op PRs have been showing full-chord render µs deltas of ~±33 (e.g. #896), which is bench noise, not the PR's cost. This makes each bench measurement the mean of 3 runs: **flash once, capture 20 s, reset the board, capture again — 3×** — for both the PR build and its merge-base baseline.

## Changes

- **`measure.py --runs N`**: flashes once, then resets and re-captures N times (LoadTestChord restarts its chord sequence on reset, and `capture()` already pulses RTS at t=0, so no re-flash is needed). Run 1 keeps `load.csv`/`serial.log`; runs 2+ add `loadK.csv`/`serialK.log`. `meta.json` gains a per-run `runs` list, and the top-level `render_us_final`/`render_us_max`/`n_samples` become the mean/max/total over the clean runs. A run that gets doubly hit by external bench interference keeps its logs but is dropped from the averages (and still FAILs the verdict, as before). Default is `--runs 1`, so `make speedtest` and the sweep are unchanged.
- **`hwci_report.py`**: averages each chord size's settled load across the clean runs, prefixes per-run problems with `run N:`, and adds a per-run full-chord line to the PR comment so run-to-run spread is visible at a glance:

  > **Full chord settled render µs: 1610 (was 1555, Δ +3.5%)** (peak 1640, 117 samples, mean of 3 runs)
  >
  > <sub>per-run full-chord µs — this PR: 1600 / 1600 / 1630 · main @ abc1234: 1550 / 1560 / 1555</sub>

  Old single-run `meta.json` files (no `runs` key) still analyze, so a dir from an old sweep or a mixed-version bench run doesn't break the report.
- **`amy-hwci.yml`**: passes `--runs 3` for both builds, uploads the per-run logs/traces (`serial*.log` / `load*.csv` globs), and updates the comment text. Adds ~80 s per bench job — well inside the 20 min timeout.

## Testing

Simulated the whole pipeline with `upload`/`capture` stubbed to synthetic UART lines: 3 clean runs (means + spread line verified against per-run stats), an interfered run 2 (excluded from means, `run 2:` errors, FAIL verdict), single-run mode (byte-identical report shape to today), and a legacy no-`runs` baseline dir. All 15 checks pass; workflow YAML validated.

Note: the bench checks out harness scripts from **main**, so this PR's own HW CI comment will still be a single-run one — the 3× averaging takes effect for PRs benched after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)