### PR TITLE
oscillators.c: render_lut_256 shaves cycles off sine partial rendering.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ speedtest:
 
 speedtest-piano:
 	echo "Compiling LoadTestChord.ino..."
-	arduino-cli compile --fqbn esp32:esp32:amyboard --build-path ./build --build-property "compiler.c.extra_flags=-DARDUINO_SPEEDTEST" --build-property "compiler.cpp.extra_flags=-DSPEEDTEST_PATCH=256" tools/arduino_loadsweep/LoadTestChord
+	arduino-cli compile --fqbn esp32:esp32:amyboard --build-path ./build --build-property "compiler.c.extra_flags=-DARDUINO_SPEEDTEST" --build-property "compiler.cpp.extra_flags=-DSPEEDTEST_PATCH=256 -DSPEEDTEST_NUM_NOTES=6" tools/arduino_loadsweep/LoadTestChord
 	echo 'Running measure.py.  Press RESET on board after seeing "[flash] ok (attempt 1)"'
 	python tools/arduino_loadsweep/measure.py --out ./load --port ${USBSERIAL} ./build
 

--- a/amy/headers.py
+++ b/amy/headers.py
@@ -355,11 +355,11 @@ def generate_gamma9001_headers(sounds_dir='sounds/gamma9001', bin_path='build/dr
     print("gamma9001: %d ROM samples -> pcm_gamma808.h, %d samples (%.2f MB) -> %s + pcm_gamma9001.h + %s"
           % (len(rom), len(bin_entries), offset * 2 / 1e6, bin_path, c_path))
 
-def cos_lut(table_size, harmonics_weights, harmonics_phases=None):
+def cos_lut(table_size, harmonics_weights, harmonics_phases=None, extra_point=False):
     if harmonics_phases is None:
         harmonics_phases = np.zeros(len(harmonics_weights))
-    table = np.zeros(table_size)
-    phases = np.arange(table_size) * 2 * np.pi / table_size
+    table = np.zeros(table_size + extra_point)
+    phases = np.arange(table_size + extra_point) * 2 * np.pi / table_size
     for harmonic_number, harmonic_weight in enumerate(harmonics_weights):
         table += harmonic_weight * np.cos(
             phases * harmonic_number + harmonics_phases[harmonic_number])
@@ -369,7 +369,7 @@ def cos_lut(table_size, harmonics_weights, harmonics_phases=None):
 # A LUTset is a list of LUTentries describing downsampled versions of the same
 # basic waveform, sorted with the longest (highest-bandwidth) first.
 def create_lutset(LUTentry, harmonic_weights, harmonic_phases=None, 
-                  length_factor=8, bandwidth_factor=None):
+                  length_factor=8, bandwidth_factor=None, extra_point=False):
     if bandwidth_factor is None:
         bandwidth_factor = np.sqrt(0.5)
     """Create an ordered list of LUTs with decreasing harmonic content.
@@ -388,6 +388,7 @@ def create_lutset(LUTentry, harmonic_weights, harmonic_phases=None,
         bandwidth_factor: Target ratio between the highest harmonics in successive
             table entries. Default is sqrt(0.5), so after two tables, bandwidth is
             reduced by 1/2 (and length with follow).
+        extra_point: Add an extra point for interpolation without address wrap.
 
     Returns:
         A list of LUTentry objects, sorted in decreasing order of the highest 
@@ -410,7 +411,7 @@ def create_lutset(LUTentry, harmonic_weights, harmonic_phases=None,
         lut_size = int(2 ** np.ceil(np.log(length_factor * highest_harmonic) / np.log(2)))
         lutsets.append(LUTentry(
                 table=cos_lut(lut_size, harmonic_weights[:num_harmonics], 
-                                harmonic_phases[:num_harmonics]),    # / lut_size,
+                                harmonic_phases[:num_harmonics], extra_point),    # / lut_size,
                 highest_harmonic=highest_harmonic))
         float_num_harmonics = bandwidth_factor * float_num_harmonics
     return lutsets
@@ -487,12 +488,14 @@ def write_lutset_to_h(filename, variable_base, lutset):
     print("wrote", filename)
 
 
-def write_fxpt_lutable(f, lutable, name, samples_per_row=8):
+def write_fxpt_lutable(f, lutable, name, samples_per_row=8, attr=''):
     """Write a single lutable to an open file."""
     table_size = len(lutable)
     scale_factor = np.max(np.abs(lutable.astype(float)))
-    f.write("const int16_t {:s}[{:d}] PROGMEM = {{\n".format(
-        name, table_size))
+    if attr:
+        attr += ' '
+    f.write("{:s}const int16_t {:s}[{:d}] PROGMEM = {{\n".format(
+        attr, name, table_size))
     for row_start in range(0, table_size, samples_per_row):
         for sample_index in range(row_start,
                                   min(row_start + samples_per_row, table_size)):
@@ -506,7 +509,7 @@ def write_fxpt_lutable(f, lutable, name, samples_per_row=8):
     return scale_factor
 
 
-def write_lutset_to_h_as_fxpt(filename, variable_base, lutset):
+def write_lutset_to_h_as_fxpt(filename, variable_base, lutset, attr=''):
     """Save out a lutset as a C-compatible header file using ints."""
     import math
     num_luts = len(lutset)
@@ -532,7 +535,8 @@ def write_lutset_to_h_as_fxpt(filename, variable_base, lutset):
         for i in range(num_luts):
             scale_factor = write_fxpt_lutable(
                 f, lutset[i].table,
-                '{:s}_fxpt_lutable_{:d}'.format(variable_base, i)
+                '{:s}_fxpt_lutable_{:d}'.format(variable_base, i),
+                attr=attr,
             )
             scale_factors.append(scale_factor)
         # Define the table of LUTs.
@@ -543,7 +547,7 @@ def write_lutset_to_h_as_fxpt(filename, variable_base, lutset):
             # Provide the shift size corresponding to the lutset.
             log_2_table_size = int(round(math.log(table_size) / math.log(2.0)))
             f.write("    {{{:s}_fxpt_lutable_{:d}, {:d}, {:d}, {:d}, {:f}}},\n".format(
-                variable_base, i, table_size, log_2_table_size,
+                variable_base, i, table_size & -2, log_2_table_size,
                 lutset[i].highest_harmonic, scale_factors[i]))
         # Final entry is null to indicate end of table.
         f.write("    {NULL, 0, 0, 0, 0.0},\n")
@@ -1185,9 +1189,9 @@ def generate_all():
     write_lutset_to_h_as_fxpt('src/triangle_lutset_fxpt.h', 'triangle', triangle_lutset)
 
     # Sinusoid "lutset" (only one table)
-    sine_lutset = create_lutset(LUTentry, np.array([0, 1]),  harmonic_phases = -np.pi / 2 * np.ones(2), length_factor=256)
+    sine_lutset = create_lutset(LUTentry, np.array([0, 1]),  harmonic_phases = -np.pi / 2 * np.ones(2), length_factor=256, extra_point=True)
     #write_lutset_to_h('src/sine_lutset.h', 'sine', sine_lutset)
-    write_lutset_to_h_as_fxpt('src/sine_lutset_fxpt.h', 'sine', sine_lutset)
+    write_lutset_to_h_as_fxpt('src/sine_lutset_fxpt.h', 'sine', sine_lutset, attr='AMY_DRAM_ATTR')
 
     # log2/exp2 LUTs
     make_log2_exp2_luts('src/log2_exp2_fxpt_lutable.h')

--- a/src/amy.c
+++ b/src/amy.c
@@ -2192,20 +2192,20 @@ int16_t * amy_fill_buffer() {
             // TODO -- the esp stuff here could sit outside of AMY
             // For some reason, have to drop a bit to stop hard wrapping on esp?
 #if defined(ESP_PLATFORM) || defined(__IMXRT1062__)
-                uintval >>= 1;
-            #endif
+            uintval >>= 1;
+#endif
             if (positive) {
               sample = uintval;
             } else {
               sample = -uintval;
             }
             if(AMY_NCHANS == 1) {
-                #ifdef ESP_PLATFORM
+#ifdef ESP_PLATFORM
                     // esp32's i2s driver has this bug
                     output_block[i ^ 0x01] = sample;
-                #else
+#else
                     output_block[i] = sample;
-                #endif
+#endif
             } else {
                 output_block[(AMY_NCHANS * i) + c] = sample;
             }

--- a/src/amy_fixedpoint.h
+++ b/src/amy_fixedpoint.h
@@ -294,7 +294,7 @@ static inline SAMPLE SMULR7(SAMPLE a, SAMPLE b) {
 // Add 1 to B shift-up and cast to uint32_t to strip sign bit, pad a zero sign bit on way down.
 #define S_FRAC_OF_P(P, B) (int32_t)(((uint32_t)(((P) << ((B) + 1)))) >> (1 + P_FRAC_BITS - S_FRAC_BITS))
 // Increment phasor but wrap at +1.0
-#define P_WRAPPED_SUM(P, I) (int32_t)(((uint32_t)((((uint32_t)(P)) + ((uint32_t)(I))) << 1)) >> 1)
+#define P_WRAPPED_SUM(P, I) (int32_t)(((uint32_t)((((uint32_t)(P)) + ((uint32_t)(I))) << (32 - P_FRAC_BITS))) >> (32 - P_FRAC_BITS))
 
 #endif // AMY_USED_FIXEDPOINT
 

--- a/src/interp_partials.c
+++ b/src/interp_partials.c
@@ -72,7 +72,6 @@ void partials_note_off(uint16_t osc) {
     }
 }
 
-
 static inline float p_combine_controls(float *controls, float *coefs) {
     float result = 0;
     for (int i = 0; i <= COEF_EG0; ++i)

--- a/src/oscillators.c
+++ b/src/oscillators.c
@@ -217,7 +217,7 @@ AMY_IRAM_ATTR PHASOR render_lut_256(SAMPLE* buf,
                   const LUT* lut,
                   SAMPLE* pmax_value) {
     // RENDER_LUT_PREAMBLE
-    int lut_mask = 255;
+    //int lut_mask = 255;
     int lut_bits = 8;
     SAMPLE sample = 0;
     SAMPLE max_value = 0;

--- a/src/oscillators.c
+++ b/src/oscillators.c
@@ -209,6 +209,38 @@ AMY_IRAM_ATTR PHASOR render_lut(SAMPLE* buf,
     return phase;
 }
 
+// Highly optimized for 256 pt sine table
+AMY_IRAM_ATTR PHASOR render_lut_256(SAMPLE* buf,
+                  PHASOR phase,
+                  PHASOR step,
+                  SAMPLE incoming_amp, SAMPLE ending_amp,
+                  const LUT* lut,
+                  SAMPLE* pmax_value) {
+    // RENDER_LUT_PREAMBLE
+    int lut_mask = 255;
+    int lut_bits = 8;
+    SAMPLE sample = 0;
+    SAMPLE max_value = 0;
+    SAMPLE current_amp = incoming_amp;
+    SAMPLE incremental_amp = SHIFTR(ending_amp - incoming_amp, BLOCK_SIZE_BITS);
+    for(uint16_t i = 0; i < AMY_BLOCK_SIZE; i++) {
+        int16_t base_index = INT_OF_P(phase, lut_bits);
+        SAMPLE frac = S_FRAC_OF_P(phase, lut_bits);
+        SAMPLE b = L2S(lut->table[base_index]);
+        //SAMPLE c = L2S(lut->table[(base_index + 1) & lut_mask]);
+        SAMPLE c = L2S(lut->table[base_index + 1]); // table has guard point at end
+        sample = b + MUL0_SS(c - b, frac);
+        SAMPLE value = buf[i] + MULA_SS(sample, current_amp);
+        buf[i] = value;
+        if (value < 0) value = -value;
+        if (value > max_value) max_value = value;
+        current_amp += incremental_amp;
+        phase = P_WRAPPED_SUM(phase, step);
+    }
+    *pmax_value = max_value;
+    return phase;
+}
+
 AMY_IRAM_ATTR PHASOR render_lut_cub(SAMPLE* buf,
                       PHASOR phase,
                       PHASOR step,
@@ -664,7 +696,8 @@ AMY_IRAM_ATTR SAMPLE render_partial(SAMPLE * buf, uint16_t osc) {
     SAMPLE last_amp = F2S(msynth[osc]->last_amp);
     //printf("render_partial: time %.3f logfreq %f freq %f last_amp %f amp %f step %f\n", (float)amy_global.total_blocks*AMY_BLOCK_SIZE/(float)AMY_SAMPLE_RATE, msynth[osc]->logfreq, freq, S2F(last_amp), S2F(amp), P2F(step) * synth[osc]->lut->table_size);
     SAMPLE max_value;
-    synth[osc]->phase = render_lut(buf, synth[osc]->phase, step, last_amp, amp, /* synth[osc]->lut */ &sine_fxpt_lutset[0], &max_value);
+    //synth[osc]->phase = render_lut(buf, synth[osc]->phase, step, last_amp, amp, /* synth[osc]->lut */ &sine_fxpt_lutset[0], &max_value);
+    synth[osc]->phase = render_lut_256(buf, synth[osc]->phase, step, last_amp, amp, /* synth[osc]->lut */ &sine_fxpt_lutset[0], &max_value);
     msynth[osc]->last_amp = msynth[osc]->amp;
     return max_value;
 }

--- a/src/sine_lutset_fxpt.h
+++ b/src/sine_lutset_fxpt.h
@@ -13,7 +13,7 @@ typedef struct {
 } lut_entry_fxpt;
 #endif // LUTENTRY_FXPT_DEFINED
 
-const int16_t sine_fxpt_lutable_0[256] PROGMEM = {
+AMY_DRAM_ATTR const int16_t sine_fxpt_lutable_0[257] PROGMEM = {
 0,804,1608,2411,3212,4011,4808,5602,
 6393,7180,7962,8740,9512,10279,11039,11793,
 12540,13279,14010,14733,15447,16151,16846,17531,
@@ -46,6 +46,7 @@ const int16_t sine_fxpt_lutable_0[256] PROGMEM = {
 -18205,-17531,-16846,-16151,-15447,-14733,-14010,-13279,
 -12540,-11793,-11039,-10279,-9512,-8740,-7962,-7180,
 -6393,-5602,-4808,-4011,-3212,-2411,-1608,-804,
+0,
 };
 
 lut_entry_fxpt sine_fxpt_lutset[2] = {


### PR DESCRIPTION
By having a special case `render_lut_256` in which the lookup table is assumed to be 256 points with an extra 257th point at the end to avoid having to wrap the index, we're able to bring 6-note speediest-piano from 4068us down to 3412us.