### PR TITLE
Don't apply IRAM/DRAM placement (#905) on Tulip builds

### DIFF
--- a/src/amy.h
+++ b/src/amy.h
@@ -165,11 +165,16 @@ extern void amy_set_gamma9001_pcm(const int16_t * data);
 
 #ifdef ESP_PLATFORM
 #include <esp_heap_caps.h>
+#endif
+
+#if defined(ESP_PLATFORM) && !defined(TULIP)
 // From github.com/rt-rtos/S3-Amysynth: Place the render hot path in internal
 // IRAM. Use IRAM_ATTR (per-symbol) rather than a linker fragment because this
 // build uses GCC LTO: .text.* section names are rewritten in ltrans, so
 // object/symbol-granularity `noflash` rules silently miss. IRAM_ATTR rides the
 // symbol itself (.iram1.*) and survives LTO. No-op on non-ESP platforms.
+// Not on Tulip: its S3 image (display + USB host + MicroPython) doesn't have
+// the spare internal IRAM/DRAM, and the placement hangs boot (tulipcc PR #1164).
 #define AMY_IRAM_ATTR IRAM_ATTR
 // Pin the clipping lookup table
 // (~9.6 KB) to internal DRAM. Read on every output sample; in flash .rodata it


### PR DESCRIPTION
#905's IRAM_ATTR/DRAM_ATTR render-path placement hangs Tulip (TULIP4_R11) at boot — the serial console stops right after `Starting MicroPython on core 1` and never reaches the REPL (seen on tulipcc HW CI for shorepine/tulipcc#1164, run 29502489895; AMYboard passed the same run). Tulip's S3 image (display + USB host + MicroPython) doesn't have the spare internal IRAM/DRAM.

This gates the attributes on `!defined(TULIP)` (the define tulipcc's esp32s3 build sets), so AMYboard and other ESP32 builds keep the ~10% speedup and Tulip builds are unchanged from pre-#905.

`make test`: 111 tests pass. HW CI validation via a tulipcc PR pinning this commit is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)