### PR TITLE
Es8311 codec support

### DIFF
--- a/docs/arduino.md
+++ b/docs/arduino.md
@@ -75,10 +75,6 @@ Here's an example of a PCM1808 and PCM5101 working together to provide audio in 
 <img src="AMY-Arduino-ESP32S3_bb.png" width="600"/>
 
 
-### ES8311 (Freenove FNK0104 and similar)
-
-Boards built around the `ES8311` codec (for example the [Freenove FNK0104](https://store.freenove.com/products/fnk0104) ESP32-S3 display boards) drive their speaker through the codec plus a Class-D amplifier, so the codec must be configured over I2C before it will pass audio. AMY includes a small ES8311 playback driver (`src/es8311.c`); see the [`AMY_ES8311_FNK0104`](../examples/AMY_ES8311_FNK0104/AMY_ES8311_FNK0104.ino) example, which starts AMY's I2S output and then calls `amy_es8311_init()`. On the FNK0104 the audio pins are `MCLK=4`, `BCLK=5`, `WS=7`, `DOUT=8`, the codec control bus is `SDA=16 / SCL=15` (address `0x18`), and the amplifier enable is on `GPIO 1`. If you can pass compiler flags, building AMY with `-DAMY_CODEC_ES8311` makes AMY configure the codec automatically (pins overridable via `-DAMY_ES8311_*` defines).
-
 ## Per-board notes
 
 ### AMYboard
@@ -88,6 +84,12 @@ Our built-for-AMY board [AMYboard](https://amyboard.com) should just work out of
 ### ESP32, ESP32-S3, ESP32-P4
 
 Tested: Arduino IDE 2.3.6 (mac) + arduino-esp32 3.2.0
+
+### ES8311 (Freenove FNK0104 and similar)
+
+Boards built around the `ES8311` codec (for example the [Freenove FNK0104](https://store.freenove.com/products/fnk0104) ESP32-S3 display boards) drive their speaker through the codec plus a Class-D amplifier, so the codec must be configured over I2C before it will pass audio. AMY includes a small ES8311 playback driver (`src/es8311.c`); see the [`AMY_ES8311_FNK0104`](../examples/AMY_ES8311_FNK0104/AMY_ES8311_FNK0104.ino) example, which starts AMY's I2S output and then calls `amy_es8311_init()`. On the FNK0104 the audio pins are `MCLK=4`, `BCLK=5`, `WS=7`, `DOUT=8`, the codec control bus is `SDA=16 / SCL=15` (address `0x18`), and the amplifier enable is on `GPIO 1`. If you can pass compiler flags, building AMY with `-DAMY_CODEC_ES8311` makes AMY configure the codec automatically (pins overridable via `-DAMY_ES8311_*` defines).
+
+**Set the codec up before `Wire.begin()`.** The driver takes exclusive ownership of the I2C port while it configures the codec, then releases the pins again. On boards that share the codec's control bus with something else — on the FNK0104 the FT6336U touch controller is on the same `SDA=16 / SCL=15` — bringing that other device up first makes the codec's bus init fail, which means silence. So call `amy_start()` / `amy_es8311_init()` (or `amy_start()` alone under `-DAMY_CODEC_ES8311`) *first*, and initialise the display/touch panel afterwards. `amy_es8311_status()` reports how the codec bring-up went, including when AMY did it for you inside `amy_start()`.
 
 
 ### Teensy 4.0, 4.1

--- a/docs/arduino.md
+++ b/docs/arduino.md
@@ -75,6 +75,10 @@ Here's an example of a PCM1808 and PCM5101 working together to provide audio in 
 <img src="AMY-Arduino-ESP32S3_bb.png" width="600"/>
 
 
+### ES8311 (Freenove FNK0104 and similar)
+
+Boards built around the `ES8311` codec (for example the [Freenove FNK0104](https://store.freenove.com/products/fnk0104) ESP32-S3 display boards) drive their speaker through the codec plus a Class-D amplifier, so the codec must be configured over I2C before it will pass audio. AMY includes a small ES8311 playback driver (`src/es8311.c`); see the [`AMY_ES8311_FNK0104`](../examples/AMY_ES8311_FNK0104/AMY_ES8311_FNK0104.ino) example, which starts AMY's I2S output and then calls `amy_es8311_init()`. On the FNK0104 the audio pins are `MCLK=4`, `BCLK=5`, `WS=7`, `DOUT=8`, the codec control bus is `SDA=16 / SCL=15` (address `0x18`), and the amplifier enable is on `GPIO 1`. If you can pass compiler flags, building AMY with `-DAMY_CODEC_ES8311` makes AMY configure the codec automatically (pins overridable via `-DAMY_ES8311_*` defines).
+
 ## Per-board notes
 
 ### AMYboard

--- a/examples/AMY_ES8311_FNK0104/AMY_ES8311_FNK0104.ino
+++ b/examples/AMY_ES8311_FNK0104/AMY_ES8311_FNK0104.ino
@@ -24,17 +24,14 @@
 
 #include <AMY-Arduino.h>
 
-// FNK0104 audio pins.
+// FNK0104 I2S pins.  The codec-control side (I2C SDA/SCL, codec address, amp
+// enable, startup volume) already defaults to the FNK0104 as the AMY_ES8311_*
+// defines in es8311.h -- on a different ES8311 board, #define those before the
+// AMY-Arduino.h include above.
 #define FNK_I2S_MCLK   4
 #define FNK_I2S_BCLK   5
 #define FNK_I2S_WS     7
 #define FNK_I2S_DOUT   8
-#define FNK_I2C_SDA    16
-#define FNK_I2C_SCL    15
-#define FNK_ES8311_ADDR 0x18
-#define FNK_PA_ENABLE  1
-#define FNK_PA_ACTIVE_LOW 1   // FNK0104 amp enable is active-low (LOW = amp on)
-#define FNK_VOLUME     100    // ES8311 DAC volume 0-100; 100 = unity (0 dB)
 
 void setup() {
   amy_config_t amy_config = amy_default_config();
@@ -66,11 +63,11 @@ void setup() {
   // Configure the ES8311 over I2C and switch on the power amplifier.  MCLK is
   // i2s_mclk_mult * sample rate -- take it from the config so this can't drift
   // away from what AMY's I2S peripheral is actually generating.
-  amy_err_t rc = amy_es8311_init(0 /*I2C_NUM_0*/, FNK_I2C_SDA, FNK_I2C_SCL,
-                                 FNK_ES8311_ADDR, FNK_PA_ENABLE, FNK_PA_ACTIVE_LOW,
+  amy_err_t rc = amy_es8311_init(AMY_ES8311_I2C_PORT, AMY_ES8311_I2C_SDA, AMY_ES8311_I2C_SCL,
+                                 AMY_ES8311_I2C_ADDR, AMY_ES8311_PA_GPIO, AMY_ES8311_PA_ACTIVE_LOW,
                                  AMY_SAMPLE_RATE,
                                  (uint32_t)AMY_SAMPLE_RATE * amy_config.i2s_mclk_mult,
-                                 FNK_VOLUME);
+                                 AMY_ES8311_VOLUME);
 #endif
   if (rc == AMY_OK) {
     printf("ES8311 codec init OK\n");

--- a/examples/AMY_ES8311_FNK0104/AMY_ES8311_FNK0104.ino
+++ b/examples/AMY_ES8311_FNK0104/AMY_ES8311_FNK0104.ino
@@ -1,0 +1,115 @@
+// AMY on a Freenove FNK0104 ESP32-S3 display board.
+//
+// The FNK0104 drives its speaker through an ES8311 I2S codec + Class-D power
+// amplifier, so it needs an I2C register setup that AMY's plain PCM5102-style
+// path doesn't do.  AMY ships a small ES8311 driver (src/es8311.c); this sketch
+// starts AMY's I2S output and then configures the codec over I2C.
+//
+// FNK0104 audio wiring (2.8" FNK0104AB):
+//   I2S : MCLK=4  BCLK=5  WS/LRCLK=7  DOUT=8   (DIN=6, unused here)
+//   I2C : SDA=16  SCL=15  (ES8311 control, address 0x18)
+//   Amp : enable on GPIO 1
+//
+// No special build flags are required: amy_es8311_init() is part of the AMY
+// library on ESP32, so we just call it from setup() after amy_start().
+// (If you can pass compiler flags, e.g. in PlatformIO, building AMY with
+//  -DAMY_CODEC_ES8311 makes AMY configure the codec automatically and you can
+//  drop the amy_es8311_init() call below.)
+
+#include <AMY-Arduino.h>
+
+// ES8311 codec setup (implemented in the AMY library, src/es8311.c).
+extern "C" {
+  amy_err_t amy_es8311_init(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr,
+                            int8_t pa_enable_gpio, uint8_t pa_active_low,
+                            uint32_t sample_rate, uint32_t mclk_hz, uint8_t volume);
+};
+
+// FNK0104 audio pins.
+#define FNK_I2S_MCLK   4
+#define FNK_I2S_BCLK   5
+#define FNK_I2S_WS     7
+#define FNK_I2S_DOUT   8
+#define FNK_I2C_SDA    16
+#define FNK_I2C_SCL    15
+#define FNK_ES8311_ADDR 0x18
+#define FNK_PA_ENABLE  1
+#define FNK_PA_ACTIVE_LOW 1   // FNK0104 amp enable is active-low (LOW = amp on)
+
+void setup() {
+  amy_config_t amy_config = amy_default_config();
+  amy_config.features.default_synths = 0;
+  amy_config.features.audio_in = 0;
+
+  // Render on core 1 (multicore) plus a dedicated render thread (multithread).
+  amy_config.platform.multicore = 1;
+  amy_config.platform.multithread = 1;
+
+  // Let AMY own the I2S output.
+  amy_config.audio = AMY_AUDIO_IS_I2S;
+  amy_config.i2s_mclk = FNK_I2S_MCLK;   // ES8311 needs MCLK
+  amy_config.i2s_bclk = FNK_I2S_BCLK;
+  amy_config.i2s_lrc  = FNK_I2S_WS;
+  amy_config.i2s_dout = FNK_I2S_DOUT;
+
+  // Starts I2S: MCLK/BCLK/WS are running after this returns.
+  amy_start(amy_config);
+
+  // Now configure the ES8311 over I2C and switch on the power amplifier.
+  // MCLK = 256 * sample rate (AMY's default ESP I2S clock config).
+  amy_err_t rc = amy_es8311_init(0 /*I2C_NUM_0*/, FNK_I2C_SDA, FNK_I2C_SCL,
+                                 FNK_ES8311_ADDR, FNK_PA_ENABLE, FNK_PA_ACTIVE_LOW,
+                                 AMY_SAMPLE_RATE, (uint32_t)AMY_SAMPLE_RATE * 256,
+                                 80 /* volume 0-100 */);
+  if (rc == AMY_OK) {
+    printf("ES8311 codec init OK\n");
+  } else {
+    // Codec didn't come up — check wiring / I2C address.
+    printf("ES8311 codec init FAILED (%d)\n", rc);
+  }
+
+  // Set up a simple synth (Juno patch 1) on channel 1 so we have something to play.
+  amy_event e = amy_default_event();
+  e.reset_osc = RESET_AMY;
+  amy_add_event(&e);
+  e = amy_default_event();
+  e.synth = 1;
+  e.patch_number = 1;
+  e.num_voices = 6;
+  amy_add_event(&e);
+}
+
+static long last_note_ms = 0;
+static const int notes[] = { 60, 64, 67, 72 };
+static int note_idx = 0;
+static int playing_note = -1;  // -1 until the first note is played
+
+void loop() {
+  // Required: pump AMY every block.
+  amy_update();
+
+  // Play a note from the little arpeggio once a second so the speaker is audible.
+  long now = millis();
+  if (now - last_note_ms > 1000) {
+    last_note_ms = now;
+
+    // Release the previously-playing note (skip on the very first note).
+    if (playing_note >= 0) {
+      amy_event off = amy_default_event();
+      off.synth = 1;
+      off.midi_note = playing_note;
+      off.velocity = 0;
+      amy_add_event(&off);
+    }
+
+    // Start the next note.
+    amy_event on = amy_default_event();
+    on.synth = 1;
+    on.midi_note = notes[note_idx];
+    on.velocity = 1;
+    amy_add_event(&on);
+
+    playing_note = notes[note_idx];
+    note_idx = (note_idx + 1) % 4;
+  }
+}

--- a/examples/AMY_ES8311_FNK0104/AMY_ES8311_FNK0104.ino
+++ b/examples/AMY_ES8311_FNK0104/AMY_ES8311_FNK0104.ino
@@ -11,19 +11,18 @@
 //   Amp : enable on GPIO 1
 //
 // No special build flags are required: amy_es8311_init() is part of the AMY
-// library on ESP32, so we just call it from setup() after amy_start().
+// library on ESP32 (prototype in src/es8311.h, pulled in by AMY-Arduino.h), so
+// we just call it from setup() after amy_start().
 // (If you can pass compiler flags, e.g. in PlatformIO, building AMY with
-//  -DAMY_CODEC_ES8311 makes AMY configure the codec automatically and you can
-//  drop the amy_es8311_init() call below.)
+//  -DAMY_CODEC_ES8311 makes AMY configure the codec inside amy_start() instead;
+//  this sketch then just reports amy_es8311_status().)
+//
+// Ordering matters on this board: the ES8311 shares SDA=16 / SCL=15 with the
+// FT6336U touch controller, and the codec driver needs exclusive ownership of
+// that I2C port while it runs.  Configure the codec *first*, then Wire.begin()
+// for the touch panel / anything else on the bus.
 
 #include <AMY-Arduino.h>
-
-// ES8311 codec setup (implemented in the AMY library, src/es8311.c).
-extern "C" {
-  amy_err_t amy_es8311_init(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr,
-                            int8_t pa_enable_gpio, uint8_t pa_active_low,
-                            uint32_t sample_rate, uint32_t mclk_hz, uint8_t volume);
-};
 
 // FNK0104 audio pins.
 #define FNK_I2S_MCLK   4
@@ -35,15 +34,20 @@ extern "C" {
 #define FNK_ES8311_ADDR 0x18
 #define FNK_PA_ENABLE  1
 #define FNK_PA_ACTIVE_LOW 1   // FNK0104 amp enable is active-low (LOW = amp on)
+#define FNK_VOLUME     100    // ES8311 DAC volume 0-100; 100 = unity (0 dB)
 
 void setup() {
   amy_config_t amy_config = amy_default_config();
   amy_config.features.default_synths = 0;
   amy_config.features.audio_in = 0;
 
-  // Render on core 1 (multicore) plus a dedicated render thread (multithread).
+  // Split rendering across both cores.  We deliberately leave multithread at 0:
+  // with a background render thread, the amy_add_event() calls in loop() below
+  // would race that thread over voice/oscillator allocation (AMY's queue lock
+  // covers the delta list, not the allocation state).  With multithread = 0,
+  // amy_update() executes events on this task, so loop() is the only writer.
   amy_config.platform.multicore = 1;
-  amy_config.platform.multithread = 1;
+  amy_config.platform.multithread = 0;
 
   // Let AMY own the I2S output.
   amy_config.audio = AMY_AUDIO_IS_I2S;
@@ -55,16 +59,24 @@ void setup() {
   // Starts I2S: MCLK/BCLK/WS are running after this returns.
   amy_start(amy_config);
 
-  // Now configure the ES8311 over I2C and switch on the power amplifier.
-  // MCLK = 256 * sample rate (AMY's default ESP I2S clock config).
+#ifdef AMY_CODEC_ES8311
+  // AMY already configured the codec (and the amp) from inside amy_start().
+  amy_err_t rc = amy_es8311_status();
+#else
+  // Configure the ES8311 over I2C and switch on the power amplifier.  MCLK is
+  // i2s_mclk_mult * sample rate -- take it from the config so this can't drift
+  // away from what AMY's I2S peripheral is actually generating.
   amy_err_t rc = amy_es8311_init(0 /*I2C_NUM_0*/, FNK_I2C_SDA, FNK_I2C_SCL,
                                  FNK_ES8311_ADDR, FNK_PA_ENABLE, FNK_PA_ACTIVE_LOW,
-                                 AMY_SAMPLE_RATE, (uint32_t)AMY_SAMPLE_RATE * 256,
-                                 80 /* volume 0-100 */);
+                                 AMY_SAMPLE_RATE,
+                                 (uint32_t)AMY_SAMPLE_RATE * amy_config.i2s_mclk_mult,
+                                 FNK_VOLUME);
+#endif
   if (rc == AMY_OK) {
     printf("ES8311 codec init OK\n");
   } else {
-    // Codec didn't come up — check wiring / I2C address.
+    // Codec didn't come up — check wiring / I2C address, and that nothing else
+    // (Wire.begin() for the touch panel) claimed SDA/SCL first.
     printf("ES8311 codec init FAILED (%d)\n", rc);
   }
 
@@ -79,8 +91,9 @@ void setup() {
   amy_add_event(&e);
 }
 
-static long last_note_ms = 0;
+static uint32_t last_note_ms = 0;
 static const int notes[] = { 60, 64, 67, 72 };
+static const int num_notes = sizeof(notes) / sizeof(notes[0]);
 static int note_idx = 0;
 static int playing_note = -1;  // -1 until the first note is played
 
@@ -89,7 +102,8 @@ void loop() {
   amy_update();
 
   // Play a note from the little arpeggio once a second so the speaker is audible.
-  long now = millis();
+  // Unsigned math, so this keeps working across the ~49-day millis() rollover.
+  uint32_t now = millis();
   if (now - last_note_ms > 1000) {
     last_note_ms = now;
 
@@ -110,6 +124,6 @@ void loop() {
     amy_add_event(&on);
 
     playing_note = notes[note_idx];
-    note_idx = (note_idx + 1) % 4;
+    note_idx = (note_idx + 1) % num_notes;
   }
 }

--- a/src/AMY-Arduino.h
+++ b/src/AMY-Arduino.h
@@ -8,6 +8,11 @@
 
 extern "C" {
   #include "amy.h"
+  #ifdef ESP_PLATFORM
+    // ES8311 codec setup for boards that need it (Freenove FNK0104 and friends).
+    // Declared here so sketches get the real prototype instead of hand-copying it.
+    #include "es8311.h"
+  #endif
 }
 
 

--- a/src/amy.c
+++ b/src/amy.c
@@ -2207,9 +2207,9 @@ int16_t * amy_fill_buffer() {
 
             // TODO -- the esp stuff here could sit outside of AMY
             // For some reason, have to drop a bit to stop hard wrapping on esp?
-#if defined(ESP_PLATFORM) || defined(__IMXRT1062__)
-            uintval >>= 1;
-#endif
+            // (0 bits everywhere else.)  Anything downstream that wants this gain
+            // back reads AMY_OUTPUT_HEADROOM_BITS rather than assuming a number.
+            uintval >>= AMY_OUTPUT_HEADROOM_BITS;
             if (positive) {
               sample = uintval;
             } else {

--- a/src/amy.h
+++ b/src/amy.h
@@ -234,6 +234,19 @@ extern void amy_set_gamma9001_pcm(const int16_t * data);
 
 // Rest of amy setup
 #define SAMPLE_MAX 32767
+
+// Bits dropped from the output sample in amy_fill_buffer (see amy.c): ESP and
+// Teensy hard-wrap without this.  The soft clipper already bounds samples to
+// SAMPLE_MAX, so this makes the output ceiling SAMPLE_MAX >> bits -- i.e. ~6.02 dB
+// of guaranteed headroom per bit, for any content.  Downstream gain stages can
+// give exactly that much back without any risk of clipping; es8311.c does.
+// (Values parenthesized so the Makefile's constants.py scrape skips this
+// platform-dependent, C-internal define.)
+#if defined(ESP_PLATFORM) || defined(__IMXRT1062__)
+#define AMY_OUTPUT_HEADROOM_BITS (1)
+#else
+#define AMY_OUTPUT_HEADROOM_BITS (0)
+#endif
 #define MAX_ALGO_OPS 6 
 #define DEFAULT_NUM_BREAKPOINTS 8
 // We need a max on the number of breakpoints to lay out the params enum statically.  Otherwise, it's dynamic.

--- a/src/amy_i2c.h
+++ b/src/amy_i2c.h
@@ -1,0 +1,43 @@
+// amy_i2c.h
+// Tiny shared helper for AMY's ESP32 codec control buses.
+//
+// Several boards need an audio codec configured over I2C before I2S will pass
+// any audio (the PCM9211 on AMYboard, the ES8311 on the Freenove FNK0104, ...).
+// They all follow the same pattern: open an ESP-IDF driver_ng I2C master bus
+// (driver/i2c_master.h -- the legacy driver would fight Arduino's Wire), write a
+// handful of registers, then tear the bus back down so Wire, a touch panel or
+// anything else sharing those pins can claim them.  Getting that ownership
+// dance wrong fails silently (no audio, no error), so it lives in one place
+// here rather than being copied per codec.  Implemented in i2s.c.
+
+#ifndef AMY_I2C_H
+#define AMY_I2C_H
+
+#ifdef ESP_PLATFORM
+
+#include <stdint.h>
+#include "driver/i2c_master.h"
+
+// A temporarily-opened I2C master bus plus the one device we talk to on it.
+typedef struct {
+    i2c_master_bus_handle_t bus;
+    i2c_master_dev_handle_t dev;
+} amy_i2c_dev_t;
+
+// Open i2c_port on sda/scl and attach the 7-bit device at addr.  On failure
+// nothing is left open and *d is zeroed, so the caller can just report the error
+// (calling amy_i2c_close_device() anyway is harmless).
+esp_err_t amy_i2c_open_device(amy_i2c_dev_t *d, int i2c_port, int8_t sda, int8_t scl,
+                              uint8_t addr, uint32_t scl_speed_hz);
+
+// Detach the device and delete the bus, releasing the pins.  Safe to call on a
+// zeroed or partly-opened amy_i2c_dev_t, and safe to call twice.
+void amy_i2c_close_device(amy_i2c_dev_t *d);
+
+// Single register transactions.  Both return ESP_ERR_INVALID_STATE, rather than
+// handing a NULL handle to the IDF, if d isn't open.
+esp_err_t amy_i2c_write_reg(const amy_i2c_dev_t *d, uint8_t reg, uint8_t val);
+esp_err_t amy_i2c_read_reg(const amy_i2c_dev_t *d, uint8_t reg, uint8_t *val);
+
+#endif // ESP_PLATFORM
+#endif // AMY_I2C_H

--- a/src/es8311.c
+++ b/src/es8311.c
@@ -14,8 +14,6 @@
 //     caller passes the resulting frequency in, so what we program here can't
 //     drift away from what the I2S peripheral actually generates.
 //   * Data is 32-bit, MSB / left-justified (I2S_STD_MSB_SLOT_DEFAULT_CONFIG).
-//     Define AMY_ES8311_I2S_PHILIPS to use standard (Philips) I2S framing
-//     instead, should AMY's slot config ever change.
 
 #if defined(ESP_PLATFORM)
 
@@ -54,6 +52,7 @@
 #define ES8311_DAC_REG31            0x31   // DAC mute
 #define ES8311_DAC_REG32            0x32   // DAC volume
 #define ES8311_DAC_REG37            0x37
+#define ES8311_GPIO_REG44           0x44   // GPIO / I2C noise immunity
 #define ES8311_GP_REG45             0x45
 #define ES8311_CHD1_REGFD           0xFD   // chip ID 1
 #define ES8311_CHD2_REGFE           0xFE   // chip ID 2
@@ -61,10 +60,17 @@
 #define ES8311_I2C_FREQ             400000
 
 // reg32 (DAC volume) steps 0.5 dB: 0x00 = -95.5 dB, 0xBF = 0 dB, and anything
-// above 0xBF is *digital gain*.  AMY's mixed output routinely runs to full
-// scale, so our 0-100 volume scale tops out at unity rather than clipping inside
-// the codec -- which sounds just like an I2S format problem.
+// above 0xBF is *digital gain* (up to +32 dB at 0xFF), which would clip a signal
+// that already reaches full scale.
 #define ES8311_DAC_VOL_0DB          0xBF
+// AMY's output on this platform can't reach full scale: amy_fill_buffer's soft
+// clipper bounds the sample to SAMPLE_MAX and then drops
+// AMY_OUTPUT_HEADROOM_BITS bits (see amy.h), so the I2S stream is ceilinged
+// ~6.02 dB below full scale per dropped bit no matter what's playing.  Giving
+// exactly that back here (12 half-dB steps per bit) restores a full-scale analog
+// output and still cannot clip -- and it tracks amy.h, so removing AMY's bit
+// drop automatically drops this gain back to unity.
+#define ES8311_DAC_VOL_MAX          (ES8311_DAC_VOL_0DB + 12 * AMY_OUTPUT_HEADROOM_BITS)
 
 // Clock coefficient row: how to derive the codec's internal clocks from a given
 // (MCLK, sample-rate) pair.  Copied from the Espressif reference driver.
@@ -86,17 +92,10 @@ struct coeff_div {
 // AMY_SAMPLE_RATE is fixed at compile time, so only the rows for that one rate
 // can ever be selected; the reference driver's other ~55 rows would be a
 // kilobyte of dead flash on an MCU.  Every MCLK variant of our rate stays,
-// because amy_config.i2s_mclk_mult picks which one we feed the codec.  A build at
-// a rate the reference table doesn't list keeps the whole table, so get_coeff()
-// still behaves (and still reports what's missing).
-#if (AMY_SAMPLE_RATE != 8000) && (AMY_SAMPLE_RATE != 11025) && (AMY_SAMPLE_RATE != 12000) && \
-    (AMY_SAMPLE_RATE != 16000) && (AMY_SAMPLE_RATE != 22050) && (AMY_SAMPLE_RATE != 24000) && \
-    (AMY_SAMPLE_RATE != 32000) && (AMY_SAMPLE_RATE != 44100) && (AMY_SAMPLE_RATE != 48000) && \
-    (AMY_SAMPLE_RATE != 96000)
-#define ES8311_WANT(r) 1
-#else
+// because amy_config.i2s_mclk_mult picks which one we feed the codec.  (A build
+// at a rate the table doesn't list compiles to an empty table, and get_coeff()
+// reports the miss.)
 #define ES8311_WANT(r) (AMY_SAMPLE_RATE == (r))
-#endif
 
 static const struct coeff_div coeff_div[] = {
     // mclk      rate   prediv  mult  adcdiv dacdiv fsmode lrch  lrcl  bckdiv adcosr dacosr
@@ -199,23 +198,27 @@ static esp_err_t es_read(const amy_i2c_dev_t *d, uint8_t reg, uint8_t *val) {
     return ret;
 }
 
-static int get_coeff(uint32_t mclk, uint32_t rate) {
+static const struct coeff_div *get_coeff(uint32_t mclk, uint32_t rate) {
     for (unsigned i = 0; i < sizeof(coeff_div) / sizeof(coeff_div[0]); i++) {
         if (coeff_div[i].rate == rate && coeff_div[i].mclk == mclk)
-            return (int)i;
+            return &coeff_div[i];
     }
-    return -1;
+    return NULL;
 }
 
-// Program the clock-manager registers for the given (mclk, rate) pair.
+int amy_es8311_supports_mclk(uint32_t mclk_hz, uint32_t sample_rate) {
+    return get_coeff(mclk_hz, sample_rate) != NULL;
+}
+
+// Program the clock-manager registers for the given coefficient row.
 // Codec is a slave, MCLK sourced from the MCLK pin (not inverted).
-static esp_err_t es8311_config_clock(const amy_i2c_dev_t *d, int coeff) {
+static esp_err_t es8311_config_clock(const amy_i2c_dev_t *d, const struct coeff_div *c) {
     uint8_t regv;
     esp_err_t ret;
 
     // Pre-divider / pre-multiplier (reg02). pre_multi 1/2/4/8 -> 0/1/2/3.
     uint8_t datmp = 0;
-    switch (coeff_div[coeff].pre_multi) {
+    switch (c->pre_multi) {
         case 1: datmp = 0; break;
         case 2: datmp = 1; break;
         case 4: datmp = 2; break;
@@ -225,14 +228,14 @@ static esp_err_t es8311_config_clock(const amy_i2c_dev_t *d, int coeff) {
     ret = es_read(d, ES8311_CLK_MANAGER_REG02, &regv);
     if (ret != ESP_OK) return ret;
     regv &= 0x07;
-    regv |= (coeff_div[coeff].pre_div - 1) << 5;
+    regv |= (c->pre_div - 1) << 5;
     regv |= datmp << 3;
     ret = es_write(d, ES8311_CLK_MANAGER_REG02, regv);
     if (ret != ESP_OK) return ret;
 
     // ADC/DAC clock dividers (reg05).
-    regv = (coeff_div[coeff].adc_div - 1) << 4;
-    regv |= (coeff_div[coeff].dac_div - 1) << 0;
+    regv = (c->adc_div - 1) << 4;
+    regv |= (c->dac_div - 1) << 0;
     ret = es_write(d, ES8311_CLK_MANAGER_REG05, regv);
     if (ret != ESP_OK) return ret;
 
@@ -240,8 +243,8 @@ static esp_err_t es8311_config_clock(const amy_i2c_dev_t *d, int coeff) {
     ret = es_read(d, ES8311_CLK_MANAGER_REG03, &regv);
     if (ret != ESP_OK) return ret;
     regv &= 0x80;
-    regv |= coeff_div[coeff].fs_mode << 6;
-    regv |= coeff_div[coeff].adc_osr << 0;
+    regv |= c->fs_mode << 6;
+    regv |= c->adc_osr << 0;
     ret = es_write(d, ES8311_CLK_MANAGER_REG03, regv);
     if (ret != ESP_OK) return ret;
 
@@ -249,7 +252,7 @@ static esp_err_t es8311_config_clock(const amy_i2c_dev_t *d, int coeff) {
     ret = es_read(d, ES8311_CLK_MANAGER_REG04, &regv);
     if (ret != ESP_OK) return ret;
     regv &= 0x80;
-    regv |= coeff_div[coeff].dac_osr << 0;
+    regv |= c->dac_osr << 0;
     ret = es_write(d, ES8311_CLK_MANAGER_REG04, regv);
     if (ret != ESP_OK) return ret;
 
@@ -257,10 +260,10 @@ static esp_err_t es8311_config_clock(const amy_i2c_dev_t *d, int coeff) {
     ret = es_read(d, ES8311_CLK_MANAGER_REG07, &regv);
     if (ret != ESP_OK) return ret;
     regv &= 0xC0;
-    regv |= coeff_div[coeff].lrck_h << 0;
+    regv |= c->lrck_h << 0;
     ret = es_write(d, ES8311_CLK_MANAGER_REG07, regv);
     if (ret != ESP_OK) return ret;
-    regv = coeff_div[coeff].lrck_l;
+    regv = c->lrck_l;
     ret = es_write(d, ES8311_CLK_MANAGER_REG08, regv);
     if (ret != ESP_OK) return ret;
 
@@ -268,10 +271,10 @@ static esp_err_t es8311_config_clock(const amy_i2c_dev_t *d, int coeff) {
     ret = es_read(d, ES8311_CLK_MANAGER_REG06, &regv);
     if (ret != ESP_OK) return ret;
     regv &= 0xE0;
-    if (coeff_div[coeff].bclk_div < 19)
-        regv |= (coeff_div[coeff].bclk_div - 1) << 0;
+    if (c->bclk_div < 19)
+        regv |= (c->bclk_div - 1) << 0;
     else
-        regv |= (coeff_div[coeff].bclk_div) << 0;
+        regv |= (c->bclk_div) << 0;
     ret = es_write(d, ES8311_CLK_MANAGER_REG06, regv);
     if (ret != ESP_OK) return ret;
 
@@ -284,16 +287,8 @@ static esp_err_t es8311_config_clock(const amy_i2c_dev_t *d, int coeff) {
 static amy_err_t es8311_init_impl(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr,
                                   int8_t pa_enable_gpio, uint8_t pa_active_low,
                                   uint32_t sample_rate, uint32_t mclk_hz, uint8_t volume) {
-    // The default ESP I2S path drives 32-bit MSB (left-justified) slots.
-#ifdef AMY_ES8311_I2S_PHILIPS
-    const uint8_t fmt_bits = 0x00;   // standard I2S (Philips)
-#else
-    const uint8_t fmt_bits = 0x01;   // MSB / left-justified
-#endif
-    const uint8_t len_bits = 0x10;   // 32-bit word length
-
-    int coeff = get_coeff(mclk_hz, sample_rate);
-    if (coeff < 0) {
+    const struct coeff_div *coeff = get_coeff(mclk_hz, sample_rate);
+    if (coeff == NULL) {
         fprintf(stderr, "ES8311: no clock coefficients for %luHz MCLK at %luHz\n",
                 (unsigned long)mclk_hz, (unsigned long)sample_rate);
         return -1;
@@ -316,6 +311,13 @@ static amy_err_t es8311_init_impl(int i2c_port, int8_t sda, int8_t scl, uint8_t 
         ret = (call); \
         if (ret != ESP_OK) goto init_failed; \
     } while (0)
+
+    // The ES8311 can occasionally NACK its first I2C transaction.  Espressif's
+    // reference sequence writes reg44 twice both to enable the chip's I2C noise
+    // immunity and to make the first write a disposable warm-up.  Require the
+    // second write to succeed before treating subsequent accesses as reliable.
+    (void)amy_i2c_write_reg(&d, ES8311_GPIO_REG44, 0x08);
+    ES8311_INIT_CHECK(es_write(&d, ES8311_GPIO_REG44, 0x08));
 
     // Presence check (ES8311 chip id is 0x83 0x11).
     uint8_t id1, id2, regv;
@@ -360,11 +362,12 @@ static amy_err_t es8311_init_impl(int i2c_port, int8_t sda, int8_t scl, uint8_t 
     ES8311_INIT_CHECK(es_write(&d, ES8311_ADC_REG1B, 0x0A));
     ES8311_INIT_CHECK(es_write(&d, ES8311_ADC_REG1C, 0x6A));
 
-    // ---- Serial data-port format: 32-bit, left-justified (or Philips) ----
+    // ---- Serial data-port format ----
     // reg09/reg0A: serial-port mute in bit6 (so 0 here also un-mutes the port),
-    // word length in bits [4:2], format in bits [1:0].
-    ES8311_INIT_CHECK(es_write(&d, ES8311_SDPIN_REG09, len_bits | fmt_bits));
-    ES8311_INIT_CHECK(es_write(&d, ES8311_SDPOUT_REG0A, len_bits | fmt_bits));
+    // word length in bits [4:2], format in bits [1:0].  0x11 = 32-bit words,
+    // MSB / left-justified, matching AMY's I2S_STD_MSB_SLOT_DEFAULT_CONFIG.
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SDPIN_REG09, 0x11));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SDPOUT_REG0A, 0x11));
 
     // ---- Start playback (DAC) path ----
     ES8311_INIT_CHECK(es_write(&d, ES8311_ADC_REG17, 0xBF));
@@ -379,7 +382,7 @@ static amy_err_t es8311_init_impl(int i2c_port, int8_t sda, int8_t scl, uint8_t 
     // ---- Volume + un-mute ----
     if (volume > 100) volume = 100;
     ES8311_INIT_CHECK(es_write(&d, ES8311_DAC_REG32,
-                               (uint8_t)(((uint32_t)volume * ES8311_DAC_VOL_0DB + 50) / 100)));
+                               (uint8_t)(((uint32_t)volume * ES8311_DAC_VOL_MAX + 50) / 100)));
     // Un-mute: clear the DAC mute bits (reg31 [6:5]).
     ES8311_INIT_CHECK(es_read(&d, ES8311_DAC_REG31, &regv));
     ES8311_INIT_CHECK(es_write(&d, ES8311_DAC_REG31, regv & 0x9F));

--- a/src/es8311.c
+++ b/src/es8311.c
@@ -3,14 +3,16 @@
 //
 // Ported from Espressif's reference ES8311 driver (ESPRESSIF MIT License) down
 // to just the playback path AMY needs, and re-plumbed onto the ESP-IDF
-// driver_ng I2C master API (driver/i2c_master.h) so it coexists with Arduino's
-// Wire, exactly like the PCM9211 setup in i2s.c.
+// driver_ng I2C master API (via amy_i2c.h) so it coexists with Arduino's Wire,
+// exactly like the PCM9211 setup in i2s.c.
 //
 // Assumptions (matching AMY's default ESP I2S setup in i2s.c):
 //   * The ES8311 is the I2S slave; AMY (the ESP) is the master and supplies
 //     MCLK, BCLK and WS.
 //   * The codec's internal MCLK comes from the MCLK pin (not BCLK).
-//   * MCLK = sample_rate * 256 (AMY's default I2S_STD_CLK_DEFAULT_CONFIG).
+//   * MCLK = sample_rate * amy_config.i2s_mclk_mult (256 by default).  The
+//     caller passes the resulting frequency in, so what we program here can't
+//     drift away from what the I2S peripheral actually generates.
 //   * Data is 32-bit, MSB / left-justified (I2S_STD_MSB_SLOT_DEFAULT_CONFIG).
 //     Define AMY_ES8311_I2S_PHILIPS to use standard (Philips) I2S framing
 //     instead, should AMY's slot config ever change.
@@ -19,7 +21,7 @@
 
 #include <stdio.h>
 #include "es8311.h"
-#include "driver/i2c_master.h"
+#include "amy_i2c.h"
 #include "driver/gpio.h"
 #include "esp_rom_sys.h"   // esp_rom_delay_us
 
@@ -56,8 +58,16 @@
 #define ES8311_CHD1_REGFD           0xFD   // chip ID 1
 #define ES8311_CHD2_REGFE           0xFE   // chip ID 2
 
+#define ES8311_I2C_FREQ             400000
+
+// reg32 (DAC volume) steps 0.5 dB: 0x00 = -95.5 dB, 0xBF = 0 dB, and anything
+// above 0xBF is *digital gain*.  AMY's mixed output routinely runs to full
+// scale, so our 0-100 volume scale tops out at unity rather than clipping inside
+// the codec -- which sounds just like an I2S format problem.
+#define ES8311_DAC_VOL_0DB          0xBF
+
 // Clock coefficient row: how to derive the codec's internal clocks from a given
-// (MCLK, sample-rate) pair.  Copied verbatim from the Espressif reference driver.
+// (MCLK, sample-rate) pair.  Copied from the Espressif reference driver.
 struct coeff_div {
     uint32_t mclk;
     uint32_t rate;
@@ -73,9 +83,24 @@ struct coeff_div {
     uint8_t dac_osr;
 };
 
+// AMY_SAMPLE_RATE is fixed at compile time, so only the rows for that one rate
+// can ever be selected; the reference driver's other ~55 rows would be a
+// kilobyte of dead flash on an MCU.  Every MCLK variant of our rate stays,
+// because amy_config.i2s_mclk_mult picks which one we feed the codec.  A build at
+// a rate the reference table doesn't list keeps the whole table, so get_coeff()
+// still behaves (and still reports what's missing).
+#if (AMY_SAMPLE_RATE != 8000) && (AMY_SAMPLE_RATE != 11025) && (AMY_SAMPLE_RATE != 12000) && \
+    (AMY_SAMPLE_RATE != 16000) && (AMY_SAMPLE_RATE != 22050) && (AMY_SAMPLE_RATE != 24000) && \
+    (AMY_SAMPLE_RATE != 32000) && (AMY_SAMPLE_RATE != 44100) && (AMY_SAMPLE_RATE != 48000) && \
+    (AMY_SAMPLE_RATE != 96000)
+#define ES8311_WANT(r) 1
+#else
+#define ES8311_WANT(r) (AMY_SAMPLE_RATE == (r))
+#endif
+
 static const struct coeff_div coeff_div[] = {
     // mclk      rate   prediv  mult  adcdiv dacdiv fsmode lrch  lrcl  bckdiv adcosr dacosr
-    /* 8k */
+#if ES8311_WANT(8000)
     {12288000, 8000 , 0x06, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {18432000, 8000 , 0x03, 0x02, 0x03, 0x03, 0x00, 0x05, 0xff, 0x18, 0x10, 0x10},
     {16384000, 8000 , 0x08, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
@@ -86,17 +111,20 @@ static const struct coeff_div coeff_div[] = {
     {2048000 , 8000 , 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {1536000 , 8000 , 0x03, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {1024000 , 8000 , 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
-    /* 11.025k */
+#endif
+#if ES8311_WANT(11025)
     {11289600, 11025, 0x04, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {5644800 , 11025, 0x02, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {2822400 , 11025, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {1411200 , 11025, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
-    /* 12k */
+#endif
+#if ES8311_WANT(12000)
     {12288000, 12000, 0x04, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {6144000 , 12000, 0x02, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {3072000 , 12000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {1536000 , 12000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
-    /* 16k */
+#endif
+#if ES8311_WANT(16000)
     {12288000, 16000, 0x03, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {18432000, 16000, 0x03, 0x02, 0x03, 0x03, 0x00, 0x02, 0xff, 0x0c, 0x10, 0x10},
     {16384000, 16000, 0x04, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
@@ -107,18 +135,21 @@ static const struct coeff_div coeff_div[] = {
     {2048000 , 16000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {1536000 , 16000, 0x03, 0x08, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {1024000 , 16000, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
-    /* 22.05k */
+#endif
+#if ES8311_WANT(22050)
     {11289600, 22050, 0x02, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {5644800 , 22050, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {2822400 , 22050, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {1411200 , 22050, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
-    /* 24k */
+#endif
+#if ES8311_WANT(24000)
     {12288000, 24000, 0x02, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {18432000, 24000, 0x03, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {6144000 , 24000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {3072000 , 24000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {1536000 , 24000, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
-    /* 32k */
+#endif
+#if ES8311_WANT(32000)
     {12288000, 32000, 0x03, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {18432000, 32000, 0x03, 0x04, 0x03, 0x03, 0x00, 0x02, 0xff, 0x0c, 0x10, 0x10},
     {16384000, 32000, 0x02, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
@@ -129,39 +160,39 @@ static const struct coeff_div coeff_div[] = {
     {2048000 , 32000, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {1536000 , 32000, 0x03, 0x08, 0x01, 0x01, 0x01, 0x00, 0x7f, 0x02, 0x10, 0x10},
     {1024000 , 32000, 0x01, 0x08, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
-    /* 44.1k */
+#endif
+#if ES8311_WANT(44100)
     {11289600, 44100, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {5644800 , 44100, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {2822400 , 44100, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {1411200 , 44100, 0x01, 0x08, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
-    /* 48k */
+#endif
+#if ES8311_WANT(48000)
     {12288000, 48000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {18432000, 48000, 0x03, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {6144000 , 48000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {3072000 , 48000, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {1536000 , 48000, 0x01, 0x08, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
-    /* 96k */
+#endif
+#if ES8311_WANT(96000)
     {12288000, 96000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {18432000, 96000, 0x03, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {6144000 , 96000, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {3072000 , 96000, 0x01, 0x08, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
     {1536000 , 96000, 0x01, 0x08, 0x01, 0x01, 0x01, 0x00, 0x7f, 0x02, 0x10, 0x10},
+#endif
 };
 
-static i2c_master_dev_handle_t es_dev = NULL;
-
-static esp_err_t es_write(uint8_t reg, uint8_t val) {
-    uint8_t buf[2] = { reg, val };
-    esp_err_t ret = i2c_master_transmit(es_dev, buf, 2, 100);
+static esp_err_t es_write(const amy_i2c_dev_t *d, uint8_t reg, uint8_t val) {
+    esp_err_t ret = amy_i2c_write_reg(d, reg, val);
     if (ret != ESP_OK) {
         fprintf(stderr, "ES8311: write reg 0x%02x failed: %s\n", reg, esp_err_to_name(ret));
     }
     return ret;
 }
 
-static esp_err_t es_read(uint8_t reg, uint8_t *val) {
-    *val = 0;
-    esp_err_t ret = i2c_master_transmit_receive(es_dev, &reg, 1, val, 1, 100);
+static esp_err_t es_read(const amy_i2c_dev_t *d, uint8_t reg, uint8_t *val) {
+    esp_err_t ret = amy_i2c_read_reg(d, reg, val);
     if (ret != ESP_OK) {
         fprintf(stderr, "ES8311: read reg 0x%02x failed: %s\n", reg, esp_err_to_name(ret));
     }
@@ -178,7 +209,7 @@ static int get_coeff(uint32_t mclk, uint32_t rate) {
 
 // Program the clock-manager registers for the given (mclk, rate) pair.
 // Codec is a slave, MCLK sourced from the MCLK pin (not inverted).
-static esp_err_t es8311_config_clock(int coeff) {
+static esp_err_t es8311_config_clock(const amy_i2c_dev_t *d, int coeff) {
     uint8_t regv;
     esp_err_t ret;
 
@@ -191,65 +222,68 @@ static esp_err_t es8311_config_clock(int coeff) {
         case 8: datmp = 3; break;
         default: break;
     }
-    ret = es_read(ES8311_CLK_MANAGER_REG02, &regv);
+    ret = es_read(d, ES8311_CLK_MANAGER_REG02, &regv);
     if (ret != ESP_OK) return ret;
     regv &= 0x07;
     regv |= (coeff_div[coeff].pre_div - 1) << 5;
     regv |= datmp << 3;
-    ret = es_write(ES8311_CLK_MANAGER_REG02, regv);
+    ret = es_write(d, ES8311_CLK_MANAGER_REG02, regv);
     if (ret != ESP_OK) return ret;
 
     // ADC/DAC clock dividers (reg05).
     regv = (coeff_div[coeff].adc_div - 1) << 4;
     regv |= (coeff_div[coeff].dac_div - 1) << 0;
-    ret = es_write(ES8311_CLK_MANAGER_REG05, regv);
+    ret = es_write(d, ES8311_CLK_MANAGER_REG05, regv);
     if (ret != ESP_OK) return ret;
 
     // ADC over-sample rate + fs mode (reg03).
-    ret = es_read(ES8311_CLK_MANAGER_REG03, &regv);
+    ret = es_read(d, ES8311_CLK_MANAGER_REG03, &regv);
     if (ret != ESP_OK) return ret;
     regv &= 0x80;
     regv |= coeff_div[coeff].fs_mode << 6;
     regv |= coeff_div[coeff].adc_osr << 0;
-    ret = es_write(ES8311_CLK_MANAGER_REG03, regv);
+    ret = es_write(d, ES8311_CLK_MANAGER_REG03, regv);
     if (ret != ESP_OK) return ret;
 
     // DAC over-sample rate (reg04).
-    ret = es_read(ES8311_CLK_MANAGER_REG04, &regv);
+    ret = es_read(d, ES8311_CLK_MANAGER_REG04, &regv);
     if (ret != ESP_OK) return ret;
     regv &= 0x80;
     regv |= coeff_div[coeff].dac_osr << 0;
-    ret = es_write(ES8311_CLK_MANAGER_REG04, regv);
+    ret = es_write(d, ES8311_CLK_MANAGER_REG04, regv);
     if (ret != ESP_OK) return ret;
 
     // LRCK divider high/low (reg07/reg08).
-    ret = es_read(ES8311_CLK_MANAGER_REG07, &regv);
+    ret = es_read(d, ES8311_CLK_MANAGER_REG07, &regv);
     if (ret != ESP_OK) return ret;
     regv &= 0xC0;
     regv |= coeff_div[coeff].lrck_h << 0;
-    ret = es_write(ES8311_CLK_MANAGER_REG07, regv);
+    ret = es_write(d, ES8311_CLK_MANAGER_REG07, regv);
     if (ret != ESP_OK) return ret;
     regv = coeff_div[coeff].lrck_l;
-    ret = es_write(ES8311_CLK_MANAGER_REG08, regv);
+    ret = es_write(d, ES8311_CLK_MANAGER_REG08, regv);
     if (ret != ESP_OK) return ret;
 
     // BCLK divider (reg06).
-    ret = es_read(ES8311_CLK_MANAGER_REG06, &regv);
+    ret = es_read(d, ES8311_CLK_MANAGER_REG06, &regv);
     if (ret != ESP_OK) return ret;
     regv &= 0xE0;
     if (coeff_div[coeff].bclk_div < 19)
         regv |= (coeff_div[coeff].bclk_div - 1) << 0;
     else
         regv |= (coeff_div[coeff].bclk_div) << 0;
-    ret = es_write(ES8311_CLK_MANAGER_REG06, regv);
+    ret = es_write(d, ES8311_CLK_MANAGER_REG06, regv);
     if (ret != ESP_OK) return ret;
 
     return ESP_OK;
 }
 
-amy_err_t amy_es8311_init(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr,
-                          int8_t pa_enable_gpio, uint8_t pa_active_low,
-                          uint32_t sample_rate, uint32_t mclk_hz, uint8_t volume) {
+// The bring-up proper.  Wrapped by amy_es8311_init below, which records the
+// result so amy_es8311_status() can report it to a caller that did not do the
+// bring-up itself.
+static amy_err_t es8311_init_impl(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr,
+                                  int8_t pa_enable_gpio, uint8_t pa_active_low,
+                                  uint32_t sample_rate, uint32_t mclk_hz, uint8_t volume) {
     // The default ESP I2S path drives 32-bit MSB (left-justified) slots.
 #ifdef AMY_ES8311_I2S_PHILIPS
     const uint8_t fmt_bits = 0x00;   // standard I2S (Philips)
@@ -266,29 +300,13 @@ amy_err_t amy_es8311_init(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr
     }
 
     // Bring up the I2C master bus + codec device.
-    i2c_master_bus_config_t bus_conf = {
-        .i2c_port = i2c_port,
-        .sda_io_num = sda,
-        .scl_io_num = scl,
-        .clk_source = I2C_CLK_SRC_DEFAULT,
-        .glitch_ignore_cnt = 7,
-        .flags.enable_internal_pullup = true,
-    };
-    i2c_master_bus_handle_t bus = NULL;
-    esp_err_t ret = i2c_new_master_bus(&bus_conf, &bus);
+    amy_i2c_dev_t d;
+    esp_err_t ret = amy_i2c_open_device(&d, i2c_port, sda, scl, i2c_addr, ES8311_I2C_FREQ);
     if (ret != ESP_OK) {
-        fprintf(stderr, "ES8311: I2C bus init failed: %s\n", esp_err_to_name(ret));
-        return -1;
-    }
-    i2c_device_config_t dev_conf = {
-        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
-        .device_address = i2c_addr,
-        .scl_speed_hz = 400000,
-    };
-    ret = i2c_master_bus_add_device(bus, &dev_conf, &es_dev);
-    if (ret != ESP_OK) {
-        fprintf(stderr, "ES8311: I2C add device 0x%02x failed: %s\n", i2c_addr, esp_err_to_name(ret));
-        i2c_del_master_bus(bus);
+        fprintf(stderr, "ES8311: I2C open (port %d, sda %d, scl %d, addr 0x%02x) failed: %s\n"
+                        "        If something else already owns that bus -- e.g. Wire.begin() for a\n"
+                        "        touch panel sharing those pins -- configure the codec first.\n",
+                i2c_port, sda, scl, i2c_addr, esp_err_to_name(ret));
         return -1;
     }
 
@@ -301,8 +319,8 @@ amy_err_t amy_es8311_init(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr
 
     // Presence check (ES8311 chip id is 0x83 0x11).
     uint8_t id1, id2, regv;
-    ES8311_INIT_CHECK(es_read(ES8311_CHD1_REGFD, &id1));
-    ES8311_INIT_CHECK(es_read(ES8311_CHD2_REGFE, &id2));
+    ES8311_INIT_CHECK(es_read(&d, ES8311_CHD1_REGFD, &id1));
+    ES8311_INIT_CHECK(es_read(&d, ES8311_CHD2_REGFE, &id2));
     if (!(id1 == 0x83 && id2 == 0x11)) {
         fprintf(stderr, "ES8311: unexpected chip id 0x%02x%02x (expected 0x8311)\n", id1, id2);
         ret = ESP_FAIL;
@@ -310,65 +328,61 @@ amy_err_t amy_es8311_init(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr
     }
 
     // ---- Codec init (clock manager + power) ----
-    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG01, 0x30));
-    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG02, 0x00));
-    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG03, 0x10));
-    ES8311_INIT_CHECK(es_write(ES8311_ADC_REG16, 0x24));
-    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG04, 0x10));
-    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG05, 0x00));
-    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG0B, 0x00));
-    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG0C, 0x00));
-    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG10, 0x1F));
-    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG11, 0x7F));
-    ES8311_INIT_CHECK(es_write(ES8311_RESET_REG00, 0x80));   // power up, CSM/clock on
+    ES8311_INIT_CHECK(es_write(&d, ES8311_CLK_MANAGER_REG01, 0x30));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_CLK_MANAGER_REG02, 0x00));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_CLK_MANAGER_REG03, 0x10));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_ADC_REG16, 0x24));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_CLK_MANAGER_REG04, 0x10));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_CLK_MANAGER_REG05, 0x00));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SYSTEM_REG0B, 0x00));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SYSTEM_REG0C, 0x00));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SYSTEM_REG10, 0x1F));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SYSTEM_REG11, 0x7F));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_RESET_REG00, 0x80));   // power up, CSM/clock on
 
     // Slave mode: clear bit6 of reg00.
-    ES8311_INIT_CHECK(es_read(ES8311_RESET_REG00, &regv));
-    ES8311_INIT_CHECK(es_write(ES8311_RESET_REG00, regv & 0xBF));
-    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG01, 0x3F));
+    ES8311_INIT_CHECK(es_read(&d, ES8311_RESET_REG00, &regv));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_RESET_REG00, regv & 0xBF));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_CLK_MANAGER_REG01, 0x3F));
     // MCLK from the MCLK pin (not BCLK): clear bit7 of reg01.
-    ES8311_INIT_CHECK(es_read(ES8311_CLK_MANAGER_REG01, &regv));
-    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG01, regv & 0x7F));
+    ES8311_INIT_CHECK(es_read(&d, ES8311_CLK_MANAGER_REG01, &regv));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_CLK_MANAGER_REG01, regv & 0x7F));
 
-    ES8311_INIT_CHECK(es8311_config_clock(coeff));
+    ES8311_INIT_CHECK(es8311_config_clock(&d, coeff));
 
     // MCLK / SCLK not inverted.
-    ES8311_INIT_CHECK(es_read(ES8311_CLK_MANAGER_REG01, &regv));
-    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG01, regv & ~0x40));
-    ES8311_INIT_CHECK(es_read(ES8311_CLK_MANAGER_REG06, &regv));
-    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG06, regv & ~0x20));
+    ES8311_INIT_CHECK(es_read(&d, ES8311_CLK_MANAGER_REG01, &regv));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_CLK_MANAGER_REG01, regv & ~0x40));
+    ES8311_INIT_CHECK(es_read(&d, ES8311_CLK_MANAGER_REG06, &regv));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_CLK_MANAGER_REG06, regv & ~0x20));
 
-    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG13, 0x10));
-    ES8311_INIT_CHECK(es_write(ES8311_ADC_REG1B, 0x0A));
-    ES8311_INIT_CHECK(es_write(ES8311_ADC_REG1C, 0x6A));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SYSTEM_REG13, 0x10));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_ADC_REG1B, 0x0A));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_ADC_REG1C, 0x6A));
 
     // ---- Serial data-port format: 32-bit, left-justified (or Philips) ----
-    // DAC port (reg09): word length in bits [4:2], format in bits [1:0].
-    ES8311_INIT_CHECK(es_write(ES8311_SDPIN_REG09, (len_bits) | fmt_bits));
-    ES8311_INIT_CHECK(es_write(ES8311_SDPOUT_REG0A, (len_bits) | fmt_bits));
+    // reg09/reg0A: serial-port mute in bit6 (so 0 here also un-mutes the port),
+    // word length in bits [4:2], format in bits [1:0].
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SDPIN_REG09, len_bits | fmt_bits));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SDPOUT_REG0A, len_bits | fmt_bits));
 
     // ---- Start playback (DAC) path ----
-    // Un-mute the DAC serial port (clear bit6 of reg09).
-    ES8311_INIT_CHECK(es_read(ES8311_SDPIN_REG09, &regv));
-    ES8311_INIT_CHECK(es_write(ES8311_SDPIN_REG09, regv & ~0x40));
-    ES8311_INIT_CHECK(es_write(ES8311_ADC_REG17, 0xBF));
-    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG0E, 0x02));
-    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG12, 0x00));   // enable DAC
-    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG14, 0x1A));   // analog PGA / not DMIC
-    ES8311_INIT_CHECK(es_read(ES8311_SYSTEM_REG14, &regv));
-    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG14, regv & ~0x40));
-    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG0D, 0x01));
-    ES8311_INIT_CHECK(es_write(ES8311_ADC_REG15, 0x40));
-    ES8311_INIT_CHECK(es_write(ES8311_DAC_REG37, 0x48));
-    ES8311_INIT_CHECK(es_write(ES8311_GP_REG45, 0x00));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_ADC_REG17, 0xBF));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SYSTEM_REG0E, 0x02));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SYSTEM_REG12, 0x00));   // enable DAC
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SYSTEM_REG14, 0x1A));   // analog PGA, not DMIC (bit6 = 0)
+    ES8311_INIT_CHECK(es_write(&d, ES8311_SYSTEM_REG0D, 0x01));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_ADC_REG15, 0x40));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_DAC_REG37, 0x48));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_GP_REG45, 0x00));
 
     // ---- Volume + un-mute ----
     if (volume > 100) volume = 100;
-    ES8311_INIT_CHECK(es_write(ES8311_DAC_REG32, (uint8_t)((volume * 2550) / 1000)));  // 0..255
-    // Un-mute: clear DAC mute bits (reg31 [6:5]) and clear the system mute (reg12).
-    ES8311_INIT_CHECK(es_read(ES8311_DAC_REG31, &regv));
-    ES8311_INIT_CHECK(es_write(ES8311_DAC_REG31, regv & 0x9F));
-    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG12, 0x00));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_DAC_REG32,
+                               (uint8_t)(((uint32_t)volume * ES8311_DAC_VOL_0DB + 50) / 100)));
+    // Un-mute: clear the DAC mute bits (reg31 [6:5]).
+    ES8311_INIT_CHECK(es_read(&d, ES8311_DAC_REG31, &regv));
+    ES8311_INIT_CHECK(es_write(&d, ES8311_DAC_REG31, regv & 0x9F));
 
     // Give the DAC ramp a moment before the amp comes up (avoids a turn-on pop).
     esp_rom_delay_us(2000);
@@ -384,29 +398,83 @@ amy_err_t amy_es8311_init(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr
 
     // The codec now runs off I2S; release the I2C bus so Arduino Wire (touch
     // panel, etc.) can reuse it, mirroring the PCM9211 setup in i2s.c.
-    ret = i2c_master_bus_rm_device(es_dev);
-    es_dev = NULL;
-    if (ret != ESP_OK) {
-        fprintf(stderr, "ES8311: I2C device cleanup failed: %s\n", esp_err_to_name(ret));
-        i2c_del_master_bus(bus);
-        return -1;
-    }
-    ret = i2c_del_master_bus(bus);
-    if (ret != ESP_OK) {
-        fprintf(stderr, "ES8311: I2C bus cleanup failed: %s\n", esp_err_to_name(ret));
-        return -1;
-    }
+    amy_i2c_close_device(&d);
 
 #undef ES8311_INIT_CHECK
     return AMY_OK;
 
 init_failed:
-    if (es_dev != NULL) {
-        i2c_master_bus_rm_device(es_dev);
-        es_dev = NULL;
-    }
-    if (bus != NULL) i2c_del_master_bus(bus);
+    amy_i2c_close_device(&d);
     return -1;
 }
+
+static amy_err_t es8311_last_status = AMY_ES8311_NOT_STARTED;
+
+// What we last configured.  amy_es8311_init() hands the I2C pins back when it's
+// done, so shutting the codec down again means re-opening the control bus.
+static struct {
+    int i2c_port;
+    int8_t sda;
+    int8_t scl;
+    uint8_t i2c_addr;
+    int8_t pa_gpio;
+    uint8_t pa_active_low;
+} es8311_hw;
+
+amy_err_t amy_es8311_init(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr,
+                          int8_t pa_enable_gpio, uint8_t pa_active_low,
+                          uint32_t sample_rate, uint32_t mclk_hz, uint8_t volume) {
+    // If a codec is already up (a second esp32_setup_i2s(), a stop/start cycle),
+    // mute it and drop the amp first so we re-configure a quiet chip instead of
+    // reprogramming clocks underneath a live amplifier.
+    if (es8311_last_status == AMY_OK) amy_es8311_deinit();
+
+    es8311_last_status = es8311_init_impl(i2c_port, sda, scl, i2c_addr,
+                                         pa_enable_gpio, pa_active_low,
+                                         sample_rate, mclk_hz, volume);
+    if (es8311_last_status == AMY_OK) {
+        es8311_hw.i2c_port = i2c_port;
+        es8311_hw.sda = sda;
+        es8311_hw.scl = scl;
+        es8311_hw.i2c_addr = i2c_addr;
+        es8311_hw.pa_gpio = pa_enable_gpio;
+        es8311_hw.pa_active_low = pa_active_low;
+    }
+    return es8311_last_status;
+}
+
+amy_err_t amy_es8311_deinit(void) {
+    if (es8311_last_status != AMY_OK) return AMY_OK;   // nothing of ours is running
+    es8311_last_status = AMY_ES8311_NOT_STARTED;
+
+    // Shut the power amplifier down *first*: muting the DAC -- or, worse, having
+    // the caller stop MCLK/BCLK/WS -- while the amp is live puts a pop, or a
+    // sustained DC thump, through the speaker.
+    if (es8311_hw.pa_gpio >= 0) {
+        gpio_set_level((gpio_num_t)es8311_hw.pa_gpio, es8311_hw.pa_active_low ? 1 : 0);
+        esp_rom_delay_us(2000);   // let the amp actually get there
+    }
+
+    // Then quiet the codec, so a stopped I2S clock (or the next init) meets a
+    // muted, powered-down DAC.  Re-open the control bus we handed back in init.
+    amy_i2c_dev_t d;
+    esp_err_t ret = amy_i2c_open_device(&d, es8311_hw.i2c_port, es8311_hw.sda, es8311_hw.scl,
+                                       es8311_hw.i2c_addr, ES8311_I2C_FREQ);
+    if (ret != ESP_OK) {
+        fprintf(stderr, "ES8311: I2C open for shutdown failed: %s "
+                        "(amp is off, DAC left as it was)\n", esp_err_to_name(ret));
+        return -1;
+    }
+    uint8_t regv;
+    es_write(&d, ES8311_DAC_REG32, 0x00);              // volume down to -95.5 dB
+    if (es_read(&d, ES8311_DAC_REG31, &regv) == ESP_OK)
+        es_write(&d, ES8311_DAC_REG31, regv | 0x60);   // mute the DAC
+    es_write(&d, ES8311_SYSTEM_REG12, 0x02);           // DAC off
+    es_write(&d, ES8311_SYSTEM_REG0D, 0xFA);           // power down the analog blocks
+    amy_i2c_close_device(&d);
+    return AMY_OK;
+}
+
+amy_err_t amy_es8311_status(void) { return es8311_last_status; }
 
 #endif // ESP_PLATFORM

--- a/src/es8311.c
+++ b/src/es8311.c
@@ -1,0 +1,412 @@
+// es8311.c
+// Minimal ES8311 mono audio-codec driver for AMY on ESP32.
+//
+// Ported from Espressif's reference ES8311 driver (ESPRESSIF MIT License) down
+// to just the playback path AMY needs, and re-plumbed onto the ESP-IDF
+// driver_ng I2C master API (driver/i2c_master.h) so it coexists with Arduino's
+// Wire, exactly like the PCM9211 setup in i2s.c.
+//
+// Assumptions (matching AMY's default ESP I2S setup in i2s.c):
+//   * The ES8311 is the I2S slave; AMY (the ESP) is the master and supplies
+//     MCLK, BCLK and WS.
+//   * The codec's internal MCLK comes from the MCLK pin (not BCLK).
+//   * MCLK = sample_rate * 256 (AMY's default I2S_STD_CLK_DEFAULT_CONFIG).
+//   * Data is 32-bit, MSB / left-justified (I2S_STD_MSB_SLOT_DEFAULT_CONFIG).
+//     Define AMY_ES8311_I2S_PHILIPS to use standard (Philips) I2S framing
+//     instead, should AMY's slot config ever change.
+
+#if defined(ESP_PLATFORM)
+
+#include <stdio.h>
+#include "es8311.h"
+#include "driver/i2c_master.h"
+#include "driver/gpio.h"
+#include "esp_rom_sys.h"   // esp_rom_delay_us
+
+// ---- ES8311 register map (subset used here) ----
+#define ES8311_RESET_REG00          0x00
+#define ES8311_CLK_MANAGER_REG01    0x01
+#define ES8311_CLK_MANAGER_REG02    0x02
+#define ES8311_CLK_MANAGER_REG03    0x03
+#define ES8311_CLK_MANAGER_REG04    0x04
+#define ES8311_CLK_MANAGER_REG05    0x05
+#define ES8311_CLK_MANAGER_REG06    0x06
+#define ES8311_CLK_MANAGER_REG07    0x07
+#define ES8311_CLK_MANAGER_REG08    0x08
+#define ES8311_SDPIN_REG09          0x09   // DAC serial digital port
+#define ES8311_SDPOUT_REG0A         0x0A   // ADC serial digital port
+#define ES8311_SYSTEM_REG0B         0x0B
+#define ES8311_SYSTEM_REG0C         0x0C
+#define ES8311_SYSTEM_REG0D         0x0D
+#define ES8311_SYSTEM_REG0E         0x0E
+#define ES8311_SYSTEM_REG10         0x10
+#define ES8311_SYSTEM_REG11         0x11
+#define ES8311_SYSTEM_REG12         0x12
+#define ES8311_SYSTEM_REG13         0x13
+#define ES8311_SYSTEM_REG14         0x14
+#define ES8311_ADC_REG15            0x15
+#define ES8311_ADC_REG16            0x16
+#define ES8311_ADC_REG17            0x17
+#define ES8311_ADC_REG1B            0x1B
+#define ES8311_ADC_REG1C            0x1C
+#define ES8311_DAC_REG31            0x31   // DAC mute
+#define ES8311_DAC_REG32            0x32   // DAC volume
+#define ES8311_DAC_REG37            0x37
+#define ES8311_GP_REG45             0x45
+#define ES8311_CHD1_REGFD           0xFD   // chip ID 1
+#define ES8311_CHD2_REGFE           0xFE   // chip ID 2
+
+// Clock coefficient row: how to derive the codec's internal clocks from a given
+// (MCLK, sample-rate) pair.  Copied verbatim from the Espressif reference driver.
+struct coeff_div {
+    uint32_t mclk;
+    uint32_t rate;
+    uint8_t pre_div;
+    uint8_t pre_multi;
+    uint8_t adc_div;
+    uint8_t dac_div;
+    uint8_t fs_mode;
+    uint8_t lrck_h;
+    uint8_t lrck_l;
+    uint8_t bclk_div;
+    uint8_t adc_osr;
+    uint8_t dac_osr;
+};
+
+static const struct coeff_div coeff_div[] = {
+    // mclk      rate   prediv  mult  adcdiv dacdiv fsmode lrch  lrcl  bckdiv adcosr dacosr
+    /* 8k */
+    {12288000, 8000 , 0x06, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 8000 , 0x03, 0x02, 0x03, 0x03, 0x00, 0x05, 0xff, 0x18, 0x10, 0x10},
+    {16384000, 8000 , 0x08, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {8192000 , 8000 , 0x04, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000 , 8000 , 0x03, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {4096000 , 8000 , 0x02, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000 , 8000 , 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2048000 , 8000 , 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000 , 8000 , 0x03, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1024000 , 8000 , 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    /* 11.025k */
+    {11289600, 11025, 0x04, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {5644800 , 11025, 0x02, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2822400 , 11025, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1411200 , 11025, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    /* 12k */
+    {12288000, 12000, 0x04, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000 , 12000, 0x02, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000 , 12000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000 , 12000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    /* 16k */
+    {12288000, 16000, 0x03, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 16000, 0x03, 0x02, 0x03, 0x03, 0x00, 0x02, 0xff, 0x0c, 0x10, 0x10},
+    {16384000, 16000, 0x04, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {8192000 , 16000, 0x02, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000 , 16000, 0x03, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {4096000 , 16000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000 , 16000, 0x03, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2048000 , 16000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000 , 16000, 0x03, 0x08, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1024000 , 16000, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    /* 22.05k */
+    {11289600, 22050, 0x02, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {5644800 , 22050, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2822400 , 22050, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1411200 , 22050, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    /* 24k */
+    {12288000, 24000, 0x02, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 24000, 0x03, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000 , 24000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000 , 24000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000 , 24000, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    /* 32k */
+    {12288000, 32000, 0x03, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 32000, 0x03, 0x04, 0x03, 0x03, 0x00, 0x02, 0xff, 0x0c, 0x10, 0x10},
+    {16384000, 32000, 0x02, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {8192000 , 32000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000 , 32000, 0x03, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {4096000 , 32000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000 , 32000, 0x03, 0x08, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2048000 , 32000, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000 , 32000, 0x03, 0x08, 0x01, 0x01, 0x01, 0x00, 0x7f, 0x02, 0x10, 0x10},
+    {1024000 , 32000, 0x01, 0x08, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    /* 44.1k */
+    {11289600, 44100, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {5644800 , 44100, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {2822400 , 44100, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1411200 , 44100, 0x01, 0x08, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    /* 48k */
+    {12288000, 48000, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 48000, 0x03, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000 , 48000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000 , 48000, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000 , 48000, 0x01, 0x08, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    /* 96k */
+    {12288000, 96000, 0x01, 0x02, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {18432000, 96000, 0x03, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {6144000 , 96000, 0x01, 0x04, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {3072000 , 96000, 0x01, 0x08, 0x01, 0x01, 0x00, 0x00, 0xff, 0x04, 0x10, 0x10},
+    {1536000 , 96000, 0x01, 0x08, 0x01, 0x01, 0x01, 0x00, 0x7f, 0x02, 0x10, 0x10},
+};
+
+static i2c_master_dev_handle_t es_dev = NULL;
+
+static esp_err_t es_write(uint8_t reg, uint8_t val) {
+    uint8_t buf[2] = { reg, val };
+    esp_err_t ret = i2c_master_transmit(es_dev, buf, 2, 100);
+    if (ret != ESP_OK) {
+        fprintf(stderr, "ES8311: write reg 0x%02x failed: %s\n", reg, esp_err_to_name(ret));
+    }
+    return ret;
+}
+
+static esp_err_t es_read(uint8_t reg, uint8_t *val) {
+    *val = 0;
+    esp_err_t ret = i2c_master_transmit_receive(es_dev, &reg, 1, val, 1, 100);
+    if (ret != ESP_OK) {
+        fprintf(stderr, "ES8311: read reg 0x%02x failed: %s\n", reg, esp_err_to_name(ret));
+    }
+    return ret;
+}
+
+static int get_coeff(uint32_t mclk, uint32_t rate) {
+    for (unsigned i = 0; i < sizeof(coeff_div) / sizeof(coeff_div[0]); i++) {
+        if (coeff_div[i].rate == rate && coeff_div[i].mclk == mclk)
+            return (int)i;
+    }
+    return -1;
+}
+
+// Program the clock-manager registers for the given (mclk, rate) pair.
+// Codec is a slave, MCLK sourced from the MCLK pin (not inverted).
+static esp_err_t es8311_config_clock(int coeff) {
+    uint8_t regv;
+    esp_err_t ret;
+
+    // Pre-divider / pre-multiplier (reg02). pre_multi 1/2/4/8 -> 0/1/2/3.
+    uint8_t datmp = 0;
+    switch (coeff_div[coeff].pre_multi) {
+        case 1: datmp = 0; break;
+        case 2: datmp = 1; break;
+        case 4: datmp = 2; break;
+        case 8: datmp = 3; break;
+        default: break;
+    }
+    ret = es_read(ES8311_CLK_MANAGER_REG02, &regv);
+    if (ret != ESP_OK) return ret;
+    regv &= 0x07;
+    regv |= (coeff_div[coeff].pre_div - 1) << 5;
+    regv |= datmp << 3;
+    ret = es_write(ES8311_CLK_MANAGER_REG02, regv);
+    if (ret != ESP_OK) return ret;
+
+    // ADC/DAC clock dividers (reg05).
+    regv = (coeff_div[coeff].adc_div - 1) << 4;
+    regv |= (coeff_div[coeff].dac_div - 1) << 0;
+    ret = es_write(ES8311_CLK_MANAGER_REG05, regv);
+    if (ret != ESP_OK) return ret;
+
+    // ADC over-sample rate + fs mode (reg03).
+    ret = es_read(ES8311_CLK_MANAGER_REG03, &regv);
+    if (ret != ESP_OK) return ret;
+    regv &= 0x80;
+    regv |= coeff_div[coeff].fs_mode << 6;
+    regv |= coeff_div[coeff].adc_osr << 0;
+    ret = es_write(ES8311_CLK_MANAGER_REG03, regv);
+    if (ret != ESP_OK) return ret;
+
+    // DAC over-sample rate (reg04).
+    ret = es_read(ES8311_CLK_MANAGER_REG04, &regv);
+    if (ret != ESP_OK) return ret;
+    regv &= 0x80;
+    regv |= coeff_div[coeff].dac_osr << 0;
+    ret = es_write(ES8311_CLK_MANAGER_REG04, regv);
+    if (ret != ESP_OK) return ret;
+
+    // LRCK divider high/low (reg07/reg08).
+    ret = es_read(ES8311_CLK_MANAGER_REG07, &regv);
+    if (ret != ESP_OK) return ret;
+    regv &= 0xC0;
+    regv |= coeff_div[coeff].lrck_h << 0;
+    ret = es_write(ES8311_CLK_MANAGER_REG07, regv);
+    if (ret != ESP_OK) return ret;
+    regv = coeff_div[coeff].lrck_l;
+    ret = es_write(ES8311_CLK_MANAGER_REG08, regv);
+    if (ret != ESP_OK) return ret;
+
+    // BCLK divider (reg06).
+    ret = es_read(ES8311_CLK_MANAGER_REG06, &regv);
+    if (ret != ESP_OK) return ret;
+    regv &= 0xE0;
+    if (coeff_div[coeff].bclk_div < 19)
+        regv |= (coeff_div[coeff].bclk_div - 1) << 0;
+    else
+        regv |= (coeff_div[coeff].bclk_div) << 0;
+    ret = es_write(ES8311_CLK_MANAGER_REG06, regv);
+    if (ret != ESP_OK) return ret;
+
+    return ESP_OK;
+}
+
+amy_err_t amy_es8311_init(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr,
+                          int8_t pa_enable_gpio, uint8_t pa_active_low,
+                          uint32_t sample_rate, uint32_t mclk_hz, uint8_t volume) {
+    // The default ESP I2S path drives 32-bit MSB (left-justified) slots.
+#ifdef AMY_ES8311_I2S_PHILIPS
+    const uint8_t fmt_bits = 0x00;   // standard I2S (Philips)
+#else
+    const uint8_t fmt_bits = 0x01;   // MSB / left-justified
+#endif
+    const uint8_t len_bits = 0x10;   // 32-bit word length
+
+    int coeff = get_coeff(mclk_hz, sample_rate);
+    if (coeff < 0) {
+        fprintf(stderr, "ES8311: no clock coefficients for %luHz MCLK at %luHz\n",
+                (unsigned long)mclk_hz, (unsigned long)sample_rate);
+        return -1;
+    }
+
+    // Bring up the I2C master bus + codec device.
+    i2c_master_bus_config_t bus_conf = {
+        .i2c_port = i2c_port,
+        .sda_io_num = sda,
+        .scl_io_num = scl,
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .glitch_ignore_cnt = 7,
+        .flags.enable_internal_pullup = true,
+    };
+    i2c_master_bus_handle_t bus = NULL;
+    esp_err_t ret = i2c_new_master_bus(&bus_conf, &bus);
+    if (ret != ESP_OK) {
+        fprintf(stderr, "ES8311: I2C bus init failed: %s\n", esp_err_to_name(ret));
+        return -1;
+    }
+    i2c_device_config_t dev_conf = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = i2c_addr,
+        .scl_speed_hz = 400000,
+    };
+    ret = i2c_master_bus_add_device(bus, &dev_conf, &es_dev);
+    if (ret != ESP_OK) {
+        fprintf(stderr, "ES8311: I2C add device 0x%02x failed: %s\n", i2c_addr, esp_err_to_name(ret));
+        i2c_del_master_bus(bus);
+        return -1;
+    }
+
+    // From this point on, any hardware-access failure tears down the temporary
+    // I2C bus and returns an error without enabling the power amplifier.
+#define ES8311_INIT_CHECK(call) do { \
+        ret = (call); \
+        if (ret != ESP_OK) goto init_failed; \
+    } while (0)
+
+    // Presence check (ES8311 chip id is 0x83 0x11).
+    uint8_t id1, id2, regv;
+    ES8311_INIT_CHECK(es_read(ES8311_CHD1_REGFD, &id1));
+    ES8311_INIT_CHECK(es_read(ES8311_CHD2_REGFE, &id2));
+    if (!(id1 == 0x83 && id2 == 0x11)) {
+        fprintf(stderr, "ES8311: unexpected chip id 0x%02x%02x (expected 0x8311)\n", id1, id2);
+        ret = ESP_FAIL;
+        goto init_failed;
+    }
+
+    // ---- Codec init (clock manager + power) ----
+    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG01, 0x30));
+    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG02, 0x00));
+    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG03, 0x10));
+    ES8311_INIT_CHECK(es_write(ES8311_ADC_REG16, 0x24));
+    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG04, 0x10));
+    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG05, 0x00));
+    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG0B, 0x00));
+    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG0C, 0x00));
+    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG10, 0x1F));
+    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG11, 0x7F));
+    ES8311_INIT_CHECK(es_write(ES8311_RESET_REG00, 0x80));   // power up, CSM/clock on
+
+    // Slave mode: clear bit6 of reg00.
+    ES8311_INIT_CHECK(es_read(ES8311_RESET_REG00, &regv));
+    ES8311_INIT_CHECK(es_write(ES8311_RESET_REG00, regv & 0xBF));
+    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG01, 0x3F));
+    // MCLK from the MCLK pin (not BCLK): clear bit7 of reg01.
+    ES8311_INIT_CHECK(es_read(ES8311_CLK_MANAGER_REG01, &regv));
+    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG01, regv & 0x7F));
+
+    ES8311_INIT_CHECK(es8311_config_clock(coeff));
+
+    // MCLK / SCLK not inverted.
+    ES8311_INIT_CHECK(es_read(ES8311_CLK_MANAGER_REG01, &regv));
+    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG01, regv & ~0x40));
+    ES8311_INIT_CHECK(es_read(ES8311_CLK_MANAGER_REG06, &regv));
+    ES8311_INIT_CHECK(es_write(ES8311_CLK_MANAGER_REG06, regv & ~0x20));
+
+    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG13, 0x10));
+    ES8311_INIT_CHECK(es_write(ES8311_ADC_REG1B, 0x0A));
+    ES8311_INIT_CHECK(es_write(ES8311_ADC_REG1C, 0x6A));
+
+    // ---- Serial data-port format: 32-bit, left-justified (or Philips) ----
+    // DAC port (reg09): word length in bits [4:2], format in bits [1:0].
+    ES8311_INIT_CHECK(es_write(ES8311_SDPIN_REG09, (len_bits) | fmt_bits));
+    ES8311_INIT_CHECK(es_write(ES8311_SDPOUT_REG0A, (len_bits) | fmt_bits));
+
+    // ---- Start playback (DAC) path ----
+    // Un-mute the DAC serial port (clear bit6 of reg09).
+    ES8311_INIT_CHECK(es_read(ES8311_SDPIN_REG09, &regv));
+    ES8311_INIT_CHECK(es_write(ES8311_SDPIN_REG09, regv & ~0x40));
+    ES8311_INIT_CHECK(es_write(ES8311_ADC_REG17, 0xBF));
+    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG0E, 0x02));
+    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG12, 0x00));   // enable DAC
+    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG14, 0x1A));   // analog PGA / not DMIC
+    ES8311_INIT_CHECK(es_read(ES8311_SYSTEM_REG14, &regv));
+    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG14, regv & ~0x40));
+    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG0D, 0x01));
+    ES8311_INIT_CHECK(es_write(ES8311_ADC_REG15, 0x40));
+    ES8311_INIT_CHECK(es_write(ES8311_DAC_REG37, 0x48));
+    ES8311_INIT_CHECK(es_write(ES8311_GP_REG45, 0x00));
+
+    // ---- Volume + un-mute ----
+    if (volume > 100) volume = 100;
+    ES8311_INIT_CHECK(es_write(ES8311_DAC_REG32, (uint8_t)((volume * 2550) / 1000)));  // 0..255
+    // Un-mute: clear DAC mute bits (reg31 [6:5]) and clear the system mute (reg12).
+    ES8311_INIT_CHECK(es_read(ES8311_DAC_REG31, &regv));
+    ES8311_INIT_CHECK(es_write(ES8311_DAC_REG31, regv & 0x9F));
+    ES8311_INIT_CHECK(es_write(ES8311_SYSTEM_REG12, 0x00));
+
+    // Give the DAC ramp a moment before the amp comes up (avoids a turn-on pop).
+    esp_rom_delay_us(2000);
+
+    // ---- Enable the on-board power amplifier ----
+    // Many of these boards (e.g. the FNK0104) gate the amp with an active-low
+    // enable, so driving it HIGH holds the amp in shutdown -> silence.  Drive it
+    // to the level that turns the amp ON.
+    if (pa_enable_gpio >= 0) {
+        ES8311_INIT_CHECK(gpio_set_direction((gpio_num_t)pa_enable_gpio, GPIO_MODE_OUTPUT));
+        ES8311_INIT_CHECK(gpio_set_level((gpio_num_t)pa_enable_gpio, pa_active_low ? 0 : 1));
+    }
+
+    // The codec now runs off I2S; release the I2C bus so Arduino Wire (touch
+    // panel, etc.) can reuse it, mirroring the PCM9211 setup in i2s.c.
+    ret = i2c_master_bus_rm_device(es_dev);
+    es_dev = NULL;
+    if (ret != ESP_OK) {
+        fprintf(stderr, "ES8311: I2C device cleanup failed: %s\n", esp_err_to_name(ret));
+        i2c_del_master_bus(bus);
+        return -1;
+    }
+    ret = i2c_del_master_bus(bus);
+    if (ret != ESP_OK) {
+        fprintf(stderr, "ES8311: I2C bus cleanup failed: %s\n", esp_err_to_name(ret));
+        return -1;
+    }
+
+#undef ES8311_INIT_CHECK
+    return AMY_OK;
+
+init_failed:
+    if (es_dev != NULL) {
+        i2c_master_bus_rm_device(es_dev);
+        es_dev = NULL;
+    }
+    if (bus != NULL) i2c_del_master_bus(bus);
+    return -1;
+}
+
+#endif // ESP_PLATFORM

--- a/src/es8311.h
+++ b/src/es8311.h
@@ -8,8 +8,10 @@
 // slave) and feeds it MCLK from the ESP's I2S MCLK pin.  Only the playback
 // (DAC) path is implemented here.
 //
-// To use it, build AMY with -DAMY_CODEC_ES8311 and set the I2S pins in your
-// amy_config before amy_start().  On the FNK0104 that is:
+// To use it, either call amy_es8311_init() yourself right after amy_start() (see
+// the AMY_ES8311_FNK0104 example) or build AMY with -DAMY_CODEC_ES8311, which
+// does it from inside amy_start().  Either way, set the I2S pins in your
+// amy_config first.  On the FNK0104 that is:
 //     amy_config.i2s_mclk = 4;
 //     amy_config.i2s_bclk = 5;
 //     amy_config.i2s_lrc  = 7;   // WS
@@ -33,13 +35,40 @@
 //   pa_active_low  : 1 if the amp-enable pin is active-low (driven LOW to turn the
 //                    amp ON, e.g. the Freenove FNK0104), 0 if active-high
 //   sample_rate    : audio sample rate in Hz (normally AMY_SAMPLE_RATE)
-//   mclk_hz        : MCLK frequency AMY feeds the codec (sample_rate * mclk mult)
-//   volume         : startup DAC volume, 0-100
+//   mclk_hz        : MCLK frequency AMY feeds the codec, i.e.
+//                    sample_rate * amy_config.i2s_mclk_mult (256 by default).
+//                    Must match what I2S actually generates or the codec's
+//                    dividers are programmed for a clock it isn't getting.
+//   volume         : startup DAC volume, 0-100, where 100 is unity (0 dB) and
+//                    each step down attenuates ~0.5 dB (0 is ~ -95 dB, silence).
+//                    The codec can apply digital gain above unity, but AMY's
+//                    output already reaches full scale, so we don't offer it:
+//                    it would just clip inside the DAC.
 // The ESP-side I2S channel must already be enabled (so MCLK/BCLK are running)
 // before this is called.  Returns AMY_OK on success, -1 on failure.
+// Note that the driver takes exclusive ownership of i2c_port for the duration of
+// the call and hands the pins back afterwards, so anything else on that bus
+// (Arduino Wire for a touch panel, say) must be initialised *after* this.
 amy_err_t amy_es8311_init(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr,
                           int8_t pa_enable_gpio, uint8_t pa_active_low,
                           uint32_t sample_rate, uint32_t mclk_hz, uint8_t volume);
+
+// Mute the DAC and switch the power amplifier back off, using the pins/address
+// the last successful amy_es8311_init() was given.  Call this *before* stopping
+// I2S: pulling MCLK/BCLK/WS out from under a live amplifier thumps the speaker.
+// A no-op (returning AMY_OK) if no codec was brought up.  AMY does this itself
+// from esp32_teardown_i2s() under -DAMY_CODEC_ES8311.
+amy_err_t amy_es8311_deinit(void);
+
+// Result of the last amy_es8311_init() call, for callers that did not make it
+// themselves: under -DAMY_CODEC_ES8311 the bring-up happens inside
+// esp32_setup_i2s(), which has no way to hand the codec's status back up through
+// amy_start().  Without this, a codec that failed to configure is just a silent
+// board with no clue why.  AMY_OK / -1 as amy_es8311_init, or
+// AMY_ES8311_NOT_STARTED if no codec is currently up (never initialised, or shut
+// down again by amy_es8311_deinit()).
+#define AMY_ES8311_NOT_STARTED (-2)
+amy_err_t amy_es8311_status(void);
 
 #endif // ESP_PLATFORM
 #endif // AMY_ES8311_H

--- a/src/es8311.h
+++ b/src/es8311.h
@@ -17,7 +17,8 @@
 //     amy_config.i2s_lrc  = 7;   // WS
 //     amy_config.i2s_dout = 8;
 // The I2C control pins, codec address, power-amp enable GPIO and startup volume
-// default to the FNK0104 and can be overridden with -D defines (see i2s.c).
+// default to the FNK0104 (below) and can be overridden with -D defines, or by
+// defining them before including this header (AMY-Arduino.h pulls it in).
 
 #ifndef AMY_ES8311_H
 #define AMY_ES8311_H
@@ -26,6 +27,32 @@
 
 #include <stdint.h>
 #include "amy.h"   // amy_err_t, AMY_OK
+
+// Codec control-bus wiring defaults (the Freenove FNK0104).  Used by
+// esp32_setup_i2s() under -DAMY_CODEC_ES8311, and handy for sketches that call
+// amy_es8311_init() themselves.
+#ifndef AMY_ES8311_I2C_PORT
+#define AMY_ES8311_I2C_PORT   0      // I2C_NUM_0
+#endif
+#ifndef AMY_ES8311_I2C_SDA
+#define AMY_ES8311_I2C_SDA    16     // FNK0104 codec-control SDA
+#endif
+#ifndef AMY_ES8311_I2C_SCL
+#define AMY_ES8311_I2C_SCL    15     // FNK0104 codec-control SCL
+#endif
+#ifndef AMY_ES8311_I2C_ADDR
+#define AMY_ES8311_I2C_ADDR   0x18   // ES8311 with CE tied low
+#endif
+#ifndef AMY_ES8311_PA_GPIO
+#define AMY_ES8311_PA_GPIO    1      // FNK0104 power-amplifier enable
+#endif
+#ifndef AMY_ES8311_PA_ACTIVE_LOW
+#define AMY_ES8311_PA_ACTIVE_LOW 1   // FNK0104 amp enable is active-low
+#endif
+#ifndef AMY_ES8311_VOLUME
+#define AMY_ES8311_VOLUME     100    // 0-100; 100 = loudest AMY can drive it
+                                     // without clipping (see amy_es8311_init)
+#endif
 
 // Configure and power up an ES8311 for I2S playback.
 //   i2c_port       : I2C_NUM_0 / I2C_NUM_1
@@ -39,11 +66,14 @@
 //                    sample_rate * amy_config.i2s_mclk_mult (256 by default).
 //                    Must match what I2S actually generates or the codec's
 //                    dividers are programmed for a clock it isn't getting.
-//   volume         : startup DAC volume, 0-100, where 100 is unity (0 dB) and
-//                    each step down attenuates ~0.5 dB (0 is ~ -95 dB, silence).
-//                    The codec can apply digital gain above unity, but AMY's
-//                    output already reaches full scale, so we don't offer it:
-//                    it would just clip inside the DAC.
+//   volume         : startup DAC volume, 0-100.  100 is as loud as AMY can drive
+//                    the codec without clipping: AMY's output stage keeps
+//                    ~6 dB of headroom on this platform (see
+//                    AMY_OUTPUT_HEADROOM_BITS in amy.h), and 100 gives exactly
+//                    that back as codec digital gain, so peaks land at full
+//                    scale and never above it.  Below 100 the scale is linear in
+//                    dB at ~0.5 dB per step, down to ~ -95 dB (silence) at 0 --
+//                    so 50 is very quiet indeed, not "half volume".
 // The ESP-side I2S channel must already be enabled (so MCLK/BCLK are running)
 // before this is called.  Returns AMY_OK on success, -1 on failure.
 // Note that the driver takes exclusive ownership of i2c_port for the duration of
@@ -52,6 +82,12 @@
 amy_err_t amy_es8311_init(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr,
                           int8_t pa_enable_gpio, uint8_t pa_active_low,
                           uint32_t sample_rate, uint32_t mclk_hz, uint8_t volume);
+
+// True if the driver's clock-coefficient table has a row for this (MCLK,
+// sample-rate) pair -- i.e. amy_es8311_init() with these values can succeed.
+// The table is the single source of truth; i2s.c uses this to pick an MCLK
+// multiple the codec can actually take.
+int amy_es8311_supports_mclk(uint32_t mclk_hz, uint32_t sample_rate);
 
 // Mute the DAC and switch the power amplifier back off, using the pins/address
 // the last successful amy_es8311_init() was given.  Call this *before* stopping

--- a/src/es8311.h
+++ b/src/es8311.h
@@ -1,0 +1,45 @@
+// es8311.h
+// Minimal ES8311 mono audio-codec driver for AMY on ESP32 (Arduino / ESP-IDF).
+//
+// The ES8311 is an I2S audio codec that must be configured over I2C before it
+// will pass any audio.  It's found on, e.g., the Freenove FNK0104 ESP32-S3
+// display boards, which pair it with a Class-D power amplifier driving a small
+// speaker.  AMY drives the codec as an I2S *master* (the ES8311 is the I2S
+// slave) and feeds it MCLK from the ESP's I2S MCLK pin.  Only the playback
+// (DAC) path is implemented here.
+//
+// To use it, build AMY with -DAMY_CODEC_ES8311 and set the I2S pins in your
+// amy_config before amy_start().  On the FNK0104 that is:
+//     amy_config.i2s_mclk = 4;
+//     amy_config.i2s_bclk = 5;
+//     amy_config.i2s_lrc  = 7;   // WS
+//     amy_config.i2s_dout = 8;
+// The I2C control pins, codec address, power-amp enable GPIO and startup volume
+// default to the FNK0104 and can be overridden with -D defines (see i2s.c).
+
+#ifndef AMY_ES8311_H
+#define AMY_ES8311_H
+
+#ifdef ESP_PLATFORM
+
+#include <stdint.h>
+#include "amy.h"   // amy_err_t, AMY_OK
+
+// Configure and power up an ES8311 for I2S playback.
+//   i2c_port       : I2C_NUM_0 / I2C_NUM_1
+//   sda, scl       : I2C GPIOs wired to the codec's control port
+//   i2c_addr       : 7-bit codec address (0x18 with CE low, 0x19 with CE high)
+//   pa_enable_gpio : GPIO that enables the on-board power amplifier (-1 if none)
+//   pa_active_low  : 1 if the amp-enable pin is active-low (driven LOW to turn the
+//                    amp ON, e.g. the Freenove FNK0104), 0 if active-high
+//   sample_rate    : audio sample rate in Hz (normally AMY_SAMPLE_RATE)
+//   mclk_hz        : MCLK frequency AMY feeds the codec (sample_rate * mclk mult)
+//   volume         : startup DAC volume, 0-100
+// The ESP-side I2S channel must already be enabled (so MCLK/BCLK are running)
+// before this is called.  Returns AMY_OK on success, -1 on failure.
+amy_err_t amy_es8311_init(int i2c_port, int8_t sda, int8_t scl, uint8_t i2c_addr,
+                          int8_t pa_enable_gpio, uint8_t pa_active_low,
+                          uint32_t sample_rate, uint32_t mclk_hz, uint8_t volume);
+
+#endif // ESP_PLATFORM
+#endif // AMY_ES8311_H

--- a/src/i2s.c
+++ b/src/i2s.c
@@ -57,8 +57,11 @@
 //        - call amy_fill_buffer
 
 #include "driver/i2s_std.h"
-#ifdef AMYBOARD_ARDUINO
+#if defined(AMYBOARD_ARDUINO) || defined(AMY_CODEC_ES8311)
 #include "driver/i2c_master.h"
+#endif
+#ifdef AMY_CODEC_ES8311
+#include "es8311.h"
 #endif
 i2s_chan_handle_t tx_handle;
 i2s_chan_handle_t rx_handle;
@@ -118,6 +121,38 @@ amy_err_t esp32_setup_i2s(void) {
     /* Before writing data, start the TX channel first */
     i2s_channel_enable(tx_handle);
     if(AMY_HAS_AUDIO_IN) i2s_channel_enable(rx_handle);
+
+#ifdef AMY_CODEC_ES8311
+    // Configure an ES8311 codec (e.g. the Freenove FNK0104 ESP32-S3 boards) over
+    // I2C now that MCLK/BCLK/WS are running.  Pins/address/amp-enable default to
+    // the FNK0104 and can be overridden with -D build defines.  The default ESP
+    // I2S clock config above produces MCLK = 256 * sample rate.
+    #ifndef AMY_ES8311_I2C_PORT
+    #define AMY_ES8311_I2C_PORT   I2C_NUM_0
+    #endif
+    #ifndef AMY_ES8311_I2C_SDA
+    #define AMY_ES8311_I2C_SDA    16     // FNK0104 codec-control SDA
+    #endif
+    #ifndef AMY_ES8311_I2C_SCL
+    #define AMY_ES8311_I2C_SCL    15     // FNK0104 codec-control SCL
+    #endif
+    #ifndef AMY_ES8311_I2C_ADDR
+    #define AMY_ES8311_I2C_ADDR   0x18   // ES8311 with CE tied low
+    #endif
+    #ifndef AMY_ES8311_PA_GPIO
+    #define AMY_ES8311_PA_GPIO    1      // FNK0104 power-amplifier enable
+    #endif
+    #ifndef AMY_ES8311_PA_ACTIVE_LOW
+    #define AMY_ES8311_PA_ACTIVE_LOW 1   // FNK0104 amp enable is active-low
+    #endif
+    #ifndef AMY_ES8311_VOLUME
+    #define AMY_ES8311_VOLUME     80     // startup DAC volume, 0-100
+    #endif
+    amy_es8311_init(AMY_ES8311_I2C_PORT, AMY_ES8311_I2C_SDA, AMY_ES8311_I2C_SCL,
+                    AMY_ES8311_I2C_ADDR, AMY_ES8311_PA_GPIO, AMY_ES8311_PA_ACTIVE_LOW,
+                    AMY_SAMPLE_RATE, (uint32_t)AMY_SAMPLE_RATE * 256, AMY_ES8311_VOLUME);
+#endif // AMY_CODEC_ES8311
+
     return AMY_OK;
 }
 

--- a/src/i2s.c
+++ b/src/i2s.c
@@ -151,6 +151,19 @@ amy_err_t esp32_setup_i2s(void) {
             mclk_mult = 256;
             break;
     }
+#ifdef AMY_USE_ES8311
+    // The ESP can generate multiples the ES8311's clock-coefficient table has no
+    // row for; accepting one here would just make codec bring-up fail later.
+    if (!amy_es8311_supports_mclk((uint32_t)AMY_SAMPLE_RATE * mclk_mult, AMY_SAMPLE_RATE)) {
+        fprintf(stderr, "i2s: ES8311 does not support %ux MCLK at %uHz, using 256\n",
+                (unsigned)mclk_mult, (unsigned)AMY_SAMPLE_RATE);
+        mclk_mult = 256;
+    }
+#endif
+    // Keep the config describing the hardware: anything reading i2s_mclk_mult
+    // after amy_start() (to program another MCLK consumer, say) must see the
+    // multiple I2S actually generates, not the value we overrode.
+    amy_global.config.i2s_mclk_mult = mclk_mult;
 
     i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_AUTO, I2S_ROLE_MASTER);
     if(AMY_HAS_AUDIO_IN) {
@@ -211,28 +224,7 @@ amy_err_t esp32_setup_i2s(void) {
 #ifdef AMY_USE_ES8311
     // Configure an ES8311 codec (e.g. the Freenove FNK0104 ESP32-S3 boards) over
     // I2C now that MCLK/BCLK/WS are running.  Pins/address/amp-enable default to
-    // the FNK0104 and can be overridden with -D build defines.
-    #ifndef AMY_ES8311_I2C_PORT
-    #define AMY_ES8311_I2C_PORT   I2C_NUM_0
-    #endif
-    #ifndef AMY_ES8311_I2C_SDA
-    #define AMY_ES8311_I2C_SDA    16     // FNK0104 codec-control SDA
-    #endif
-    #ifndef AMY_ES8311_I2C_SCL
-    #define AMY_ES8311_I2C_SCL    15     // FNK0104 codec-control SCL
-    #endif
-    #ifndef AMY_ES8311_I2C_ADDR
-    #define AMY_ES8311_I2C_ADDR   0x18   // ES8311 with CE tied low
-    #endif
-    #ifndef AMY_ES8311_PA_GPIO
-    #define AMY_ES8311_PA_GPIO    1      // FNK0104 power-amplifier enable
-    #endif
-    #ifndef AMY_ES8311_PA_ACTIVE_LOW
-    #define AMY_ES8311_PA_ACTIVE_LOW 1   // FNK0104 amp enable is active-low
-    #endif
-    #ifndef AMY_ES8311_VOLUME
-    #define AMY_ES8311_VOLUME     100    // startup DAC volume, 0-100 (100 = 0 dB)
-    #endif
+    // the FNK0104 and can be overridden with -D build defines (see es8311.h).
     // amy_start() ignores this function's result, so a codec that didn't come up
     // would otherwise be a silent board with nothing said anywhere: complain
     // here, leave the verdict in amy_es8311_status() for the sketch to report,

--- a/src/i2s.c
+++ b/src/i2s.c
@@ -57,19 +57,101 @@
 //        - call amy_fill_buffer
 
 #include "driver/i2s_std.h"
-#if defined(AMYBOARD_ARDUINO) || defined(AMY_CODEC_ES8311)
-#include "driver/i2c_master.h"
-#endif
-#ifdef AMY_CODEC_ES8311
-#include "es8311.h"
+#include "amy_i2c.h"
+#if defined(AMY_CODEC_ES8311)
+  #if defined(AMYBOARD) || defined(AMYBOARD_ARDUINO)
+    // AMYboard has its own codecs and its own setup_i2s below, which never looks
+    // at an ES8311.  Silently compiling the driver in and never calling it just
+    // leaves the user with a silent board and no clue, so say so at build time.
+    #warning "AMY_CODEC_ES8311 has no effect on AMYboard builds -- AMYboard drives its own codecs"
+  #else
+    #define AMY_USE_ES8311 1
+    #include "es8311.h"
+  #endif
 #endif
 i2s_chan_handle_t tx_handle;
 i2s_chan_handle_t rx_handle;
+
+///////////////////////////////////////////////////////////////
+// Shared codec-control I2C (see amy_i2c.h)
+
+#define AMY_I2C_TIMEOUT_MS 100
+
+esp_err_t amy_i2c_open_device(amy_i2c_dev_t *d, int i2c_port, int8_t sda, int8_t scl,
+                              uint8_t addr, uint32_t scl_speed_hz) {
+    d->bus = NULL;
+    d->dev = NULL;
+    i2c_master_bus_config_t bus_conf = {
+        .i2c_port = i2c_port,
+        .sda_io_num = sda,
+        .scl_io_num = scl,
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .glitch_ignore_cnt = 7,
+        .flags.enable_internal_pullup = true,
+    };
+    esp_err_t ret = i2c_new_master_bus(&bus_conf, &d->bus);
+    if (ret != ESP_OK) {
+        d->bus = NULL;
+        return ret;
+    }
+    i2c_device_config_t dev_conf = {
+        .dev_addr_length = I2C_ADDR_BIT_LEN_7,
+        .device_address = addr,
+        .scl_speed_hz = scl_speed_hz,
+    };
+    ret = i2c_master_bus_add_device(d->bus, &dev_conf, &d->dev);
+    if (ret != ESP_OK) {
+        d->dev = NULL;
+        i2c_del_master_bus(d->bus);
+        d->bus = NULL;
+    }
+    return ret;
+}
+
+void amy_i2c_close_device(amy_i2c_dev_t *d) {
+    esp_err_t ret;
+    if (d->dev != NULL) {
+        ret = i2c_master_bus_rm_device(d->dev);
+        if (ret != ESP_OK) fprintf(stderr, "i2c: device cleanup failed: %s\n", esp_err_to_name(ret));
+        d->dev = NULL;
+    }
+    if (d->bus != NULL) {
+        ret = i2c_del_master_bus(d->bus);
+        if (ret != ESP_OK) fprintf(stderr, "i2c: bus cleanup failed: %s\n", esp_err_to_name(ret));
+        d->bus = NULL;
+    }
+}
+
+esp_err_t amy_i2c_write_reg(const amy_i2c_dev_t *d, uint8_t reg, uint8_t val) {
+    if (d == NULL || d->dev == NULL) return ESP_ERR_INVALID_STATE;
+    uint8_t buf[2] = { reg, val };
+    return i2c_master_transmit(d->dev, buf, 2, AMY_I2C_TIMEOUT_MS);
+}
+
+esp_err_t amy_i2c_read_reg(const amy_i2c_dev_t *d, uint8_t reg, uint8_t *val) {
+    if (d == NULL || d->dev == NULL) return ESP_ERR_INVALID_STATE;
+    *val = 0;
+    return i2c_master_transmit_receive(d->dev, &reg, 1, val, 1, AMY_I2C_TIMEOUT_MS);
+}
 
 
 #if !defined(AMYBOARD) && !defined(AMYBOARD_ARDUINO)
 // default ESP setup i2s
 amy_err_t esp32_setup_i2s(void) {
+    // MCLK = i2s_mclk_mult * Fs.  Codecs that take an MCLK (e.g. the ES8311
+    // below) have to be programmed for the same number, so derive both from this
+    // one place.  The ESP I2S peripheral only accepts a few multiples; anything
+    // else would fail inside i2s_channel_init_std_mode() and leave us silent.
+    uint32_t mclk_mult = amy_global.config.i2s_mclk_mult;
+    switch (mclk_mult) {
+        case 128: case 256: case 384: case 512: break;
+        default:
+            fprintf(stderr, "i2s: unsupported i2s_mclk_mult %u (want 128/256/384/512), using 256\n",
+                    (unsigned)mclk_mult);
+            mclk_mult = 256;
+            break;
+    }
+
     i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_AUTO, I2S_ROLE_MASTER);
     if(AMY_HAS_AUDIO_IN) {
         i2s_new_channel(&chan_cfg, &tx_handle, &rx_handle);
@@ -114,6 +196,10 @@ amy_err_t esp32_setup_i2s(void) {
         },
     };
 #endif
+    // I2S_STD_CLK_DEFAULT_CONFIG hardcodes 256; honour amy_config.i2s_mclk_mult
+    // (as pico_support.cpp does) so the config field means something on ESP too.
+    std_cfg.clk_cfg.mclk_multiple = (i2s_mclk_multiple_t)mclk_mult;
+
     /* Initialize the channel */
     i2s_channel_init_std_mode(tx_handle, &std_cfg);
     if(AMY_HAS_AUDIO_IN) i2s_channel_init_std_mode(rx_handle, &std_cfg);
@@ -122,11 +208,10 @@ amy_err_t esp32_setup_i2s(void) {
     i2s_channel_enable(tx_handle);
     if(AMY_HAS_AUDIO_IN) i2s_channel_enable(rx_handle);
 
-#ifdef AMY_CODEC_ES8311
+#ifdef AMY_USE_ES8311
     // Configure an ES8311 codec (e.g. the Freenove FNK0104 ESP32-S3 boards) over
     // I2C now that MCLK/BCLK/WS are running.  Pins/address/amp-enable default to
-    // the FNK0104 and can be overridden with -D build defines.  The default ESP
-    // I2S clock config above produces MCLK = 256 * sample rate.
+    // the FNK0104 and can be overridden with -D build defines.
     #ifndef AMY_ES8311_I2C_PORT
     #define AMY_ES8311_I2C_PORT   I2C_NUM_0
     #endif
@@ -146,12 +231,21 @@ amy_err_t esp32_setup_i2s(void) {
     #define AMY_ES8311_PA_ACTIVE_LOW 1   // FNK0104 amp enable is active-low
     #endif
     #ifndef AMY_ES8311_VOLUME
-    #define AMY_ES8311_VOLUME     80     // startup DAC volume, 0-100
+    #define AMY_ES8311_VOLUME     100    // startup DAC volume, 0-100 (100 = 0 dB)
     #endif
-    amy_es8311_init(AMY_ES8311_I2C_PORT, AMY_ES8311_I2C_SDA, AMY_ES8311_I2C_SCL,
-                    AMY_ES8311_I2C_ADDR, AMY_ES8311_PA_GPIO, AMY_ES8311_PA_ACTIVE_LOW,
-                    AMY_SAMPLE_RATE, (uint32_t)AMY_SAMPLE_RATE * 256, AMY_ES8311_VOLUME);
-#endif // AMY_CODEC_ES8311
+    // amy_start() ignores this function's result, so a codec that didn't come up
+    // would otherwise be a silent board with nothing said anywhere: complain
+    // here, leave the verdict in amy_es8311_status() for the sketch to report,
+    // and hand the error back for callers that do check it.
+    amy_err_t codec_err = amy_es8311_init(
+        AMY_ES8311_I2C_PORT, AMY_ES8311_I2C_SDA, AMY_ES8311_I2C_SCL,
+        AMY_ES8311_I2C_ADDR, AMY_ES8311_PA_GPIO, AMY_ES8311_PA_ACTIVE_LOW,
+        AMY_SAMPLE_RATE, (uint32_t)AMY_SAMPLE_RATE * mclk_mult, AMY_ES8311_VOLUME);
+    if (codec_err != AMY_OK) {
+        fprintf(stderr, "AMY: ES8311 codec init failed -- audio output will be silent\n");
+        return codec_err;
+    }
+#endif // AMY_USE_ES8311
 
     return AMY_OK;
 }
@@ -228,41 +322,22 @@ amy_err_t esp32_setup_i2s(void) {
             { 0x6F, 0x40 },  // MPIO_A = CLKST / MPIO_B = AUXIN2 / MPIO_C = AUXIN1
         };
 
-        i2c_master_bus_config_t bus_conf = {
-            .i2c_port = I2C_NUM_0,
-            .sda_io_num = PCM9211_I2C_SDA,
-            .scl_io_num = PCM9211_I2C_SCL,
-            .clk_source = I2C_CLK_SRC_DEFAULT,
-            .glitch_ignore_cnt = 7,
-            .flags.enable_internal_pullup = true,
-        };
-        i2c_master_bus_handle_t bus_handle = NULL;
-        i2c_master_dev_handle_t dev_handle = NULL;
-        esp_err_t ret = i2c_new_master_bus(&bus_conf, &bus_handle);
-        if (ret == ESP_OK) {
-            i2c_device_config_t dev_conf = {
-                .dev_addr_length = I2C_ADDR_BIT_LEN_7,
-                .device_address = PCM9211_I2C_ADDR,
-                .scl_speed_hz = PCM9211_I2C_FREQ,
-            };
-            ret = i2c_master_bus_add_device(bus_handle, &dev_conf, &dev_handle);
-        }
+        amy_i2c_dev_t pcm9211;
+        esp_err_t ret = amy_i2c_open_device(&pcm9211, I2C_NUM_0, PCM9211_I2C_SDA, PCM9211_I2C_SCL,
+                                           PCM9211_I2C_ADDR, PCM9211_I2C_FREQ);
         if (ret != ESP_OK) {
             fprintf(stderr, "PCM9211: I2C init failed: %s\n", esp_err_to_name(ret));
         } else {
             for (int i = 0; i < sizeof(pcm9211_regs) / sizeof(pcm9211_regs[0]); i++) {
-                uint8_t buf[2] = { pcm9211_regs[i][0], pcm9211_regs[i][1] };
-                ret = i2c_master_transmit(dev_handle, buf, 2, 100);
+                ret = amy_i2c_write_reg(&pcm9211, pcm9211_regs[i][0], pcm9211_regs[i][1]);
                 if (ret != ESP_OK) {
                     fprintf(stderr, "PCM9211: reg 0x%02x write 0x%02x failed: %s\n",
-                        buf[0], buf[1], esp_err_to_name(ret));
+                        pcm9211_regs[i][0], pcm9211_regs[i][1], esp_err_to_name(ret));
                 }
             }
+            // Tear down the I2C driver so Arduino Wire can use bus 0 later
+            amy_i2c_close_device(&pcm9211);
         }
-
-        // Tear down the I2C driver so Arduino Wire can use bus 0 later
-        if (dev_handle) i2c_master_bus_rm_device(dev_handle);
-        if (bus_handle) i2c_del_master_bus(bus_handle);
     }
 #endif // AMYBOARD_ARDUINO
 
@@ -272,6 +347,11 @@ amy_err_t esp32_setup_i2s(void) {
 #endif
 
 amy_err_t esp32_teardown_i2s(void) {
+#ifdef AMY_USE_ES8311
+    // Mute the codec and drop its power amplifier before the clocks stop below:
+    // taking MCLK/BCLK/WS away from a live amp pops (or DC-thumps) the speaker.
+    amy_es8311_deinit();
+#endif
     i2s_channel_disable(tx_handle);
     if(AMY_HAS_AUDIO_IN) i2s_channel_disable(rx_handle);
     i2s_del_channel(tx_handle);


### PR DESCRIPTION
Hi, 

As discussed on Discord. This is very Claude coded, but it has been quite extensively tested on a FNK0104 board. 

I haven't done C in 20 years so my reviewing is limited. 

There's a new `amy_i2c_open_device` function which is shared rather than copying code. I thought it looked ok. That's the only major modification to the core Amy code. 