### PR TITLE
Fix Godot addon release: stub midi_active_channel fns, fail PRs on link errors

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -87,3 +87,37 @@ jobs:
           git diff -- godot/amy.gd
           exit 1
         fi
+
+  godot-build:
+    # Build the Godot GDExtension for Linux. amy_midi.c is excluded from the
+    # Godot build, so new functions there that core code calls need stubs in
+    # godot/src/amy_platform_stubs.c — without this job that only surfaces as a
+    # Windows link failure at release time (which silently ships releases with
+    # no addon zip). The SConstruct links Linux with -Wl,--no-undefined so the
+    # same unresolved symbols fail here, on the PR.
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install scons
+      run: pip install scons
+
+    - name: Checkout godot-cpp
+      uses: actions/checkout@v4
+      with:
+        repository: godotengine/godot-cpp
+        ref: godot-4.4-stable
+        path: godot-cpp
+        submodules: true
+
+    - name: Build GDExtension (Linux debug)
+      working-directory: godot
+      run: scons platform=linux arch=x86_64 target=template_debug -j4
+      env:
+        GODOT_CPP_PATH: ${{ github.workspace }}/godot-cpp
+        AMY_SRC_PATH: ${{ github.workspace }}/src

--- a/godot/SConstruct
+++ b/godot/SConstruct
@@ -74,6 +74,9 @@ if target_platform == "macos":
     env.Append(LINKFLAGS=["-framework", "CoreFoundation"])
 elif target_platform == "linux":
     env.Append(LIBS=["pthread", "m"])
+    # Fail the link on unresolved symbols (matches Windows DLL behavior), so a
+    # missing amy_platform_stubs.c entry breaks CI here instead of at runtime.
+    env.Append(LINKFLAGS=["-Wl,--no-undefined"])
 elif target_platform == "windows":
     if is_msvc:
         env.Append(CCFLAGS=["-DWINDOWS"])

--- a/godot/src/amy_platform_stubs.c
+++ b/godot/src/amy_platform_stubs.c
@@ -6,6 +6,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 // --- i2s.c stubs ---
 void amy_platform_init(void) {}
@@ -34,6 +35,11 @@ uint8_t midi_clock_out_enabled(void) { return 0; }
 void midi_clock_out_tick(void) {}
 void midi_clock_out_start(void) {}
 void midi_clock_out_stop(void) {}
+// Called from amy.c / instrument.c / midi_mappings.c to track which MIDI
+// channels are in use; no MIDI hardware on Godot so these are no-ops.
+void midi_active_channels_reset(void) {}
+void midi_active_channel_set(uint8_t channel, bool state) { (void)channel; (void)state; }
+void midi_active_channels_debug(void) {}
 
 // --- examples.c stubs ---
 void delay_ms(uint32_t ms) { (void)ms; }

--- a/setup_godot.sh
+++ b/setup_godot.sh
@@ -408,6 +408,7 @@ cat > "${ADDON_DIR}/src/amy_platform_stubs.c" << 'STUBEOF'
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 // --- i2s.c stubs ---
 void amy_platform_init(void) {}
@@ -426,6 +427,11 @@ uint8_t midi_clock_out_enabled(void) { return 0; }
 void midi_clock_out_tick(void) {}
 void midi_clock_out_start(void) {}
 void midi_clock_out_stop(void) {}
+// Called from amy.c / instrument.c / midi_mappings.c to track which MIDI
+// channels are in use; no MIDI hardware on Godot so these are no-ops.
+void midi_active_channels_reset(void) {}
+void midi_active_channel_set(uint8_t channel, bool state) { (void)channel; (void)state; }
+void midi_active_channels_debug(void) {}
 void midi_local(uint8_t *bytes, uint16_t len) { (void)bytes; (void)len; }
 void run_midi(void) {}
 void stop_midi(void) {}
@@ -497,6 +503,11 @@ env.Append(CCFLAGS=["-DAMY_WAVETABLE", "-DAMY_NO_MINIAUDIO"])
 if sys.platform == "darwin":
     env.Append(CCFLAGS=["-DMACOS"])
     env.Append(LINKFLAGS=["-framework", "CoreFoundation"])
+elif sys.platform.startswith("linux"):
+    env.Append(LIBS=["pthread", "m"])
+    # Fail the link on unresolved symbols (matches Windows DLL behavior), so a
+    # missing amy_platform_stubs.c entry fails at build time instead of runtime.
+    env.Append(LINKFLAGS=["-Wl,--no-undefined"])
 
 # Build all sources together - AMY C files + GDExtension C++ files
 all_sources = []


### PR DESCRIPTION
## Problem

Releases **1.2.70 through 1.2.77 shipped with no `amy-godot-addon.zip`** — the Godot addon workflow has failed on every release dispatch since the `midi_active_channel` functions landed. The Windows link fails with three unresolved externals: `midi_active_channels_reset`, `midi_active_channels_debug`, and `midi_active_channel_set`. They're defined in `amy_midi.c` (excluded from the Godot build) but called from `amy.c`, `instrument.c`, and `midi_mappings.c`. Only Windows caught it because the DLL requires all symbols at link time; macOS/Linux shared libs tolerate undefined symbols and defer to runtime.

## Fix

- Add no-op stubs for the three functions to `godot/src/amy_platform_stubs.c` and the embedded copy in `setup_godot.sh`.

## Prevention (fail the PR, not the release)

- Link the Linux GDExtension with `-Wl,--no-undefined` in both SConstructs, so unresolved symbols fail the Linux build exactly like the Windows one.
- New `godot-build` job in `c-cpp.yml` builds the Linux GDExtension (template_debug) on every PR. Combined with the strict link flag, any future amy_midi.c/stub drift fails PR CI instead of silently shipping asset-less releases.

Verified locally by linking the full Godot C source list + stubs into a shared library with undefined-symbol errors enabled: only libc symbols remain undefined.

Once merged, the auto-release will cut the next version with the addon zip attached again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)