### PR TITLE
esp32: only poll the MIDI UART when MIDI-over-UART is configured

### DIFF
--- a/src/i2s.c
+++ b/src/i2s.c
@@ -432,7 +432,11 @@ extern void esp_poll_midi(void);
 void amy_update_tasks() {
     if (!amy_global.config.platform.multithread) {
         amy_execute_deltas();
-        esp_poll_midi();
+        // Only poll the UART if MIDI-over-UART is actually configured -- run_midi()
+        // only calls esp_init_midi() under the same condition, so without this the
+        // uart_read_bytes() below hits an uninstalled driver once per audio block
+        // and logs an error every time (~187/sec at 48kHz).
+        if (amy_global.config.midi & AMY_MIDI_IS_UART) esp_poll_midi();
     } else{
         // Rendering is happening on separate thread, nothing to do.
     }


### PR DESCRIPTION
## The bug

The ESP32 `amy_update_tasks()` in `src/i2s.c` calls `esp_poll_midi()` unconditionally on the single-threaded path:

```c
if (!amy_global.config.platform.multithread) {
    amy_execute_deltas();
    esp_poll_midi();          // not gated on config.midi
}
```

`run_midi()` in `src/amy_midi.c` only calls `esp_init_midi()` when `config.midi & AMY_MIDI_IS_UART`. So with `platform.multithread = 0` and `midi` left at the default `AMY_MIDI_IS_NONE`, no UART driver is ever installed, and `uart_read_bytes()` runs against it once per audio block, logging

```
E uart: uart_read_bytes(1670): uart driver error
```

at the block rate for the life of the program. `amy_update_tasks()` is reached from `amy_update()` — exactly what a single-threaded sketch calls every pass of `loop()`.

There is already a comment at the `xTaskCreatePinnedToCore` call in `run_midi()` noting that "otherwise esp_poll_midi is called from amy_update_tasks()", so the coupling is intended — it's just missing the condition on the other side.

## The fix

Gate the call on the same condition `run_midi()` uses to decide whether the driver exists.

The other two platform implementations of `amy_update_tasks()` in this same file already do this: the RP2040 one gates `on_pico_uart_rx()` on `AMY_MIDI_IS_UART`, and the Teensy one gates its whole MIDI block the same way. The ESP32 version was the outlier, so this restores an invariant the file already holds elsewhere rather than adding a new rule.

## Who it affects

Only ESP32 **and** `multithread = 0` **and** MIDI not configured for UART. The default is `multithread = 1`, which takes the other branch entirely — presumably why this has gone unnoticed. When MIDI is configured for UART the call was always legitimate and is unchanged.

## Observed

Freenove FNK0104 (ESP32-S3, 48 kHz) running a single-threaded sketch: **2499 error lines in a 15-second capture**, ~166/sec. Not fatal, but it is formatted logging on the audio path, and over USB CDC it buried the sketch's own serial output — which is how it turned up.

## Testing

Verified on hardware that the spam stops, with the codec and audio otherwise unaffected. I did **not** test an ESP32 `multithread = 0` build with MIDI-over-UART *enabled* — my board had MIDI off, so I exercised the newly-guarded path rather than the still-polling one. That configuration should be unaffected by construction (same condition that installs the driver), but flagging it as reasoned rather than measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)