### PR TITLE
Execute pending resets before loading Memory PCM

### DIFF
--- a/amy/test.py
+++ b/amy/test.py
@@ -1231,6 +1231,7 @@ class TestLoadSample(AmyTest):
   an "Unrecognized transfer-level command"."""
 
   def run(self):
+    amy.reset()
     amy.load_sample('sounds/partial_sources/CL SHCI A3.wav', preset=1024, midinote=57)
     amy.send(time=50, osc=0, preset=1024, wave=amy.PCM_MIX, vel=2, note=57)
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -471,6 +471,7 @@ uint16_t amy_parse_transfer_layer_message(char *message) {
         if(sm[1]==0) { // remove preset
             pcm_unload_preset(sm[0]);
         } else {
+            amy_execute_deltas();
             int16_t * ram = pcm_load(sm[0], sm[1], sm[2], 1, sm[3], sm[4], sm[5]);
             start_receiving_transfer(sm[1]*2, (uint8_t*)ram);
         }


### PR DESCRIPTION
## Summary

- execute due AMY events before allocating a Memory PCM preset
- extend the existing `TestLoadSample` golden test to cover `amy.reset()`
  immediately followed by `amy.load_sample()`

## Problem

`amy.reset()` queues `RESET_ALL_OSCS`, while Memory PCM allocation performed
by `load_sample()` happens immediately when the transfer header is parsed.

This allows the following ordering:

1. `RESET_ALL_OSCS` is queued
2. the new Memory PCM preset is allocated and loaded
3. the queued reset executes
4. `amy_reset_oscs()` calls `pcm_unload_all_presets()`
5. the newly loaded preset is removed

As a result, the same PCM note can produce different audio depending on when
the pending reset executes.

Patch loading already prevents the equivalent ordering race by calling
`amy_execute_deltas()` immediately before `patches_load_patch()` (#372).
This change applies the same ordering boundary immediately before `pcm_load()`.

Only due events are executed; future scheduled events remain queued.

## Regression test

The existing `TestLoadSample` golden test now resets AMY immediately before
loading its sample.

Before the fix:

    TestLoadSample: signal=-27.1 dB err=-26.2 dB

After the fix:

    TestLoadSample: signal=-33.7 dB err=-100.0 dB

The existing reference WAV does not change.

## Test plan

- [x] `python3 -m amy.test quiet` — 119 tests pass
- [x] `make check-c-api`
- [ ] `make web` — not run locally because `emcc` is unavailable; covered by CI
