### PR TITLE
interp_partials: don't render partials that were never allocated

### DIFF
--- a/src/interp_partials.c
+++ b/src/interp_partials.c
@@ -43,6 +43,9 @@ const bool use_this_partial_map[MAX_NUM_HARMONICS] = {
 // choose a preset from the .h file
 void partials_note_on(uint16_t osc) {
     int num_partials = synth[osc]->preset;
+    // Never reserve or render past the end of the osc pool (see render_partials).
+    if (osc + 1 + num_partials > AMY_OSCS)
+        num_partials = (osc + 1 < AMY_OSCS) ? (AMY_OSCS - osc - 1) : 0;
     for (int i = 0; i < num_partials; ++i) {
         int o = osc + 1 + i;
         // On OOM this partial stays silent.
@@ -57,8 +60,9 @@ void partials_note_on(uint16_t osc) {
         msynth[o]->logfreq = synth[o]->logfreq_coefs[COEF_CONST] + msynth[osc]->logfreq;
         partial_note_on(o);
     }
-    // Squirrel away num_oscs
-    synth[osc]->last_two[0] = synth[osc]->preset;
+    // Squirrel away num_oscs -- the count we actually reserved, which the pool
+    // clamp above may have reduced below preset.
+    synth[osc]->last_two[0] = num_partials;
 }
 
 void partials_note_off(uint16_t osc) {
@@ -199,8 +203,16 @@ AMY_IRAM_ATTR SAMPLE render_partials(SAMPLE *buf, uint16_t osc) {
     // now, render everything, add it up
     float midi_note = midi_note_for_logfreq(msynth[osc]->logfreq);
     //fprintf(stderr, "t=%u partials o=%d msynth[osc]->logfreq=%f midi_note=%f msynth[amp]=%f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, osc, msynth[osc]->logfreq, midi_note, msynth[osc]->amp);
+    // Clamp to the osc pool. The assert below is compiled out in every firmware
+    // build (-DNDEBUG), and this loop no longer wraps with % AMY_OSCS, so an
+    // out-of-range count would read straight past synth[].
+    if (osc + 1 + num_oscs > AMY_OSCS)
+        num_oscs = (osc + 1 < AMY_OSCS) ? (AMY_OSCS - osc - 1) : 0;
     assert(osc < AMY_OSCS - (num_oscs + 1));  // We won't overrun.
     for(uint16_t o = osc + 1; o < osc + 1 + num_oscs; o++) {
+        // A partial can be absent: partials_note_on() skips ones that failed to
+        // allocate. Both note_off paths already guard this; this one didn't.
+        if(synth[o] == NULL) continue;
         if(synth[o]->role == SYNTH_IS_ALGO_SOURCE) {
             // We vary each partial's "velocity" on-the-fly as the way the parent osc's amplitude envelope contributes to the partials.
             synth[o]->velocity = msynth[osc]->amp;
@@ -349,9 +361,25 @@ void interp_partials_note_on(uint16_t osc) {
     // This has to be enough for any note in this map.  Assume num_harmonics[0] is largest (lowest pitch).
     uint8_t max_num_partials = _max_partials_for_partials_voice(partials_voice);
     uint8_t max_num_breakpoints[MAX_BREAKPOINT_SETS] = {2 + partials_voice->num_sample_times_ms, DEFAULT_NUM_BREAKPOINTS};
+    // The partials live at osc+1 .. osc+max_num_partials. If that range would
+    // run off the end of the osc pool, drop the note: ensure_osc_allocd()
+    // indexes synth[] without a bounds check, and render_partials() no longer
+    // wraps with % AMY_OSCS.
+    if (osc + 1 + max_num_partials > AMY_OSCS) {
+        synth[osc]->last_two[0] = 0;
+        return;
+    }
     for (int o = 0; o < max_num_partials; ++o) {
-        // On OOM drop the note rather than render under-sized partials.
-        if (!ensure_osc_allocd(osc + 1 + o, max_num_breakpoints)) return;
+        // On OOM drop the note rather than render under-sized partials. Clear the
+        // stashed partial count on the way out: render_partials() reads it as its
+        // loop bound, and returning without touching it leaves whatever was there
+        // before -- a previous note's count, or leftover FM feedback state, since
+        // last_two is a SAMPLE we're hijacking. Either makes the render walk oscs
+        // this note never set up.
+        if (!ensure_osc_allocd(osc + 1 + o, max_num_breakpoints)) {
+            synth[osc]->last_two[0] = 0;
+            return;
+        }
     }
     int partial_osc = osc;
     for (int h = 0; h < num_harmonics; ++h) {


### PR DESCRIPTION
Three ways `render_partials()` can walk oscs it shouldn't, all reachable when a big partials patch meets a nearly-full osc pool.

Found while investigating a periodic artifact at 8-voice piano polyphony on the AMYboard HW CI bench. **These are real out-of-bounds / uninitialized reads on their own, but they are _not_ confirmed to be that artifact's cause** — see [Scope](#scope-please-read) below. Reviewing this as a standalone hardening change is the right frame.

## The three paths

**1. OOM early-return leaves a stale loop bound.**
`interp_partials_note_on()` returns early when `ensure_osc_allocd()` fails, without ever setting `synth[osc]->last_two[0]` — which `render_partials()` reads as its loop bound. Whatever was there survives: a previous note's partial count, or leftover FM feedback state, since `last_two` is a `SAMPLE` being hijacked to carry an integer. The render then walks oscs this note never set up. Now zeroed on every early-out.

**2. `render_partials()` had no NULL guard.**
`partials_note_on()` deliberately skips partials that fail to allocate (`// On OOM this partial stays silent`), leaving those `synth[]` slots NULL. `render_partials()` then does:

```c
if(synth[o]->role == SYNTH_IS_ALGO_SOURCE) {
```

Both `partials_note_off()` and `interp_partials_note_off()` already guard this (`if (synth[o] == NULL) continue;` / `if (synth[o])`) — `render_partials()` was the odd one out.

**3. The bounds check doesn't exist in firmware.**
The loop lost its `% AMY_OSCS` wrap when it was unrolled for speed, and the `assert()` that replaced it is compiled out of every firmware build (`-DNDEBUG` is in the ESP-IDF flags), so an out-of-range count reads straight past `synth[]`. The count is now clamped to the pool in `render_partials()`, and both `note_on` paths refuse to reserve past the end.

Also: `partials_note_on()` stashed `synth[osc]->preset` rather than the number of partials it actually reserved. It now stores the clamped count.

## Testing

`make test` → **119 tests pass, all `err=-100.0 dB`** (bit-identical to the committed references). Behaviour is unchanged whenever the partials fit and allocate, which is every existing test — all the new code is guards on paths that don't trigger normally.

Also builds clean in tulipcc (macOS desktop target, which compiles AMY from source).

## Scope: please read

The artifact that prompted this — periodic transients at **167.5 ms** with `patch=256, num_voices=8` and 8 low notes held, reproduced twice on the HW CI bench at phase coherence ~0.89, with render load only 0.185 mean / 0.52 max — is **not** explained by these paths.

`patch_oscs[256] = 25`, so 8 voices reserve **200 oscs** against a default `max_oscs = 250`. The OOM path should not trigger there at all. My earlier osc-pool-exhaustion theory was wrong: `_max_partials_for_partials_voice()` returns a per-*preset* constant (24 partials, from `use_this_partial_map` over `num_harmonics[0]`), not a per-note count, so a voice reserves 25 oscs regardless of pitch.

So this PR is hardening for the ≥10-voice / larger-preset case. The 167.5 ms artifact is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)