### PR TITLE
HW CI: back to one capture per build; keep measure.py --runs

### DIFF
--- a/.github/workflows/amy-hwci.yml
+++ b/.github/workflows/amy-hwci.yml
@@ -3,10 +3,12 @@ name: AMY HW CI
 # Hardware half of AMY's CI, replacing the old cross-repo dispatch to the
 # tulipcc bench: flash THIS PR's LoadTestChord firmware (built and uploaded as
 # an artifact by "AMY HW CI build") onto the physical AMYboard on the
-# self-hosted bench Pi (amyboardci), capture three 20 s runs of its debug
-# UART (flash once, reset between runs) while the
+# self-hosted bench Pi (amyboardci), capture 20 s of its debug UART while the
 # sketch stacks up an 8-note held Juno chord, and comment the measured render
-# load at each chord size — averaged across the runs — back on the PR.
+# load at each chord size back on the PR. (measure.py can average several
+# resets of one flash via --runs, but a 3x trial showed run-to-run spread of
+# only ±1-2 µs — the ±30 µs no-op deltas are per-BINARY layout jitter that
+# averaging can't remove — so CI captures once.)
 #
 # PASS/FAIL semantics: FAIL means only that the bench COULD NOT RUN the test
 # (flash/serial failure, board crash, capture interference). The load values
@@ -120,12 +122,11 @@ jobs:
             --port /dev/amyboard-dongle \
             --esptool ~/hwci-venv/bin/esptool \
             --seconds 20 \
-            --runs 3 \
             --label "pr${PR}-base" \
             --meta "{\"pr\": ${PR}, \"sha\": \"${BASE_SHA}\"}" \
             2>&1 | tee out-base/run.log || true
 
-      - name: Flash + capture 3 x 20 s of render load (this PR)
+      - name: Flash + capture 20 s of render load (this PR)
         id: measure
         continue-on-error: true   # the verdict is hwci_report.py's, below
         env:
@@ -138,7 +139,6 @@ jobs:
             --port /dev/amyboard-dongle \
             --esptool ~/hwci-venv/bin/esptool \
             --seconds 20 \
-            --runs 3 \
             --label "pr${PR}" \
             --meta "{\"pr\": ${PR}, \"sha\": \"${SHA}\"}" \
             2>&1 | tee out/run.log
@@ -185,7 +185,7 @@ jobs:
               marker,
               '### 🎛️ AMY HW CI (AMYboard bench)',
               '',
-              "Flashed this PR's AMY (LoadTestChord: 6-voice Juno `patch=1`, one held note every 2 s) onto the physical AMYboard and measured the smoothed render load as the chord grows — back-to-back with the same sketch built at the PR's merge base, so Δ is this PR's own cost. Each build is flashed once and captured 3 times (board reset between runs); the numbers are per-run means.",
+              "Flashed this PR's AMY (LoadTestChord: 6-voice Juno `patch=1`, one held note every 2 s) onto the physical AMYboard and measured the smoothed render load as the chord grows — back-to-back with the same sketch built at the PR's merge base, so Δ is this PR's own cost.",
               '',
               report,
               '',

--- a/tools/arduino_loadsweep/README.md
+++ b/tools/arduino_loadsweep/README.md
@@ -47,9 +47,12 @@ Two consecutive flash failures abort the sweep on the assumption the bench
 The same sketch + `measure.py` also power AMY's per-PR hardware CI
 (`.github/workflows/amy-hwci-build.yml` builds the firmware in the cloud —
 the PR *and* a baseline at its merge base; `amy-hwci.yml` flashes both
-back-to-back on the self-hosted bench Pi — each with `--runs 3`, so every
-number is a 3-run mean — and comments a before/after/Δ
+back-to-back on the self-hosted bench Pi and comments a before/after/Δ
 load table on the PR, formatted by `hwci_report.py`).
+CI captures each build once: a `--runs 3` trial (PR #897 benching #896)
+showed run-to-run spread of only ±1–2 µs within one binary, while the
+~±30 µs deltas seen on no-op PRs persisted across every run — they're
+per-binary code-layout jitter, which averaging resets can't remove.
 CI **FAIL means only that the PR's test couldn't run** — load values and a
 failed baseline are informational there; regression *hunting* is this
 sweep's job.


### PR DESCRIPTION
Follow-up to #897. The 3× averaging trial (re-bench of #896) answered the noise question: run-to-run spread within one flashed binary is only **±1–2 µs** (PR: 3704/3702/3703 · main: 3674/3672/3672), while the ~±30 µs full-chord delta on that no-op PR showed up identically in every run. The noise is **per-binary** (code/flash-cache layout jitter between builds), so averaging board resets can't reduce it — it just costs ~80 s per bench job.

- `amy-hwci.yml`: drop `--runs 3` from both measure invocations, restore the single-run comment text, and note the finding in the header comment. The per-run artifact globs stay (harmless, and correct if `--runs` is ever re-enabled).
- `measure.py` / `hwci_report.py`: unchanged — full `--runs` support (per-run stats, cross-run means, spread line in the report) stays for ad-hoc bench investigation.
- README: records the finding so nobody re-runs this experiment from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)