### PR TITLE
esp: don't busy-spin the MIDI task when the FreeRTOS tick is 100 Hz

### DIFF
--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -579,7 +579,14 @@ void esp_deinit_midi(void) {
 void esp_poll_midi(void) {
     const int uart_num = esp_get_uart(amy_global.config.midi_uart);
     uint8_t data[MAX_MIDI_BYTES_TO_PARSE];
-    int length = uart_read_bytes(uart_num, data, MAX_MIDI_BYTES_TO_PARSE /*MAX_MIDI_BYTES_PER_MESSAGE*MIDI_QUEUE_DEPTH*/, 1/portTICK_PERIOD_MS);
+    // Block for at least one tick. The old 1/portTICK_PERIOD_MS is
+    // integer-zero whenever the tick is slower than 1ms (e.g. ESP-IDF's
+    // and MicroPython's default CONFIG_FREERTOS_HZ=100), which made this
+    // a zero-timeout read and run_midi_task() a busy-spin pinning its
+    // core at 100% from a priority-23 task.
+    TickType_t timeout = pdMS_TO_TICKS(1);
+    if (timeout == 0) timeout = 1;
+    int length = uart_read_bytes(uart_num, data, MAX_MIDI_BYTES_TO_PARSE /*MAX_MIDI_BYTES_PER_MESSAGE*MIDI_QUEUE_DEPTH*/, timeout);
     if(length > 0) {
         convert_midi_bytes_to_messages(data,length,0);
     }


### PR DESCRIPTION
## The bug

`esp_poll_midi()` passes `1/portTICK_PERIOD_MS` as the `uart_read_bytes` timeout, intending "block ~1 ms". At `CONFIG_FREERTOS_HZ=100` — the **default** for both ESP-IDF and MicroPython — `portTICK_PERIOD_MS` is 10, so the expression is integer-zero: a non-blocking read. Since `run_midi_task()` is `while(1){ esp_poll_midi(); }`, the MIDI task busy-spins its pinned core at 100%, at priority `ESP_TASK_PRIO_MAX-2` — which also starves anything below it on that core (`esp_timer` runs at 22).

AMYboard/tulipcc never see this because they ship `CONFIG_FREERTOS_HZ=1000`, where the same expression happens to equal 1 tick. Anyone embedding amy in a stock IDF or MicroPython project gets the spin.

## Found on

Tulip 5 (ESP32-P4 running MicroPython, tick 100 Hz): per-core CPU read **100% / 14%** with AMY sitting idle. With this fix: **1.9% / 4.7%**.

## The fix

`pdMS_TO_TICKS(1)` floored to one tick, so the task always sleeps:
- at 1 kHz tick: unchanged behavior (1 ms block)
- at 100 Hz tick: blocks 10 ms per poll — fine for 31250-baud MIDI (≤ ~31 bytes per poll, buffered by the uart driver), and infinitely better than a pegged core

🤖 Generated with [Claude Code](https://claude.com/claude-code)