### PR TITLE
Store sequencer (H) and timed (t) events as wire strings, parsed at play time

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -515,7 +515,6 @@ int8_t global_init(amy_config_t c) {
     amy_global.sequencer_tick_count = 0;
     amy_global.next_amy_tick_us = 0;
     amy_global.us_per_tick = 0;
-    amy_global.sequence_entry_ll_start = NULL;
 
     struct bus_state *bus_configs = malloc_caps(sizeof(struct bus_state) * AMY_NUM_BUSES,
                                                 amy_global.config.ram_caps_synth);
@@ -2032,9 +2031,11 @@ void amy_execute_delta() {
 // this takes scheduled deltas and plays them at the right time
 void amy_execute_deltas() {
     AMY_PROFILE_START(AMY_EXECUTE_DELTAS)
-    // Advance the sequencer on AMY (sample) time and queue any due sequence
+    // Advance the sequencer on AMY (sample) time and play any due sequence
     // events, so sequencing works in any rendering context, real-time or not.
     sequencer_check_and_fill();
+    // Play any timed ('t') wire messages that have come due.
+    timed_wire_check_and_fire();
     // Make sure any CV-triggered events are added to delta queue
     update_external_cv_in();
 

--- a/src/amy.h
+++ b/src/amy.h
@@ -662,13 +662,20 @@ struct mod_synthinfo {
 };
 
 
-typedef struct sequence_entry_ll_t {
-    struct delta d;
-    uint32_t tag;
-    uint32_t tick; // 0 means not used 
-    uint32_t period; // 0 means not used 
-    struct sequence_entry_ll_t *next;
-} sequence_entry_ll_t;
+// Result of the fast ingest scan of one wire message for the scheduling
+// commands 't' (time) and 'H' (sequence).  See amy_scan_wire_message().
+typedef struct wire_schedule_t {
+    uint16_t consumed;      // chars of message in this segment (incl. 'Z')
+    uint8_t has_time;       // top-level 't' command found
+    uint8_t has_sequence;   // top-level 'H' command found
+    uint32_t time;          // value of 't'
+    uint32_t sequence[3];   // tick, period, tag from 'H' (missing values 0)
+    uint16_t time_span[2];  // [start, end) of the 't' command, for stripping
+    uint16_t seq_span[2];   // [start, end) of the 'H' command, for stripping
+} wire_schedule_t;
+
+uint16_t amy_scan_wire_message(char *message, wire_schedule_t *ws);
+uint16_t amy_strip_scheduling(const char *message, const wire_schedule_t *ws, char *out);
 
 
 typedef struct delay_line {
@@ -878,7 +885,6 @@ typedef struct global_state {
     uint32_t sequencer_tick_count;
     uint64_t next_amy_tick_us;
     uint32_t us_per_tick;
-    sequence_entry_ll_t * sequence_entry_ll_start;
 
     // Buses
     bus_state_t *bus[AMY_NUM_BUSES];
@@ -978,6 +984,9 @@ uint32_t ms_to_samples(uint32_t ms) ;
 
 // API
 void amy_add_message(char *message);
+// Parse and play a stored wire message now; base_time (UINT32_MAX for none)
+// supplies the time for events that don't carry their own.
+void amy_play_message_with_time(char *message, uint32_t base_time);
 // Like amy_add_message but the data is treated as coming from an external
 // sysex source, so file transfer routing (transfer_flag) applies.
 void amy_add_message_from_sysex(char *message);

--- a/src/api.c
+++ b/src/api.c
@@ -261,16 +261,73 @@ uint32_t amy_sysclock() {
 // would get base64-decoded and written to the file as garbage.
 bool amy_parsing_from_sysex = false;
 
-// given a wire message string play / schedule the event directly (WIRE API)
-void amy_add_message(char *message) {
-    peek_stack("add_message");
+// Parse and play a stored wire message now.  base_time is the original 't'
+// value of a timed message (or UINT32_MAX for none): events that don't carry
+// their own time get it, so the resulting deltas have the same times (and
+// ordering) as if the message had been parsed when it arrived.
+void amy_play_message_with_time(char *message, uint32_t base_time) {
+    peek_stack("play_message");
     amy_event e;
     size_t pos = 0;
     do {
         amy_clear_event(&e);
         pos = yield_event_from_message(message, &e, pos);
-        if (pos > 0)  amy_add_event(&e);
+        if (pos > 0) {
+            if (base_time != UINT32_MAX && AMY_IS_UNSET(e.time))  e.time = base_time;
+            amy_add_event(&e);
+        }
     } while(pos > 0);
+}
+
+// given a wire message string play / schedule the event directly (WIRE API)
+void amy_add_message(char *message) {
+    peek_stack("add_message");
+    amy_event e;
+    size_t pos = 0;
+    size_t len = strlen(message);
+    while (pos < len) {
+        // Transfer payloads (base64 sample/file data) must not be scanned for
+        // scheduling commands; hand them straight to the parser, which routes
+        // them to parse_transfer_message.  (Same condition as amy_parse_message.)
+        if (amy_global.transfer_flag == AMY_TRANSFER_TYPE_AUDIO ||
+            (amy_parsing_from_sysex && amy_global.transfer_flag == AMY_TRANSFER_TYPE_FILE)) {
+            amy_clear_event(&e);
+            pos = yield_event_from_message(message, &e, pos);
+            if (pos == 0) break;
+            amy_add_event(&e);
+            continue;
+        }
+        // Fast pre-scan of this message for scheduling commands ('t' in the
+        // future, or 'H').  Scheduled messages are stored as their raw wire
+        // string and only parsed when they come due; everything else takes
+        // the normal parse-and-play path.
+        wire_schedule_t ws;
+        amy_scan_wire_message(message + pos, &ws);
+        if (ws.has_sequence ||
+            (ws.has_time && !AMY_TIME_GEQ(amy_sysclock(), ws.time))) {
+            char *stripped = (char *)malloc_caps(ws.consumed + 1, amy_global.config.ram_caps_events);
+            if (stripped == NULL) {
+                amy_oom("add_message");
+            } else {
+                amy_strip_scheduling(message + pos, &ws, stripped);
+                if (ws.has_sequence) {
+                    // 'H' wins if both are present (as before: a sequenced
+                    // event's time field is effectively ignored).
+                    sequencer_add_wire(ws.sequence[SEQUENCE_TICK], ws.sequence[SEQUENCE_PERIOD],
+                                       ws.sequence[SEQUENCE_TAG], stripped);
+                } else {
+                    timed_wire_add(ws.time, stripped);
+                }
+            }
+            pos += ws.consumed;
+            continue;
+        }
+        // Not scheduled (or 't' is now/past): parse and play it now.
+        amy_clear_event(&e);
+        pos = yield_event_from_message(message, &e, pos);
+        if (pos == 0) break;
+        amy_add_event(&e);
+    }
 }
 
 // Like amy_add_message but marks the message as coming from an external
@@ -287,8 +344,16 @@ void amy_add_event(amy_event *e) {
     peek_stack("add_event");
     // was amy_process_event
     if(AMY_IS_SET(e->sequence[SEQUENCE_TICK]) || AMY_IS_SET(e->sequence[SEQUENCE_PERIOD]) || AMY_IS_SET(e->sequence[SEQUENCE_TAG])) {
-        uint8_t added = sequencer_add_event(e);
-        (void)added; // we don't need to do anything with this info at this time
+        // C-API sequenced event: serialize it to a wire message and hand it to
+        // the wire scheduler, so sequences have a single storage format.
+        char *buf = (char *)malloc_caps(MAX_MESSAGE_LEN, amy_global.config.ram_caps_events);
+        if (buf == NULL) {
+            amy_oom("add_event sequence");
+            return;
+        }
+        sprint_event(e, buf, MAX_MESSAGE_LEN, /* wirecode */ true);
+        amy_add_message(buf);
+        free(buf);
     } else if (AMY_IS_SET(e->reset_osc) && (e->reset_osc & RESET_PATCH) && AMY_IS_SET(e->patch_number)) {
         // We're resetting just one patch, do it now.  But RESET_PATCH with no patch_number should propagate to deltas.
         patches_reset_patch(e->patch_number);
@@ -306,6 +371,12 @@ void amy_add_event(amy_event *e) {
         // event doesn't read back as having no time at all.
         if(AMY_IS_UNSET(playback_time)) playback_time++;
         e->time = playback_time;
+        if (!AMY_TIME_GEQ(amy_sysclock(), playback_time)) {
+            // Future event: park a copy in the timed store.  Nothing about it
+            // (parsing, voice allocation, patch loads) happens until it's due.
+            timed_event_add(playback_time, e);
+            return;
+        }
         amy_event_to_deltas_queue(e, 0, &amy_global.delta_queue);
     }
 }
@@ -422,6 +493,7 @@ void amy_overload_failsafe() {
     amy_grab_lock();
     amy_deltas_reset();
     amy_release_lock();
+    timed_wire_reset();  // takes the lock itself
     amy_event e = amy_default_event();
     e.reset_osc = RESET_ALL_NOTES | RESET_ALL_OSCS | RESET_SEQUENCER;
     amy_add_event(&e);

--- a/src/midi_mappings.c
+++ b/src/midi_mappings.c
@@ -367,6 +367,15 @@ void midi_message_handler_to_queue(uint8_t * bytes, uint16_t len, uint32_t time,
     //
     void *state = NULL;
     if (queue == NULL)  queue = &amy_global.delta_queue;
+    if (queue == &amy_global.delta_queue && base_event == NULL && len <= 3
+        && AMY_IS_SET(time) && !AMY_TIME_GEQ(amy_sysclock(), time)) {
+        // Live MIDI input with a future timestamp: park the raw bytes in the
+        // timed store.  The whole handler (mapping lookup, template expansion,
+        // voice allocation) runs when the message comes due, against the synth
+        // state of that moment, not the state at ingest.
+        timed_midi_add(time, bytes, (uint8_t)len);
+        return;
+    }
     amy_event e;
     bool fake_note_on = (((bytes[0] & 0xF0) == 0x90) && (bytes[2] == 0xFF));
     do {

--- a/src/parse.c
+++ b/src/parse.c
@@ -620,6 +620,105 @@ int _next_alpha(char *s) {
 }
 
 
+// Fast pre-parse of one wire message for the scheduling commands 't' (time)
+// and 'H' (sequence).  This is the ingest fast path: a scheduled message is
+// stored as its raw wire string (with t/H stripped out) and only fully parsed
+// when it comes due, so bulk loads of sequencer/timed events don't pay for
+// event parsing, voice allocation and delta expansion up front.
+//
+// The scan walks command letters and skips their numeric arguments, without
+// interpreting them.  Commands whose argument is a string that may itself
+// contain wire code or arbitrary text (patch strings 'u', MIDI/CV templates
+// 'ic'/'io'/'ig', filename/code transfers 'zT'/'zF'/'zD'/'zP') consume the
+// rest of the message in the real parser, so the scan treats them as opaque:
+// it stops looking and extends the segment to the end of the string.  Any
+// 't'/'H' after such a command is part of that command's payload, never a
+// top-level scheduling command, so nothing is missed.
+//
+// Returns the number of chars in this message segment (through the 'Z'
+// terminator, or to end of string).  Fills *ws.
+uint16_t amy_scan_wire_message(char *message, wire_schedule_t *ws) {
+    uint16_t pos = 0;
+    ws->has_time = 0;
+    ws->has_sequence = 0;
+    ws->time_span[0] = ws->time_span[1] = 0;
+    ws->seq_span[0] = ws->seq_span[1] = 0;
+    while (message[pos]) {
+        char c = message[pos];
+        if (!isalpha((unsigned char)c)) { ++pos; continue; }
+        if (c == 'Z') { ++pos; break; }  // end of message
+        if (c == 't') {
+            uint16_t start = pos++;
+            ws->time = (uint32_t)atol(message + pos);
+            pos += _next_alpha(message + pos);
+            ws->has_time = 1;
+            ws->time_span[0] = start;
+            ws->time_span[1] = pos;
+            continue;
+        }
+        if (c == 'H') {
+            uint16_t start = pos++;
+            ws->sequence[0] = ws->sequence[1] = ws->sequence[2] = 0;
+            parse_list_uint32_t(message + pos, ws->sequence, 3, 0);
+            pos += _next_alpha(message + pos);
+            ws->has_sequence = 1;
+            ws->seq_span[0] = start;
+            ws->seq_span[1] = pos;
+            continue;
+        }
+        if (c == 'u') {  // patch string: rest of message is its payload
+            pos += (uint16_t)strlen(message + pos);
+            break;
+        }
+        if (c == 'i') {
+            char sub = message[pos + 1];
+            if (sub == 'c' || sub == 'o' || sub == 'g') {  // wire-code templates
+                pos += (uint16_t)strlen(message + pos);
+                break;
+            }
+            ++pos;
+            if (isalpha((unsigned char)sub)) ++pos;  // skip subcommand letter; numeric arg follows
+            continue;
+        }
+        if (c == 'z') {
+            char sub = message[pos + 1];
+            if (sub == 'T' || sub == 'F' || sub == 'D' || sub == 'P') {  // string payloads
+                pos += (uint16_t)strlen(message + pos);
+                break;
+            }
+            ++pos;
+            if (isalpha((unsigned char)sub)) ++pos;
+            continue;
+        }
+        ++pos;  // any other command; its non-alpha argument is skipped above
+    }
+    ws->consumed = pos;
+    return pos;
+}
+
+// Copy the message segment described by ws into out, minus the t/H command
+// spans.  out must have room for ws->consumed + 1 chars.  Returns the length
+// of the stripped string.
+uint16_t amy_strip_scheduling(const char *message, const wire_schedule_t *ws, char *out) {
+    // Order the (up to two) spans by start position; zero-length spans are no-ops.
+    uint16_t s1 = ws->time_span[0], e1 = ws->time_span[1];
+    uint16_t s2 = ws->seq_span[0], e2 = ws->seq_span[1];
+    if (s2 < s1) {
+        uint16_t ts = s1, te = e1;
+        s1 = s2; e1 = e2;
+        s2 = ts; e2 = te;
+    }
+    uint16_t o = 0;
+    for (uint16_t i = 0; i < ws->consumed; ++i) {
+        if (i >= s1 && i < e1) continue;
+        if (i >= s2 && i < e2) continue;
+        out[o++] = message[i];
+    }
+    out[o] = '\0';
+    return o;
+}
+
+
 size_t yield_event_from_message(char *message, amy_event *e, size_t pos) {
     //fprintf(stderr, "yield_event_from_message in:  pos %d message %s\n", pos, message);
     // Parse the wire string into an event
@@ -750,6 +849,7 @@ int amy_parse_message(char * message, amy_event *e) {
                     }
                     if(e->reset_osc & RESET_EVENTS) {
                         amy_deltas_reset();
+                        timed_wire_reset();
                     }
                     if(e->reset_osc & RESET_SYNTHS) {
                         amy_reset_oscs();

--- a/src/patches.c
+++ b/src/patches.c
@@ -1024,8 +1024,8 @@ void patches_event_has_voices(amy_event *e, struct delta **queue) {
         // Remove the note and vel that we've put in the MIDI event, but keep any other event flags.
         AMY_UNSET(e->midi_note);
         AMY_UNSET(e->velocity);
-        // Pass the target queue through: if this event is being stored (e.g. it came
-        // from sequencer_add_event), its deltas must land in that queue, not play now.
+        // Pass the target queue through: if this event is being stored (e.g. into
+        // a patch), its deltas must land in that queue, not play now.
         midi_message_handler_to_queue(bytes, 3, e->time, e, queue);
     } else {
         uint16_t voices[MAX_VOICES_PER_INSTRUMENT];

--- a/src/sequencer.c
+++ b/src/sequencer.c
@@ -7,29 +7,55 @@
 
 uint32_t sequencer_ticks() { return amy_global.sequencer_tick_count; }
 
+// Both the sequencer and timed ('t' in the future) events are stored the same
+// way: as the raw wire-message string (with its t/H command stripped) plus the
+// scheduling metadata needed to play it back.  The string is only parsed when
+// the entry comes due, so bulk ingest of scheduled events is just a scan and
+// a copy -- no event parsing, voice allocation or delta expansion up front.
 typedef struct sequence_info_t {
-    struct delta *deltas;
+    char *wire;    // Stored wire message; NULL means the tag is unused.
     //uint32_t tag;  // tag is implicit, it's its index in the table
     uint32_t tick; // 0 means not used
     uint32_t period; // 0 means not used
 } sequence_info_t;
 
+// One-shot messages scheduled at an absolute ms time ('t' in the future),
+// kept in a time-sorted list so the per-block check is O(1) when nothing is
+// due.  Wire-sourced entries hold the raw string; C-API-sourced entries hold
+// a copy of the parsed event (no lossy string round-trip); MIDI-sourced
+// entries hold the raw MIDI bytes so mapping lookup and template expansion
+// happen against the synth state at play time, not at ingest.
+typedef struct timed_wire_t {
+    char *wire;            // wire-sourced entry, or...
+    amy_event *event;      // ...event-sourced entry, or...
+    uint8_t midi_len;      // ...nonzero for a raw-MIDI entry
+    uint8_t midi_bytes[3];
+    uint32_t time;         // absolute ms on the wire clock (amy_sysclock)
+    struct timed_wire_t *next;
+} timed_wire_t;
+
 struct sequence_info_t *sequences = NULL;  // An array indexed by tag.
 int32_t max_sequences = 0;
 int32_t highest_tag = -1;
+static timed_wire_t *timed_wire_head = NULL;
 static volatile bool sequencer_running = true;
 static volatile bool sequencer_external_clock = false;
+// Firing a stored message parses it, and parsing (e.g. a patch load) can call
+// amy_execute_deltas(), which calls back into the check functions below.  This
+// flag makes those nested calls no-ops so a tick is never processed twice.
+static volatile bool wire_firing = false;
 
 void sequencer_init(int max_sequencer_tags) {
     // These are statics, so a stop/start of AMY within one process needs them
     // put back to their boot state (internal clock, running).
     sequencer_running = true;
     sequencer_external_clock = false;
+    wire_firing = false;
     max_sequences = max_sequencer_tags;
     sequences = (struct sequence_info_t *)malloc_caps(max_sequences * sizeof(struct sequence_info_t),
                                                       amy_global.config.ram_caps_synth);
     for (int32_t i = 0; i < max_sequences; ++i) {
-        sequences[i].deltas = NULL;
+        sequences[i].wire = NULL;
         sequences[i].tick = 0;
         sequences[i].period = 0;
     }
@@ -38,11 +64,12 @@ void sequencer_init(int max_sequencer_tags) {
 }
 
 void sequencer_reset() {
-    // Remove all events
+    // Remove all events.  No lock here: this is called from play_delta()
+    // (RESET_SEQUENCER), which already runs under the amy lock.
     for (int32_t i = 0; i < max_sequences; ++i) {
-        if (sequences[i].deltas) {
-            delta_release_list(sequences[i].deltas);
-            sequences[i].deltas = NULL;
+        if (sequences[i].wire) {
+            free(sequences[i].wire);
+            sequences[i].wire = NULL;
             sequences[i].tick = 0;
             sequences[i].period = 0;
         }
@@ -50,8 +77,23 @@ void sequencer_reset() {
     highest_tag = -1;
 }
 
+void timed_wire_reset() {
+    // Drop all pending timed messages (RESET_EVENTS and the overload failsafe).
+    amy_grab_lock();
+    timed_wire_t *t = timed_wire_head;
+    timed_wire_head = NULL;
+    amy_release_lock();
+    while (t) {
+        timed_wire_t *next = t->next;
+        if (t->wire) free(t->wire);
+        free(t);  // an event entry is co-allocated with its node
+        t = next;
+    }
+}
+
 void sequencer_deinit() {
     sequencer_reset();
+    timed_wire_reset();
     if (sequences != NULL) free(sequences);
     sequences = NULL;  // sequencer_check_and_fill guards on this
     max_sequences = 0;
@@ -59,11 +101,15 @@ void sequencer_deinit() {
 
 void sequencer_debug() {
     fprintf(stderr, "sequencer: max_sequences %" PRIi32" highest_tag %" PRIi32 "\n", max_sequences, highest_tag);
-    for (int32_t tag = 0; tag < max_sequences; ++tag) {
-        if (sequences[tag].deltas) {
-            fprintf(stderr, "sequence tag %" PRIu32" tick %" PRIu32 " period %"PRIu32 " num_deltas %"PRIu32 "\n",
-                    tag, sequences[tag].tick, sequences[tag].period, delta_list_len(sequences[tag].deltas));
+    for (int32_t tag = 0; tag <= highest_tag; ++tag) {
+        if (sequences[tag].wire) {
+            fprintf(stderr, "sequence tag %" PRIi32" tick %" PRIu32 " period %"PRIu32 " wire \"%s\"\n",
+                    tag, sequences[tag].tick, sequences[tag].period, sequences[tag].wire);
         }
+    }
+    for (timed_wire_t *t = timed_wire_head; t != NULL; t = t->next) {
+        fprintf(stderr, "timed wire time %" PRIu32 " %s\"%s\"\n", t->time,
+                t->wire ? "wire " : "event ", t->wire ? t->wire : "");
     }
 }
 
@@ -74,12 +120,143 @@ void sequencer_recompute() {
     amy_global.next_amy_tick_us = (amy_sysclock64() * 1000ULL) + (uint64_t)amy_global.us_per_tick;
 }
 
+// Store a wire message in the sequencer.  Takes ownership of wire (malloc'd).
+// If tick and period are both zero, the tag's entry is cleared.
+uint8_t sequencer_add_wire(uint32_t tick, uint32_t period, uint32_t tag, char *wire) {
+    if (sequences == NULL) {  // sequencer_init hasn't run
+        free(wire);
+        return 0;
+    }
+    if (tag >= (uint32_t)max_sequences) {
+        fprintf(stderr, "sequencer tag %" PRIu32" (with tick %" PRIu32", period %" PRIu32") is greater than or eq max_sequences %" PRIi32"\n",
+                tag, tick, period, max_sequences);
+        free(wire);
+        return 0;
+    }
+    amy_grab_lock();
+    // Release any existing message for this tag, even if we're just going to rewrite it.
+    if (sequences[tag].wire) free(sequences[tag].wire);
+    sequences[tag].wire = NULL;
+    sequences[tag].tick = 0;
+    sequences[tag].period = 0;
+    if ((tick == 0 && period == 0) ||  // Non-schedulable event: just clear the tag.
+        (tick != 0 && period == 0 && tick <= amy_global.sequencer_tick_count)) {  // don't schedule things in the past.
+        amy_release_lock();
+        free(wire);
+        return 0;
+    }
+    sequences[tag].tick = tick;
+    sequences[tag].period = period;
+    sequences[tag].wire = wire;
+    if ((int32_t)tag > highest_tag) highest_tag = tag;  // To limit scanning through tags.
+    amy_release_lock();
+    return 1;
+}
+
+static void timed_insert(timed_wire_t *n) {
+    amy_grab_lock();
+    // Insert in time order; equal times keep arrival order (insert after).
+    // Wrap-relative compare, same as the delta queue: see AMY_TIME_GEQ.
+    timed_wire_t **pptr = &timed_wire_head;
+    while (*pptr && AMY_TIME_GEQ(n->time, (*pptr)->time))
+        pptr = &(*pptr)->next;
+    n->next = *pptr;
+    *pptr = n;
+    amy_release_lock();
+}
+
+// Store a one-shot wire message to play at an absolute ms time.
+// Takes ownership of wire (malloc'd).
+void timed_wire_add(uint32_t time, char *wire) {
+    timed_wire_t *n = (timed_wire_t *)malloc_caps(sizeof(timed_wire_t), amy_global.config.ram_caps_events);
+    if (n == NULL) {
+        amy_oom("timed_wire_add");
+        free(wire);
+        return;
+    }
+    n->wire = wire;
+    n->event = NULL;
+    n->midi_len = 0;
+    n->time = time;
+    timed_insert(n);
+}
+
+// Store a copy of an already-parsed event (C API with a future time) to play
+// at an absolute ms time.  e->time must already be the final playback time
+// (latency included).
+void timed_event_add(uint32_t time, amy_event *e) {
+    timed_wire_t *n = (timed_wire_t *)malloc_caps(sizeof(timed_wire_t) + sizeof(amy_event),
+                                                  amy_global.config.ram_caps_events);
+    if (n == NULL) {
+        amy_oom("timed_event_add");
+        return;
+    }
+    n->wire = NULL;
+    n->event = (amy_event *)(n + 1);
+    *n->event = *e;
+    n->midi_len = 0;
+    n->time = time;
+    timed_insert(n);
+}
+
+// Store a raw (non-sysex) MIDI message with a future timestamp.
+void timed_midi_add(uint32_t time, uint8_t *bytes, uint8_t len) {
+    timed_wire_t *n = (timed_wire_t *)malloc_caps(sizeof(timed_wire_t), amy_global.config.ram_caps_events);
+    if (n == NULL) {
+        amy_oom("timed_midi_add");
+        return;
+    }
+    n->wire = NULL;
+    n->event = NULL;
+    n->midi_len = len;
+    for (uint8_t i = 0; i < len && i < 3; ++i) n->midi_bytes[i] = bytes[i];
+    n->time = time;
+    timed_insert(n);
+}
+
+// Called once per block from amy_execute_deltas(), and independent of the
+// sequencer transport: timed messages play whether or not the sequencer runs.
+void timed_wire_check_and_fire() {
+    if (wire_firing) return;  // nested via a fired message's own parse
+    wire_firing = true;
+    for (;;) {
+        timed_wire_t *n = NULL;
+        amy_grab_lock();
+        uint32_t now = amy_sysclock();
+        if (timed_wire_head && AMY_TIME_GEQ(now, timed_wire_head->time)) {
+            n = timed_wire_head;
+            timed_wire_head = n->next;
+        }
+        amy_release_lock();
+        if (n == NULL) break;
+        if (n->wire != NULL) {
+            // Play with the original 't' as the base time so the resulting deltas
+            // carry the same times (and ordering) as if they'd been queued at ingest.
+            amy_play_message_with_time(n->wire, n->time);
+            free(n->wire);
+        } else if (n->event != NULL) {
+            // Already-parsed event: its time is final, convert to deltas now.
+            amy_event_to_deltas_queue(n->event, 0, &amy_global.delta_queue);
+        } else {
+            // Raw MIDI: run the full handler now, against current synth state.
+            // The message is due, so the handler won't re-defer it.
+            midi_message_handler_to_queue(n->midi_bytes, n->midi_len, n->time, NULL, NULL);
+        }
+        free(n);
+    }
+    wire_firing = false;
+}
+
 static void sequencer_process_tick(void) {
     amy_global.sequencer_tick_count++;
     midi_clock_out_tick();  // no-op unless in AMY_MIDI_SYNC_SEND mode
-    // Scan through LL looking for matches
+    // Guard nested check-and-fire calls (via a fired message's own parse)
+    // while still processing this tick's fires; restore on the way out.
+    bool was_firing = wire_firing;
+    wire_firing = true;
+    // Scan through the tag table looking for matches
     for (int32_t tag = 0; tag <= highest_tag; ++tag) {
-        if (sequences[tag].deltas != NULL) {
+        if (sequences[tag].wire != NULL) {
             bool hit = false;
             bool delete = false;
             if(sequences[tag].period != 0) { // period set
@@ -90,20 +267,34 @@ static void sequencer_process_tick(void) {
                 if (sequences[tag].tick == amy_global.sequencer_tick_count) { hit = true; delete = true; }
             }
             if(hit) {
-                struct delta *d = sequences[tag].deltas;
-                while(d) {
-                    // assume the d->time is 0 and that's good.
-                    add_delta_to_queue(d, &amy_global.delta_queue);
-                    d = d->next;
+                // Take the message out (one-shot) or a copy of it (repeating)
+                // under the lock, so an ingest thread rewriting the tag can't
+                // free the string while we parse it.
+                char *wire = NULL;
+                amy_grab_lock();
+                if (sequences[tag].wire != NULL) {
+                    if (delete) {
+                        wire = sequences[tag].wire;
+                        sequences[tag].wire = NULL;
+                        sequences[tag].tick = 0;
+                        sequences[tag].period = 0;
+                    } else {
+                        size_t len = strlen(sequences[tag].wire);
+                        wire = (char *)malloc_caps(len + 1, amy_global.config.ram_caps_events);
+                        if (wire != NULL) memcpy(wire, sequences[tag].wire, len + 1);
+                        else amy_oom("sequencer fire");
+                    }
                 }
-                // Delete absolute tick addressed sequence entry if sent
-                if(delete) {
-                    delta_release_list(sequences[tag].deltas);
-                    sequences[tag].deltas = NULL;
+                amy_release_lock();
+                if (wire != NULL) {
+                    // Parse and play now; the deltas play back within this block.
+                    amy_play_message_with_time(wire, UINT32_MAX /* no base time: play now */);
+                    free(wire);
                 }
             }
         }
     }
+    wire_firing = was_firing;
     if(amy_global.config.amy_external_sequencer_hook != NULL) {
         amy_global.config.amy_external_sequencer_hook(amy_global.sequencer_tick_count);
     }
@@ -176,43 +367,13 @@ void sequencer_external_clock_disable() {
     amy_global.next_amy_tick_us = amy_sysclock64() * 1000ULL;
 }
 
-uint8_t sequencer_add_event(amy_event *e) {
-    // add this event to the list of sequencer events in the LL.
-    // e->sequence is set up.
-    // if the tag already exists - if there's tick/period, overwrite, if there's no tick / period, we should remove the entry
-    //fprintf(stderr, "sequencer_add_event: e->instrument %d e->note %.0f e->vel %.2f tick %d period %d tag %d\n", e->instrument, e->midi_note, e->velocity, e->sequence[SEQUENCE_TICK], e->sequence[SEQUENCE_PERIOD], e->sequence[SEQUENCE_TAG]);
-    int32_t tag = e->sequence[SEQUENCE_TAG];
-    if (tag > max_sequences) {
-        fprintf(stderr, "sequencer tag %" PRIi32" (with tick %" PRIu32", period %" PRIu32") is greater than or eq max_sequences %" PRIi32"\n",
-                tag, e->sequence[SEQUENCE_TICK], e->sequence[SEQUENCE_PERIOD], max_sequences);
-        // ignore
-        return 0;
-    }
-    // Release any existing deltas for this tag, even if we're just going to rewrite them.
-    delta_release_list(sequences[tag].deltas);
-    sequences[tag].deltas = NULL;
-
-    if(e->sequence[SEQUENCE_TICK] == 0 && e->sequence[SEQUENCE_PERIOD] == 0) return 0; // Ignore non-schedulable event.
-    if(e->sequence[SEQUENCE_TICK] != 0 && e->sequence[SEQUENCE_PERIOD] == 0 && e->sequence[SEQUENCE_TICK] <= amy_global.sequencer_tick_count) return 0; // don't schedule things in the past.
-
-    // Save the tick & period.
-    sequences[tag].tick = e->sequence[SEQUENCE_TICK];
-    sequences[tag].period = e->sequence[SEQUENCE_PERIOD];
-    // Copy all the deltas for this event to the sequences entry.
-    amy_event_to_deltas_queue(e, 0, &sequences[tag].deltas);
-
-    if (tag > highest_tag) highest_tag = tag;  // To limit scanning through tags.
-
-    return 1;
-}
-
-
 // Called once per block from amy_execute_deltas(). Ticks are decided against
 // amy_sysclock(), which counts rendered samples, so the sequencer advances on
 // AMY time in any rendering context (live, offline, tests).
 void sequencer_check_and_fill() {
     if (sequences == NULL) return;  // sequencer_init hasn't run
     if (sequencer_external_clock) return;
+    if (wire_firing) return;  // nested via a fired message's own parse
     // When we're the MIDI clock master, realtime clock keeps flowing even while
     // the transport is stopped so slaves stay tempo-locked; otherwise a stopped
     // sequencer has nothing to do.

--- a/src/sequencer.h
+++ b/src/sequencer.h
@@ -15,7 +15,17 @@ void sequencer_check_and_fill();  // called once per block from amy_execute_delt
 #ifdef __EMSCRIPTEN__
 void sequencer_check_and_call_js_hook();  // called from the browser main loop
 #endif
-uint8_t sequencer_add_event(amy_event *e);
+// Store a wire message (with its t/H already stripped) in the sequencer under
+// tag; clears the tag if tick and period are both 0.  Takes ownership of wire.
+uint8_t sequencer_add_wire(uint32_t tick, uint32_t period, uint32_t tag, char *wire);
+// Store a one-shot wire message to play at an absolute ms time.  Takes ownership of wire.
+void timed_wire_add(uint32_t time, char *wire);
+// Store a copy of an already-parsed event to play at an absolute ms time.
+void timed_event_add(uint32_t time, amy_event *e);
+// Store a raw (non-sysex) MIDI message to handle at an absolute ms time.
+void timed_midi_add(uint32_t time, uint8_t *bytes, uint8_t len);
+void timed_wire_check_and_fire();  // called once per block from amy_execute_deltas()
+void timed_wire_reset();  // drop all pending timed messages
 void sequencer_midi_clock_tick();
 void sequencer_midi_start();
 void sequencer_midi_stop();


### PR DESCRIPTION
## Motivation

Ingesting a few hundred sequencer (`H`) wire messages took ~400ms on a fast 400MHz RISC-V, because every message was fully parsed, voice-allocated and expanded into deltas at ingest. Separately, timed (`t`) events used a different mechanism (long-lived deltas in the global queue) than the sequencer (per-tag delta lists).

## What this does

**Ingest fast path.** `amy_add_message` now runs a light scanner (`amy_scan_wire_message` in parse.c) over each message that only walks command letters and skips their arguments. If it finds a top-level `H`, or a `t` in the future, it strips those commands out and stores the *raw remaining wire string* plus the schedule metadata — no event parse, no voice allocation, no deltas. Ingest cost is a scan + one malloc + memcpy, invariant to message content. Commands with string payloads that can embed wire code (`u`, `ic`/`io`/`ig`, `zT`/`zF`/`zD`/`zP`) are treated as opaque so their payloads are never misread as scheduling commands; transfer-mode payloads bypass the scanner entirely.

**One store for sequenced + timed.** `sequences[tag]` now holds a wire string (tick/period/tag semantics unchanged: overwrite, clear on `0,0,tag`, one-shot delete after firing, repeat on period). Timed one-shots live in a time-sorted list in the same module, checked once per block by `timed_wire_check_and_fire()` (independent of sequencer transport, wrap-relative compares). When an entry comes due it's parsed and played right then — timed messages keep their original `t` as the base event time so delta times/ordering are identical to the old behavior.

**All future-dated events unify on the timed store:**
- Wire messages with future `t` → stored as strings.
- C-API `amy_add_event` with a future time → stored as an event-struct copy (no lossy string round-trip).
- C-API events with `sequence` set → serialized via `sprint_event` and routed through the same wire scheduler.
- MIDI input with a future timestamp → stored as raw bytes, so mapping lookup / template expansion / **voice allocation happen against the synth state at play time, not at ingest**. (This fixes the long-standing class of bug where a note scheduled for later grabbed a voice — or a drum-map entry — from whatever the synth looked like at ingest.)

**The delta queue is no longer a scheduler.** It survives only as the block-boundary mailbox between ingest threads and the render thread, plus internal short delays (`synth_delay_ms` note-on delay, voice-steal note-offs). It can't be removed entirely: immediate cross-thread play would mutate synth state mid-render (deltas executing at block boundaries under the lock is the render-thread synchronization model). But it never accumulates long-horizon events anymore, so its O(n) sorted insert is on a always-tiny list.

## Results

- **All 119 WAV tests pass bit-exact** against existing refs (no goldens regenerated), including `TestSequencer*`, `TestOscResetIsScheduled`, `TestClearSynth`. `make ctest` (clock-wrap) passes, including scheduling across the 2^32 ms rollover.
- Ingest of 400 piano-roll-style `H` messages (synth note-ons): **2.3µs → 0.17µs per message** on an M-series Mac (~14x), and the new cost no longer scales with message complexity — on-device the gap should be much larger since the old path did per-delta lock/pool-alloc/sorted-insert plus voice allocation in SPIRAM.
- Timed `t` messages: ~1.1µs → ~0.4µs per message (raw osc events; bigger win for synth events).
- Web build (`make web`) compiles; no files added/removed so the Godot source lists are untouched; `sequencer_add_event` (removed) had no external users (checked tulipcc).

## Semantics notes

- A scheduled message's *entire* contents now execute at its scheduled time — including synth config (patch loads, `num_voices`), `S` resets, midi-CC mapping installs — instead of config executing at ingest with only deltas deferred. This is the coherent model (and what `TestOscResetIsScheduled` wanted), and no test refs changed.
- Repeating sequences re-parse (and re-allocate voices) on every fire rather than replaying a voice picked at store time — voice stealing now happens at musical time.
- C-API sequenced events round-trip through `sprint_event` (%.3f floats). Sequenced note events are unaffected in practice, but exotic float params in a *C-API-struct* sequence entry could lose a little precision. Wire-sourced sequences (Python/JS/MIDI, i.e. everything in the test suite) are stored verbatim.
- Firing parses in the render context (as CV triggers already do). A tick that fires many stored messages does its parsing inside that block; parse is µs-scale per message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)