### PR TITLE
python: accept tuples wherever list args are accepted

### DIFF
--- a/amy/__init__.py
+++ b/amy/__init__.py
@@ -212,7 +212,7 @@ def parse_list_or_comma_string(obj):
             return ""
         return str(s)
 
-    if isinstance(obj, list):
+    if isinstance(obj, (list, tuple)):
         return ','.join(map(str_none_is_empty, obj))
     return str(obj)
 


### PR DESCRIPTION
## The trap

`parse_list_or_comma_string()` handles lists and comma-strings but `str()`s anything else — so the natural

```python
amy.send(synth=10, note=36, vel=1, sequence=(0, 192, 100))   # tuple
```

silently emits `H(0, 192, 100)` — parentheses and spaces the wire parser reads as garbage. The sequencer event vanishes while immediate sends keep working, which on Tulip 5 presented as *"the sound effects play but the music is silent."* The same footgun applies to every `'L'`-typed kwarg: `reverb`, `chorus`, `echo`, `eq`, `voices`, …

## The fix

`isinstance(obj, (list, tuple))` — tuples now encode identically to lists:

```python
>>> amy.message(synth=10, note=36, vel=1.0, sequence=(0, 192, 100))
'n36l1H0,192,100i10Z'    # == the list form
```

No kwarg-map changes, so no generated API surfaces (JS/GDScript) are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)