### PR TITLE
 FIx: Use full-precision multiply for biquad feedback coefficients

### DIFF
--- a/src/filters.c
+++ b/src/filters.c
@@ -165,7 +165,19 @@ int8_t dsps_biquad_gen_bpf_f32(SAMPLE *coeffs, float f, float qFactor)
 }
 
 // Stick to the faster mult for biquad, hpf etc, since the parameters aren't so sensitive, and parametric_eq was chewing major CPU.
+/* SMULR6 truncates both operands to 12 fractional bits.  At low cutoff the
+ * split-feedback corrections e = 2 + a1 and f = 1 - a2 are ~2^-10, so they keep
+ * only 2-3 significant bits and the pole lands well off target: HPF/BPF at
+ * Q >= 2 rings up into clipping or loses its resonance, and the LPF numerator
+ * rounds to zero.  Exact multiply, ~2 more instructions. */
+#ifdef AMY_USE_FIXEDPOINT
+static inline SAMPLE SMUL64R(SAMPLE a, SAMPLE b) {
+    return (SAMPLE)((((int64_t)a * (int64_t)b) + (1 << (S_FRAC_BITS - 1))) >> S_FRAC_BITS);
+}
+#define FILT_MUL_SS(a, b) SMUL64R(a, b)
+#else
 #define FILT_MUL_SS(a, b) SMULR6(a, b)
+#endif
 
 #define FILTER_SCALEUP_BITS 0  // Apply this gain to input before filtering to avoid underflow in intermediate value.
 #define FILTER_BIQUAD_SCALEUP_BITS 0  // Apply this gain to input before filtering to avoid underflow in intermediate value.


### PR DESCRIPTION
# Use full-precision multiply for biquad feedback coefficients

Discovered while investigating the root cause of intermittent clipping caused by resonant 
HPF in sub the 100hz range.

## Symptom



An HPF with cutoff below ~100 Hz and Q > 1 produces massive sustained clipping,
worse at higher Q. Also reproducible on the LPF when a high-Q resonance overlaps
the note fundamental, though it's less audible there because the low cutoff
attenuates most of the band. The repro is erratic - some cutoff/Q combinations
ring up violently, others nearby lose their resonance instead.

## Root cause

`FILT_MUL_SS` is `SMULR6`, which truncates *both* operands to 12 fractional bits
(`>>11` on s8.23) before multiplying.

The split-feedback kernel `dsps_biquad_f32_ansi_split_fb` exists precisely to
protect pole precision - it computes feedback as
`y0 = w0 + 2*y1 - y2 - e*y1 + f*y2` with the corrections `e = 2 + a1` and
`f = 1 - a2` deliberately small. But small is exactly what 12-bit truncation
destroys. At fc = 65 Hz, Q = 4, `e ~ f ~ 0.0011`, so after quantization they
retain only **2-3 significant bits**.

So the mechanism meant to preserve the pole is the one that loses it. With the
corrections down to a couple of bits, the pole's frequency and damping land
quasi-randomly around their targets: overshoot and it rings up ~+12 dB into
sustained clipping - full-scale, since an HPF passes the whole spectrum -
overdamp and the resonance vanishes instead. Which side the rounding falls on
decides which you get, which is why the repro felt erratic.

Independently, the low-cutoff LPF numerator `(1-c)/2 ~ 3e-5` quantizes to
**zero**, which is why LPF below ~100 Hz goes silent.

**Ruled out:** block-floating-point state overflow (instrumented - zero
near-overflow events in all failing static-cutoff runs).

## Evidence

Verified on a host-side replica of the fixed-point path: s8.23 `SAMPLE`,
`SMULR6`, the `split_fb` kernel, and `filter_process`'s normbits BFP logic, all
driven by a retriggered 110 Hz saw at 0.4 FS and run against a double-precision
reference on the same coefficient stream. 4-second runs, static cutoff.

| Filter | fc | Q | peak (`SMULR6`) | peak (reference) | clipped samples | peak (`SMUL64R`) |
|---|---|---|---|---|---|---|
| HPF | 65 | 4 | **4.128** | 0.664 | 166394 | 0.664 |
| HPF | 80 | 4 | **3.418** | 0.871 | 129961 | 0.871 |
| HPF | 80 | 8 | **1.593** | 0.912 | 51449 | 0.913 |
| HPF | 65 | 8 | 0.450 (resonance lost) | 0.664 | 0 | 0.664 |
| LPF | 65 | 4 | **0.000** (silent) | 0.445 | 0 | 0.444 |
| LPF | 200 | 8 | 1.085 | 0.918 | 974 | 0.918 |
| HPF | 500 | 4 | 0.850 | 0.824 | 0 | 0.824 |

With the exact multiply, every row matches the double-precision reference to 3
decimals and all clipping disappears. Above ~200 Hz the old path was already
fine, which is consistent with the diagnosis - `e` and `f` only get small at low
cutoff.

### The one case that still clips

```
HPF fc=10Hz Q=8.0 sweep=6oct   SMULR6:   peak=7.337  ref=1.562  clipped=34005  near-wrap=464
HPF fc=10Hz Q=8.0 sweep=6oct   SMUL64R:  peak=1.562  ref=1.562  clipped=12075  near-wrap=0
```

The double-precision reference clips
identically at the same peak. That's legitimate resonance gain from a 6-octave
sweep on a Q=8 resonator.

## Recreating it

The harness is a single self-contained C file replicating the fixed-point path
(no AMY build required):

Happy to attach the harness as a gist or paste it in-thread if that's useful for
independent verification - it's ~190 lines.

## The fix

In the fixed-point build only, `FILT_MUL_SS` becomes `SMUL64R`, an exact
32x32->64 rounding multiply:

```c
SMUL64R(a, b) = ((int64_t)a * b + 2^22) >> 23
```

The float build keeps `SMULR6` untouched.

Cost is roughly 2 extra Xtensa instructions per multiply across the biquad
kernels. Note this includes the parametric EQ path, which was a deliberate
`SMULR6` choice for CPU reasons - if EQ cost measurably regresses on target, the
EQ path can be specialized back to `SMULR6`, since its fixed mid-band
coefficients are not precision-sensitive. Happy to do that pre-emptively if
preferred.

Hardware-verified on ESP32-S3: the original repro is gone and
resonant low-frequency filters sound better subjectively.
## Related, not addressed here

- `dsps_biquad_gen_hpf_f32` / `_bpf_` lack the `w0` floor (~70 Hz) and Q floor
  (0.51) that `_lpf_` has. With the precise multiply they're stable down to the
  4.8 Hz `LOWEST_RATIO` clamp, so those floors are now a voicing question rather
  than a stability one.

