### PR TITLE
unload_sample takes preset=, not patch=

### DIFF
--- a/amy/__init__.py
+++ b/amy/__init__.py
@@ -413,10 +413,10 @@ def inject_midi_bytes(data, usb=0):
     # unlike inject_midi(), which injects a single pre-formed message.
     _amy.inject_midi_bytes(data, usb)
 
-def unload_sample(patch=0):
-    s= "%d,%d" % (patch, 0)
+def unload_sample(preset=0):
+    s= "%d,%d" % (preset, 0)
     send(load_sample=s)
-    print("Patch %d unloaded from RAM" % (patch))
+    print("Preset %d unloaded from RAM" % (preset))
 
 # For AMYBoard and other AMYs that can get messages over MIDI sysex
 # AMYboard is the name of the default AMYboard USB over MIDI device. 


### PR DESCRIPTION
Requested by @dpwe in review of shorepine/tulipcc#1260.

Samples load into a PCM **preset** slot — `load_sample(preset=N)`, and every line of `docs/synth.md` calls it a preset — but its counterpart `unload_sample` took `patch=`. Those are different things on the wire: `K` is a synth patch, `p` is a PCM preset.

The mismatch has been leaking into downstream docs — tulipcc's `tulip_api.md` picked up `patch=` for `load_sample` calls as well, which raises `TypeError` (being fixed in shorepine/tulipcc#1260).

- Kwarg renamed; the unload message it builds is unchanged.
- The confirmation print now says `Preset` rather than `Patch`.
- No caller anywhere in the tree passed it by keyword (docs call it positionally, `amy.unload_sample(3)`), so nothing breaks.
- amy's own docs already say preset throughout, so no doc changes here.

`make test`: 120 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)