### PR TITLE
midi_out: skip USB gadget when no host is enumerated (fixes MIDI clock out over TRS without USB)

### DIFF
--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -741,7 +741,13 @@ void midi_out(uint8_t * bytes, uint16_t len) {
 
 // Is there USB gadget midi? Send it
 #if defined TUD_USB_GADGET
-    if(amy_global.config.midi & AMY_MIDI_IS_USB_GADGET) {
+    // tud_ready(): only try USB when a host has enumerated us (and the bus
+    // isn't suspended). tud_midi_stream_write has no mount check -- with no
+    // host attached (e.g. AMYboard on eurorack power alone) it fills its tx
+    // FIFO, then returns 0 forever, and the stall loop below burns ~1s per
+    // byte. MIDI clock out (24 PPQ) hits that from the render path and
+    // wedges the sequencer while starving the UART/TRS out.
+    if((amy_global.config.midi & AMY_MIDI_IS_USB_GADGET) && tud_ready()) {
         // tud_midi_stream_write uses a small FIFO (e.g. 64 bytes). For long
         // messages (e.g. zD sysex dumps) we must loop and yield until the
         // USB task flushes the FIFO, otherwise bytes are silently dropped.


### PR DESCRIPTION
## Problem

Reported on Discord: with `tulip.external_midi_sync(send=True)` on AMYboard, MIDI clock goes out over both USB and the TRS MIDI out port while USB is attached — but with USB disconnected (eurorack power only), the TRS out goes nearly silent and the board appears to hang; a downstream device "occasionally responds".

## Root cause

`midi_out()` always tries the USB gadget branch when `AMY_MIDI_IS_USB_GADGET` is configured. TinyUSB's `tud_midi_stream_write` has **no mount check** — it just fills the class driver's tx FIFO, and `write_flush` silently fails when no host has enumerated the device. So with no USB host attached, the FIFO fills after ~16 messages and every subsequent write returns 0, which sends `midi_out` into its stall-recovery loop (`mp_usbd_task()` + `vTaskDelay(1)` × 1000) — **~1 second per byte** — before falling through to the UART write.

MIDI clock out ticks come from `sequencer_check_and_fill()` → `midi_clock_out_tick()` in the render path, so at 24 PPQ this wedges the sequencer and reduces the TRS/DIN clock from 48 bytes/sec to ~1/sec at 120 bpm — exactly the observed "occasionally responds" behavior. The same stall hits any `midi_out` caller (e.g. Tulip's `tulip.midi_out()`) once USB is unplugged.

## Fix

Guard the gadget branch with `tud_ready()` (enumerated and not suspended). Unpowered / charger-only / detached USB skips the gadget write instantly and the UART gets bytes at full rate; behavior with a real host attached is unchanged.

## Testing

- `make test`: 117 tests pass
- tulipcc AMYboard firmware (`idf.py -DMICROPY_BOARD=AMYBOARD build`) builds clean against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)