### PR TITLE
Make AMY state dumps complete and replayable

### DIFF
--- a/amy/__init__.py
+++ b/amy/__init__.py
@@ -6,7 +6,13 @@ import time
 def _get_synth_commands_stub(synth, include_fx=False):
     return []
 
+def _dump_state_stub():
+    # Unlike get_synth_commands, an empty result would be indistinguishable from
+    # genuinely empty state, so fail loudly when the build has no dump support.
+    raise RuntimeError("amy.dump_state() is not available in this build")
+
 _get_synth_commands = _get_synth_commands_stub
+_dump_state = _dump_state_stub
 try:
     import c_amy as _amy  # Import the C module
     live = _amy.live
@@ -15,6 +21,7 @@ try:
     _ticks_ms = _amy.ticks_ms
     _render_load = _amy.render_load
     _set_render_load_threshold = _amy.set_render_load_threshold
+    _dump_state = _amy.dump_state
 except (ImportError, AttributeError):
     # C module is not required? not available?
     # I'm guessing this might mean we're on Micropython?
@@ -25,6 +32,8 @@ except (ImportError, AttributeError):
         _ticks_ms = tulip.amy_ticks_ms
         _render_load = tulip.amy_render_load
         _set_render_load_threshold = tulip.amy_set_render_load_threshold
+        # Older tulip builds predate the wrapper; keep the loud stub there.
+        _dump_state = getattr(tulip, "amy_dump_state", _dump_state_stub)
     except (ImportError, AttributeError):
         pass  # Not available (e.g. web build); _get_synth_commands returns []
 
@@ -583,6 +592,13 @@ def get_synth_commands(synth, patch_num=None, dest_synth=None, num_voices=6, inc
         prologue = [prefix + "i%div%din%dZ" % (dest_synth, num_voices, num_oscs)]
         prefix += "i%d" % dest_synth
     return "\n".join(prologue + [prefix + command for command in commands])
+
+"""
+    Reading back the complete engine state
+"""
+def dump_state():
+    # Full replayable engine state as newline-separated wire commands.
+    return _dump_state()
 
 """
     Simulate CV input from an osc (testing support)

--- a/src/amy.h
+++ b/src/amy.h
@@ -1123,6 +1123,7 @@ extern int sprint_event(amy_event *e, char *s, size_t len, bool wirecode);
 extern void fprintf_event_stderr(amy_event *e);
 extern void *yield_synth_events(uint8_t synth, struct amy_event *event, bool include_fx, void *state);
 extern void *yield_synth_commands(uint8_t synth, char *s, size_t len, bool include_fx, void *state);
+extern void set_event_for_bus_fx(amy_event *event, uint8_t bus, global_state_t *state);
 extern int size_of_amy_event(void);
 extern bool event_addresses_bus(amy_event *e);
 extern bool event_addresses_synth(amy_event *e);

--- a/src/pyamy.c
+++ b/src/pyamy.c
@@ -7,6 +7,7 @@
 #include "amy.h"
 #include "amy_midi.h"
 #include "libminiaudio-audio.h"
+#include "transfer.h"
 
 // Python module wrapper for AMY commands
 
@@ -280,6 +281,17 @@ static PyObject * get_synth_commands_wrapper(PyObject *self, PyObject *args) {
     return list_obj;
 }
 
+static PyObject *dump_state_wrapper(PyObject *self, PyObject *args) {
+    int len = 0;
+    char *dump = amy_dump_state_to_string(&len);
+    if (dump == NULL) {
+        return PyErr_NoMemory();
+    }
+    PyObject *result = PyUnicode_FromStringAndSize(dump, len);
+    free(dump);
+    return result;
+}
+
 static PyObject *set_cv_from_osc_wrapper(PyObject *self, PyObject *args) {
     if (!(PyTuple_Size(args) == 2)) return NULL;
     int cv_channel, osc;
@@ -315,6 +327,7 @@ static PyMethodDef c_amyMethods[] = {
     {"inject_midi", inject_midi_wrapper, METH_VARARGS, "Inject a MIDI message"},
     {"inject_midi_bytes", inject_midi_bytes_wrapper, METH_VARARGS, "Inject a raw MIDI byte stream through the parser"},
     {"get_synth_commands", get_synth_commands_wrapper, METH_VARARGS, "Read synth configuration commands"},
+    {"dump_state", dump_state_wrapper, METH_NOARGS, "Read complete replayable AMY state"},
     {"set_cv_from_osc", set_cv_from_osc_wrapper, METH_VARARGS, "Feed external CV input from a mod osc"},
     {"ticks_ms", amy_ticks_ms_wrapper, METH_VARARGS, "Read AMY millisecond clock"},
     {"render_load", amy_get_render_load_wrapper, METH_VARARGS, "Read current render load fraction"},

--- a/src/transfer.c
+++ b/src/transfer.c
@@ -467,7 +467,6 @@ b64_decode_ex (const char *src, size_t len, b64_buffer_t * decbuf, size_t *decsi
 static void amy_emit_state_lines(void (*cb)(const char *line, int len, void *ctx), void *ctx) {
     char buf[1024];
     char line[1100];
-    bool include_fx = true;
     for (int inst = 0; inst < instruments_max_instruments(); inst++) {
         if (instrument_number_exists(inst, NULL)) {
             uint16_t voices[MAX_VOICES_PER_INSTRUMENT];
@@ -480,14 +479,22 @@ static void amy_emit_state_lines(void (*cb)(const char *line, int len, void *ctx
             cb(line, n, ctx);
             void *state = NULL;
             do {
-                state = yield_synth_commands((uint8_t)inst, buf, sizeof(buf), include_fx, state);
+                state = yield_synth_commands((uint8_t)inst, buf, sizeof(buf), false, state);
                 if (buf[0] == '\0') continue;
-                n = snprintf(line, sizeof(line), "i%d%s", inst, buf);  // Prepends to FX as well, that's OK.
+                n = snprintf(line, sizeof(line), "i%d%s", inst, buf);
                 cb(line, n, ctx);
             } while (state);
-            // We include FX only in the first osc.
-            include_fx = false;
         }
+    }
+
+    // Bus state is global, not owned by whichever instrument happens to be enumerated first.
+    // Emit each active bus exactly once. Buses above highest_bus stay out of the dump:
+    // replaying them would activate them, adding render cost for buses nothing uses.
+    for (int bus = 0; bus <= amy_global.highest_bus; ++bus) {
+        amy_event event = amy_default_event();
+        set_event_for_bus_fx(&event, (uint8_t)bus, &amy_global);
+        int n = sprint_event(&event, line, sizeof(line), true);
+        cb(line, n, ctx);
     }
 }
 

--- a/tests/test_state_dump.py
+++ b/tests/test_state_dump.py
@@ -1,0 +1,126 @@
+import unittest
+
+import amy
+import c_amy
+
+
+class StateDumpTest(unittest.TestCase):
+    def setUp(self):
+        c_amy.stop()
+        c_amy.start(0)
+
+    def apply(self, **kwargs):
+        amy.send(**kwargs)
+        # Wire messages become engine state while AMY renders its next block.
+        c_amy.render_to_list()
+
+    def test_dump_contains_active_bus_state(self):
+        self.apply(synth=17, num_voices=1, oscs_per_voice=1, bus=2)
+        self.apply(synth=18, num_voices=1, oscs_per_voice=1, bus=3)
+
+        self.apply(bus=0, volume=0.25, eq=[-3, 0, 2])
+        self.apply(bus=1, volume=0.5, reverb=[0.2, 0.6, 0.4, 3500])
+        self.apply(bus=2, volume=0.75, chorus=[0.3, 120, 1.5, 0.4])
+        self.apply(bus=3, volume=0.9, echo=[0.35, 180, 600, 0.45, 0.1])
+
+        lines = c_amy.dump_state().splitlines()
+
+        for bus in range(4):
+            self.assertEqual(
+                1,
+                sum(line.startswith("y%d" % bus) for line in lines),
+                "expected exactly one explicit state line for bus %d" % bus,
+            )
+            bus_line = next(line for line in lines if line.startswith("y%d" % bus))
+            self.assertEqual(1, bus_line.count("y%d" % bus), "bus wirecode must be serialized once")
+
+        bus_lines = {
+            bus: next(line for line in lines if line.startswith("y%d" % bus))
+            for bus in range(4)
+        }
+        self.assertIn("V0.250", bus_lines[0])
+        self.assertIn("x-3.000,0.000,2.000", bus_lines[0])
+        self.assertIn("V0.500", bus_lines[1])
+        self.assertIn("h0.200,0.600,0.400,3500.000", bus_lines[1])
+        self.assertIn("V0.750", bus_lines[2])
+        self.assertIn("k0.300,120.000,1.500,0.400", bus_lines[2])
+        self.assertIn("V0.900", bus_lines[3])
+        # max_delay is rounded to AMY's power-of-two delay-line capacity. The resulting default-sized
+        # capacity is intentionally omitted from replay wirecode, hence the empty third field.
+        self.assertIn("M0.350,180.000,,0.450,0.100", bus_lines[3])
+
+    def test_dump_skips_inactive_buses(self):
+        # Routing a synth to bus 1 activates buses 0..1; buses 2..3 stay inactive.
+        # Replaying state for an inactive bus would activate it, so it must not be dumped.
+        self.apply(synth=17, num_voices=1, oscs_per_voice=1, bus=1)
+
+        lines = c_amy.dump_state().splitlines()
+
+        for bus in (0, 1):
+            self.assertEqual(
+                1,
+                sum(line.startswith("y%d" % bus) for line in lines),
+                "expected exactly one state line for active bus %d" % bus,
+            )
+        for bus in (2, 3):
+            self.assertEqual(
+                0,
+                sum(line.startswith("y%d" % bus) for line in lines),
+                "inactive bus %d must not appear in the dump" % bus,
+            )
+
+    def test_dump_replays_bus_state(self):
+        self.apply(synth=17, num_voices=1, oscs_per_voice=1, bus=2)
+        self.apply(synth=18, num_voices=1, oscs_per_voice=1, bus=3)
+        self.apply(
+            bus=0,
+            volume=0.4,
+            eq=[-2, 1, 3],
+            reverb=[0.1, 0.5, 0.2, 2500],
+            chorus=[0.15, 72, 0.8, 0.2],
+            echo=[0.2, 120, 500, 0.25, 0.05],
+        )
+        self.apply(
+            bus=1,
+            volume=0.55,
+            eq=[-1, 2, 4],
+            reverb=[0.2, 0.6, 0.3, 3500],
+            chorus=[0.25, 96, 1.2, 0.3],
+            echo=[0.3, 160, 600, 0.35, 0.1],
+        )
+        self.apply(
+            bus=2,
+            volume=0.7,
+            eq=[0, 3, 5],
+            reverb=[0.3, 0.7, 0.4, 4500],
+            chorus=[0.35, 120, 1.6, 0.4],
+            echo=[0.4, 200, 700, 0.45, 0.15],
+        )
+        self.apply(
+            bus=3,
+            volume=0.85,
+            eq=[1, 4, 6],
+            reverb=[0.4, 0.8, 0.5, 5500],
+            chorus=[0.45, 144, 2.0, 0.5],
+            echo=[0.5, 240, 800, 0.55, 0.2],
+        )
+        original = c_amy.dump_state()
+
+        c_amy.stop()
+        c_amy.start(0)
+        c_amy.send_wire(original.replace("\n", ""))
+        # Drain every replay event, not merely the first block.
+        for _ in range(8):
+            c_amy.render_to_list()
+
+        # Equality also proves highest_bus is restored: a lower value would drop bus lines
+        # from the second dump.
+        self.assertEqual(original, c_amy.dump_state())
+
+    def test_public_dump_state_matches_c_module(self):
+        self.apply(synth=17, num_voices=1, oscs_per_voice=1, bus=2)
+        self.assertEqual(c_amy.dump_state(), amy.dump_state())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- emit volume, EQ, reverb, chorus, and echo state exactly once per **active** bus (`0..amy_global.highest_bus`), independent of instrument enumeration
- expose public `amy.dump_state()`, arbitrated like `get_synth_commands`: `c_amy.dump_state` under CPython, `tulip.amy_dump_state` under MicroPython (Tulip wrapper submitted separately)

## Motivation

`amy_dump_state` currently cannot be used as a complete snapshot and replay interface:

- global bus state depends on which instrument is enumerated first,
- a bus with FX configured but no instrument currently routed to it is not represented,
- there is no public Python entry point for the dump.

Buses above `highest_bus` are deliberately left out of the dump — replaying them would activate them, adding render cost for buses nothing uses.

Instrument bus routing in dumps comes from the synth preamble fixed in #931; this PR is dump-layer only and composes with it (no shared files).

## Verification

- `make test` — 115 upstream AMY tests pass
- `python3 -m unittest -v tests.test_state_dump` — 4/4 pass
- all four buses with distinct volume, EQ, reverb, chorus, and echo state survive dump → reset → replay exactly
- inactive buses stay out of the dump
- `amy.dump_state()` matches `c_amy.dump_state()`
- downstream real-WASM readback and live-edit tests pass
