### PR TITLE
Widen osc_to_voice to uint16_t so max_voices can exceed 255

### DIFF
--- a/src/amy.h
+++ b/src/amy.h
@@ -1137,7 +1137,9 @@ extern bool event_addresses_synth(amy_event *e);
 extern bool event_addresses_oscs(amy_event *e);
 
 // osc -> (amy) voice ownership map (patches.c); AMY_UNSET for oscs outside any voice.
-extern uint8_t *osc_to_voice;
+// uint16_t, like every other voice index: a uint8_t here silently truncated
+// voice numbers once max_voices went over 255.
+extern uint16_t *osc_to_voice;
 
 extern struct delta **queue_for_patch_number(int patch_number);
 extern void update_num_oscs_for_patch_number(int patch_number);
@@ -1151,7 +1153,11 @@ extern void instruments_reset();
 extern void instrument_add_new(int instrument_number, int num_voices, uint16_t *amy_voices, uint16_t patch_number, uint16_t oscs_per_voice, uint8_t bus, uint32_t flags);
 extern void instrument_release(int instrument_number);
 extern void instrument_change_number(int old_instrument_number, int new_instrument_number);
-#define _INSTRUMENT_NO_VOICE (255)
+// "no voice" sentinel. Must stay outside the range of a real voice index:
+// the functions below return either this or an amy voice number, and both
+// are uint16_t, so 255 stopped being a safe choice once max_voices could
+// exceed it.
+#define _INSTRUMENT_NO_VOICE (UINT16_MAX)
 extern uint16_t instrument_voice_for_note_event(int instrument_number, int note, bool is_note_off, bool *pstolen);
 extern bool instrument_number_exists(int instrument_number, const char *tag);
 extern int instrument_get_num_voices(int instrument_number, uint16_t *amy_voices);

--- a/src/patches.c
+++ b/src/patches.c
@@ -13,7 +13,7 @@ uint32_t max_num_memory_patches = 0;
 struct delta **memory_patch_deltas = NULL;
 uint16_t *memory_patch_oscs = NULL;
 uint16_t next_user_patch_index = 0;
-uint8_t * osc_to_voice = NULL;
+uint16_t * osc_to_voice = NULL;
 uint16_t *voice_to_base_osc = NULL;
 
 void patches_deinit() {
@@ -28,13 +28,13 @@ void patches_init(int max_memory_patches) {
     uint8_t *alloc_base = malloc_caps(
             max_num_memory_patches * sizeof(struct delta *)
 	    + max_num_memory_patches * sizeof(uint16_t)
-            + AMY_OSCS * sizeof(uint8_t)
+            + AMY_OSCS * sizeof(uint16_t)
             + amy_global.config.max_voices * sizeof(uint16_t),
 	    amy_global.config.ram_caps_synth
     );
     memory_patch_deltas = (struct delta **)alloc_base;
     memory_patch_oscs = (uint16_t *)(memory_patch_deltas + max_num_memory_patches);
-    osc_to_voice = (uint8_t *)(memory_patch_oscs + max_num_memory_patches);
+    osc_to_voice = (uint16_t *)(memory_patch_oscs + max_num_memory_patches);
     voice_to_base_osc = (uint16_t *)(osc_to_voice + AMY_OSCS);
     bzero(memory_patch_deltas, max_num_memory_patches * sizeof(struct delta *));
     patches_reset();
@@ -68,9 +68,11 @@ void patches_reset() {
 }
 
 void patches_debug() {
-    for(uint8_t v = 0; v < amy_global.config.max_voices; v++) {
+    // uint16_t counter: a uint8_t one never reaches a max_voices of 256+,
+    // so this loop did not terminate.
+    for(uint16_t v = 0; v < amy_global.config.max_voices; v++) {
         if (AMY_IS_SET(voice_to_base_osc[v]))
-            fprintf(stderr, "voice %" PRIu8 " base osc %" PRIu16 "\n", v, voice_to_base_osc[v]);
+            fprintf(stderr, "voice %" PRIu16 " base osc %" PRIu16 "\n", v, voice_to_base_osc[v]);
     }
     fprintf(stderr, "osc_to_voice:\n");
     for(uint16_t i=0;i<AMY_OSCS;) {
@@ -78,7 +80,7 @@ void patches_debug() {
         fprintf(stderr, "%" PRIu16 ": ", i);
         for (j=0; j < 16; ++j) {
             if ((i + j) >= AMY_OSCS)  break;
-            fprintf(stderr, "%" PRIu8 " ", osc_to_voice[i + j]);
+            fprintf(stderr, "%" PRIu16 " ", osc_to_voice[i + j]);
         }
         i += j;
         fprintf(stderr, "\n");


### PR DESCRIPTION
Voice indices are `uint16_t` everywhere — `instrument_info.amy_voices`, `voice_to_base_osc`, `instrument_level_for_voice()`, the `voices[]` arrays `patches.c` passes around — except `osc_to_voice`, which was `uint8_t`. Set `config.max_voices` above 255 and any voice from 256 up gets silently truncated into the ownership map, so its oscs are recorded as belonging to some low-numbered voice instead.

The symptom is that the synth holding those voices goes **silent**. The "are these oscs still mine" check in `patches_voices_for_load_synth` compares `osc_to_voice[base + j]` against the real voice number; that compare never matches for a truncated entry, so the voice is left unset. The aliased low voice also ends up sharing an ownership record with it, so releasing one frees the other's oscs.

## What's in here

- `osc_to_voice` is `uint16_t *`, and the `patches_init` allocation sizes and casts to match.
- `_INSTRUMENT_NO_VOICE` 255 → `UINT16_MAX`. Without this the ceiling doesn't actually move: `instrument_note_on`, `instrument_note_off` and `instrument_voice_for_note_event` all return *either* that sentinel *or* a real amy voice number, both as `uint16_t`, so a successful note on voice 255 was indistinguishable from "no voice available". `UINT16_MAX` is also what `AMY_UNSET_VALUE` yields for a `uint16_t`, so the sentinel now matches the rest of the codebase. It stays safely out of range for the instrument-*local* slot indices it also marks, since those cap at `MAX_VOICES_PER_INSTRUMENT`.
- `patches_debug()`'s first loop counted voices in a `uint8_t`, so at `max_voices >= 256` it never terminated.

Incidental: this also removes an alignment hazard. `voice_to_base_osc` (a `uint16_t *`) is placed at `osc_to_voice + AMY_OSCS` inside one shared allocation, which lands on an odd address whenever `max_oscs` is odd. That pointer arithmetic is now in `uint16_t` units, so it can't.

Cost is `AMY_OSCS` extra bytes in the `patches_init` allocation — 250 on a default config, 1K at 1024 oscs.

## Measured

9 synths × 32 voices = 288 voices, `max_oscs` 2048, playing one note on the highest-numbered synth (so it owns voices 256–287):

| | highest index in `osc_to_voice` | oscs owned by a voice > 255 | nonzero samples | peak |
|---|---|---|---|---|
| before, 224 voices | 223 | 0 | 102172 | 3380 |
| before, 288 voices | **254** | 0 | **0 — silent** | 0 |
| after, 288 voices | 287 | 192 | 102172 | 3380 |

The last row is identical to the first, so nothing changes in the range that already worked.

`make test` is 119/119 both before and after (macOS, arm64). No test in the suite sets `max_voices` — they all run at the default 64 — so there was no cheap place to hang a regression test without adding config plumbing to `AmyTest`. Happy to add that in a follow-up if you'd like it covered. The reproducer:

<details>
<summary>voicetest.c</summary>

```c
/* Does a voice index above 255 survive the round trip?
 * link against the amy objects; run as ./voicetest [nsynths] */
#include "amy.h"
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>

void delay_ms(uint32_t ms) { usleep(ms * 1000); }

#define PER 32
static int NSYNTH = 9;

int main(int argc, char **argv) {
    if (argc > 1) NSYNTH = atoi(argv[1]);
    amy_config_t c = amy_default_config();
    c.audio = AMY_AUDIO_IS_NONE;
    c.features.default_synths = 0;
    c.features.startup_bleep = 0;
    c.max_oscs = 2048;
    c.max_voices = 300;
    amy_start(c);

    for (int s = 0; s < NSYNTH; s++) {
        amy_event e = amy_default_event();
        e.synth = 20 + s;
        e.num_voices = PER;
        e.patch_number = 0;          /* Juno: 5 oscs a voice */
        amy_add_event(&e);
    }
    /* the highest-numbered synth owns the highest voice numbers */
    amy_event e = amy_default_event();
    e.synth = 20 + NSYNTH - 1;
    e.midi_note = 60;
    e.velocity = 1.0f;
    amy_add_event(&e);

    long nz = 0; float peak = 0;
    for (int b = 0; b < 200; b++) {
        int16_t *buf = amy_simple_fill_buffer();
        for (int i = 0; i < AMY_BLOCK_SIZE * AMY_NCHANS; i++) {
            if (buf[i]) nz++;
            float a = buf[i] < 0 ? -buf[i] : buf[i];
            if (a > peak) peak = a;
        }
    }

    int high = 0, highest = -1;
    for (int o = 0; o < c.max_oscs; o++) {
        if (AMY_IS_SET(osc_to_voice[o])) {
            if (osc_to_voice[o] > 255) high++;
            if ((int)osc_to_voice[o] > highest) highest = osc_to_voice[o];
        }
    }
    printf("%d synths x %d voices = %d amy voices\n", NSYNTH, PER, NSYNTH * PER);
    printf("highest voice in osc_to_voice: %d   oscs owned by voice>255: %d\n",
           highest, high);
    printf("nonzero samples: %ld   peak: %.0f\n", nz, peak);
    printf("%s\n", (highest > 255 && nz > 0) ? "PASS" : "FAIL");
    return (highest > 255 && nz > 0) ? 0 : 1;
}
```
</details>

## Not touched

`patches_debug()`'s last loop counts memory patches in a `uint8_t` against `max_num_memory_patches`, which is the same non-terminating shape if anyone configures `max_memory_patches >= 256`. Left alone since it isn't a voice index, but say the word and I'll fold it in.