### PR TITLE
Fix amy_dump_state_to_string to include midi_note_cmds, bus FX in separate block (like #926).

### DIFF
--- a/amy/__init__.py
+++ b/amy/__init__.py
@@ -15,6 +15,7 @@ try:
     _ticks_ms = _amy.ticks_ms
     _render_load = _amy.render_load
     _set_render_load_threshold = _amy.set_render_load_threshold
+    _dump_state = _amy.dump_state
 except (ImportError, AttributeError):
     # C module is not required? not available?
     # I'm guessing this might mean we're on Micropython?
@@ -25,6 +26,7 @@ except (ImportError, AttributeError):
         _ticks_ms = tulip.amy_ticks_ms
         _render_load = tulip.amy_render_load
         _set_render_load_threshold = tulip.amy_set_render_load_threshold
+        _dump_state = tulip.amy_dump_state
     except (ImportError, AttributeError):
         pass  # Not available (e.g. web build); _get_synth_commands returns []
 
@@ -589,6 +591,12 @@ def get_synth_commands(synth, patch_num=None, dest_synth=None, num_voices=6, inc
 """
 def set_cv_from_osc(cv, osc):
     _set_cv_from_osc(cv, osc)
+
+"""
+    Reading back the complete engine state
+"""
+def dump_state():
+    return _dump_state()
 
 """
     Render load tracking

--- a/amy/test.py
+++ b/amy/test.py
@@ -1812,6 +1812,41 @@ class TestSequencerOsc(AmyTest):
     amy.send(time=900, osc=1, vel=0)
 
 
+class TestDumpState(AmyTest):
+  """Exercise amy.dump_state() against a golden."""
+
+  def test(self):
+    _amy.stop()
+    _amy.start(0)
+    amy.send(time=0, synth=1, num_voices=4, oscs_per_voice=2)
+    amy.send(time=0, synth=1, osc=0, wave=amy.SINE, freq=110, chained_osc=1)
+    amy.send(time=0, synth=1, osc=1, wave=amy.SAW_UP, freq=880)
+    amy.send(time=0, synth=2, num_voices=1, oscs_per_voice=1, bus=1, volume=0.5)
+    amy.send_raw('i1ic10,1,1,100,1,i%id%v')
+    amy.send_raw('i1io39,0,0,1,0,i%in40l%v')
+    amy.render(1)  # Let the events execute.
+    commands = amy.dump_state()
+    expected = """i1ic255Z
+i1iv4in2Z
+i1v0f110.000c1Z
+i1v1w3f880.000Z
+i1ic10,1,1.000,100.000,1.000,i%id%vZ
+i1io39,0,0.000,1.000,0.000,i%in40l%vZ
+i2ic255Z
+i2iv1in1y1Z
+i2v0Z
+y0V1.000x0.000,0.000,0.000M0.000,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z
+y1V0.500x0.000,0.000,0.000M0.000,500.000,,0.000,0.000k0.000,320.000,0.500,0.500h0.000,0.850,0.500,3000.000Z
+"""
+    if commands != expected:
+      is_ok = False
+      message = self.__class__.__name__ + ': get_synth_commands mismatch: expected:\n++\n%s\n--\n;saw:\n++\n%s\n--;' % (expected, commands)
+    else:
+      is_ok = True
+      message = self.__class__.__name__ + ' : ok'
+    return is_ok, message
+
+
 def main(argv):
   if len(argv) > 1 and argv[1] == 'quiet':
     quiet = True

--- a/src/amy.h
+++ b/src/amy.h
@@ -1123,6 +1123,8 @@ extern int sprint_event(amy_event *e, char *s, size_t len, bool wirecode);
 extern void fprintf_event_stderr(amy_event *e);
 extern void *yield_synth_events(uint8_t synth, struct amy_event *event, bool include_fx, void *state);
 extern void *yield_synth_commands(uint8_t synth, char *s, size_t len, bool include_fx, void *state);
+extern void *yield_bus_commands(char *s, size_t len, void *state);
+extern void set_event_for_bus_fx(amy_event *event, uint8_t bus, global_state_t *state);
 extern int size_of_amy_event(void);
 extern bool event_addresses_bus(amy_event *e);
 extern bool event_addresses_synth(amy_event *e);

--- a/src/patches.c
+++ b/src/patches.c
@@ -736,27 +736,34 @@ void *yield_synth_events(uint8_t instr_num, struct amy_event *event, bool includ
     return (void *)((intptr_t)state_val);
 }
 
-#define STATE_START_OF_MIDI 1024
+#define STATE_START_OF_MIDI_TPLT_CMDS 1024
+
 void *yield_synth_commands(uint8_t instr_num, char *s, size_t len, bool include_fx, void *state) {
     // Generator to return multiple wirecode strings to reconfigure a synth.
     int state_val = (intptr_t)state;
     //fprintf(stderr, "yield_synth_commands: synth %d state %d\n", instr_num, state_val);
     s[0] = '\0';  // By default, return an empty string.
-    if (state_val < STATE_START_OF_MIDI) {
+    if (state_val < STATE_START_OF_MIDI_TPLT_CMDS) {
         amy_event event = amy_default_event();
         state_val = (intptr_t)yield_synth_events(instr_num, &event, include_fx, (void *)(intptr_t)state_val);
         sprint_event(&event, s, len, /* wirecode= */ true);
         if (state_val == 0) {
             // Push the state machine on to the MIDI codes
-            state_val = STATE_START_OF_MIDI;
+            state_val = STATE_START_OF_MIDI_TPLT_CMDS;
         }
     } else {
         // MIDI CC part
         bool found = false;
         int type = MIDI_MAP_TYPE_CC;
-        for (int next_midi_code = state_val - STATE_START_OF_MIDI; next_midi_code < 128; ++next_midi_code) {
+        int starting_code = state_val - STATE_START_OF_MIDI_TPLT_CMDS;
+        for (int next_code = starting_code; next_code < 256; ++next_code) {
+            int next_midi_code = next_code;
+            if (next_midi_code >= 128) {
+                next_midi_code -= 128;
+                type = MIDI_MAP_TYPE_NOTE;
+            }
             if (midi_fetch_mapping_command(instr_num, type, next_midi_code, s, len) == true) {
-                state_val = STATE_START_OF_MIDI + next_midi_code + 1;
+                state_val = STATE_START_OF_MIDI_TPLT_CMDS + next_code + 1;
                 found = true;
                 break;
             }
@@ -765,6 +772,23 @@ void *yield_synth_commands(uint8_t instr_num, char *s, size_t len, bool include_
             // We hit the bottom of the MIDI CCs
             state_val = 0;  // Will terminate the yield cycle.
         }
+    }
+    return (void *)(intptr_t)state_val;
+}
+
+
+void *yield_bus_commands(char *s, size_t len, void *state) {
+    // Like yield_synth_commands, returns just the commands for the FX
+    int state_val = (intptr_t)state;
+    if (state_val > amy_global.highest_bus) {
+        state_val = 0;
+    } else {
+        // Return a wire command to set up a bus.
+        uint8_t bus = state_val;
+        amy_event e = amy_default_event();
+        set_event_for_bus_fx(&e, bus, &amy_global);
+        sprint_event(&e, s, len, /* wirecode= */ true);
+        ++state_val;
     }
     return (void *)(intptr_t)state_val;
 }

--- a/src/pyamy.c
+++ b/src/pyamy.c
@@ -7,6 +7,7 @@
 #include "amy.h"
 #include "amy_midi.h"
 #include "libminiaudio-audio.h"
+#include "transfer.h"
 
 // Python module wrapper for AMY commands
 
@@ -280,6 +281,17 @@ static PyObject * get_synth_commands_wrapper(PyObject *self, PyObject *args) {
     return list_obj;
 }
 
+static PyObject *dump_state_wrapper(PyObject *self, PyObject *args) {
+    int len = 0;
+    char *dump = amy_dump_state_to_string(&len);
+    if (dump == NULL) {
+        return PyErr_NoMemory();
+    }
+    PyObject *result = PyUnicode_FromStringAndSize(dump, len);
+    free(dump);
+    return result;
+}
+
 static PyObject *set_cv_from_osc_wrapper(PyObject *self, PyObject *args) {
     if (!(PyTuple_Size(args) == 2)) return NULL;
     int cv_channel, osc;
@@ -315,6 +327,7 @@ static PyMethodDef c_amyMethods[] = {
     {"inject_midi", inject_midi_wrapper, METH_VARARGS, "Inject a MIDI message"},
     {"inject_midi_bytes", inject_midi_bytes_wrapper, METH_VARARGS, "Inject a raw MIDI byte stream through the parser"},
     {"get_synth_commands", get_synth_commands_wrapper, METH_VARARGS, "Read synth configuration commands"},
+    {"dump_state", dump_state_wrapper, METH_NOARGS, "Read complete replayable AMY state"},
     {"set_cv_from_osc", set_cv_from_osc_wrapper, METH_VARARGS, "Feed external CV input from a mod osc"},
     {"ticks_ms", amy_ticks_ms_wrapper, METH_VARARGS, "Read AMY millisecond clock"},
     {"render_load", amy_get_render_load_wrapper, METH_VARARGS, "Read current render load fraction"},

--- a/src/transfer.c
+++ b/src/transfer.c
@@ -467,28 +467,30 @@ b64_decode_ex (const char *src, size_t len, b64_buffer_t * decbuf, size_t *decsi
 static void amy_emit_state_lines(void (*cb)(const char *line, int len, void *ctx), void *ctx) {
     char buf[1024];
     char line[1100];
-    bool include_fx = true;
+    void *state;
     for (int inst = 0; inst < instruments_max_instruments(); inst++) {
         if (instrument_number_exists(inst, NULL)) {
             uint16_t voices[MAX_VOICES_PER_INSTRUMENT];
             int num_voices = instrument_get_num_voices(inst, voices);
             if (num_voices < 1) continue;  // should never happen.
-            int oscs_per_voice = instrument_get_oscs_per_voice(inst);
             int n = snprintf(line, sizeof(line), "i%dic255Z", inst);
             cb(line, n, ctx);
-            n = snprintf(line, sizeof(line), "i%div%din%dZ", inst, num_voices, oscs_per_voice);
-            cb(line, n, ctx);
-            void *state = NULL;
+            state = NULL;
             do {
-                state = yield_synth_commands((uint8_t)inst, buf, sizeof(buf), include_fx, state);
+                // Don't include fx in synth reports, we include them all later.
+                state = yield_synth_commands((uint8_t)inst, buf, sizeof(buf), false, state);
                 if (buf[0] == '\0') continue;
                 n = snprintf(line, sizeof(line), "i%d%s", inst, buf);  // Prepends to FX as well, that's OK.
                 cb(line, n, ctx);
             } while (state);
-            // We include FX only in the first osc.
-            include_fx = false;
         }
     }
+    state = NULL;
+    do {
+        // Grab the bus commands.
+        state = yield_bus_commands(line, sizeof(line), state);
+        if (state) cb(line, strlen(line), ctx);
+    } while (state);
 }
 
 typedef struct { char *buf; int pos; int cap; } _string_ctx;


### PR DESCRIPTION
Unlike #926, this adds a new `yield_bus_commands` generator parallel to `yield_synth_commands`.  Adds a golden test.

Also provides `amy.dump_state()` instead of only exposing through `tulip.amy_dump_state()`.