### PR TITLE
amy_oom: log only the first failure, count the rest

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -219,13 +219,17 @@ output_sample_type * output_block;
 #endif
 
 // All runtime allocation failures report through here: count, log, and under
-// AMY_DEBUG abort() at the cause instead of degrading silently.
+// AMY_DEBUG abort() at the cause instead of degrading silently. Only the
+// first failure is logged: this can run on the render thread, where stdio
+// blocks, and failed allocations retry (and re-fail) on every note-on.
+// Poll amy_get_oom_count() for ongoing failures.
 void amy_oom(const char *fmt, ...) {
-    ++amy_global.oom_count;
-    va_list ap;
-    va_start(ap, fmt);
-    vfprintf(stderr, fmt, ap);
-    va_end(ap);
+    if (++amy_global.oom_count == 1) {
+        va_list ap;
+        va_start(ap, fmt);
+        vfprintf(stderr, fmt, ap);
+        va_end(ap);
+    }
 #ifdef AMY_DEBUG
     abort();
 #endif


### PR DESCRIPTION
Cleanup of poorly thought out logging implementation on my part:

amy_oom() writes every allocation failure to stderr, but it can be reached
from the render thread — e.g. `alloc_osc` growing a voice at note-on — where
a blocking serial write on an MCU costs more than a block deadline (~4 ms per
line at 115200 vs a 5.3 ms block). And since a failed osc alloc leaves the
osc NULL, the next note-on retries and fails again: once the heap is
exhausted, every note floods stderr from the audio path. Observed on
ESP32-S3: a failing interp-partials piano chord missed many consecutive
block deadlines purely from the printing, turning #961's graceful degrade
into an audible stall.

This logs the first failure since `amy_start()` (keeping the root-cause
diagnostic) and only counts the rest — `amy_get_oom_count()` is the pollable
signal for ongoing failures. `AMY_DEBUG` still aborts at the first cause,
and `amy_start()` resetting the counter re-arms the print per session.

No behavior change when allocations succeed.