### PR TITLE
Compile out diagnostic prints unless AMY_PRINT is defined; keep for CPython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,9 @@ for i in range(len(sources)):
 os.environ["CC"] = "gcc"
 os.environ["CXX"] = "g++"
 
-comp_args = ["-I/opt/homebrew/include", "-DAMY_DEBUG", "-Wno-unused-but-set-variable", "-Wno-unreachable-code", "-DAMY_WAVETABLE"]
+# AMY_PRINT: diagnostic prints are compiled out of AMY by default (they cost
+# render time and flash on microcontrollers); the CPython build keeps them.
+comp_args = ["-I/opt/homebrew/include", "-DAMY_DEBUG", "-DAMY_PRINT", "-Wno-unused-but-set-variable", "-Wno-unreachable-code", "-DAMY_WAVETABLE"]
 link_args = ["-L/opt/homebrew/lib","-lpthread"]
 
 # Bake the Gamma9001 drum banks (kits at patches 384-390) into the module, like

--- a/src/algorithms.c
+++ b/src/algorithms.c
@@ -132,7 +132,7 @@ static inline void copy(SAMPLE* a, SAMPLE* b) {
 SAMPLE render_mod(SAMPLE *in, SAMPLE* out, uint16_t osc, SAMPLE feedback_level, uint16_t algo_osc, SAMPLE amp) {
 
     hold_and_modify(osc);
-    //printf("render_mod: osc %d msynth.amp %f\n", osc, msynth[osc]->amp);
+    //amy_printf("render_mod: osc %d msynth.amp %f\n", osc, msynth[osc]->amp);
 
     // out = buf
     // in = mod
@@ -255,7 +255,7 @@ SAMPLE render_algo(SAMPLE* buf, uint16_t osc, uint8_t core) {
             copy(out_buf, BUS_ONE);
         }
     }
-    //fprintf(stderr, "render_algo: time %.3f osc %d last_amp %f amp %f max_val=%f\n", amy_global.time, osc, (msynth[osc]->last_amp), (msynth[osc]->amp), S2F(max_value));
+    //amy_printf("render_algo: time %.3f osc %d last_amp %f amp %f max_val=%f\n", amy_global.time, osc, (msynth[osc]->last_amp), (msynth[osc]->amp), S2F(max_value));
     // TODO, i need to figure out what happens on note offs for algo_sources.. they should still render..
     return max_value;
 }

--- a/src/amy.c
+++ b/src/amy.c
@@ -197,7 +197,7 @@ output_sample_type * output_block;
     result = malloc(size);
   #endif
     //if (size > 400000) abort();
-    //fprintf(stderr, "malloc(%ld) @0x%lx\n", size, result);
+    //amy_printf("malloc(%ld) @0x%lx\n", size, result);
     return result;
   }
 
@@ -225,10 +225,14 @@ output_sample_type * output_block;
 // Poll amy_get_oom_count() for ongoing failures.
 void amy_oom(const char *fmt, ...) {
     if (++amy_global.oom_count == 1) {
+#ifdef AMY_PRINT
         va_list ap;
         va_start(ap, fmt);
         vfprintf(stderr, fmt, ap);
         va_end(ap);
+#else
+        (void)fmt;  // count the OOM either way; only the report is gated
+#endif
     }
 #ifdef AMY_DEBUG
     abort();
@@ -260,7 +264,7 @@ bool alloc_echo_delay_lines(uint8_t bus, uint32_t max_delay_samples) {
         }
     }
     if (!success) {
-        fprintf(stderr, "unable to alloc echo of %d samples\n", (int)max_delay_samples);
+        amy_printf("unable to alloc echo of %d samples\n", (int)max_delay_samples);
         dealloc_echo_delay_lines(bus);
         return false;
     }
@@ -284,13 +288,13 @@ void config_echo(uint8_t bus, float level, float delay_ms, float max_delay_ms, f
     uint32_t max_delay_samples = enclosing_power_of_2((uint32_t)(max_delay_ms / 1000.f * AMY_SAMPLE_RATE));
     // Remember this value for max_delay_samples even if we don't allocate on this call, so a later UNSET call will pick it up.
     amy_global.bus[bus]->echo.max_delay_samples = max_delay_samples;
-    //fprintf(stderr, "config_echo: bus %d delay=%.3f ms / %d samps max_delay=%.3f ms / %d samps echo.max_delay_samples=%d\n", bus, delay_ms, delay_samples, max_delay_ms, max_delay_samples, amy_global.bus[bus]->echo.max_delay_samples);
+    //amy_printf("config_echo: bus %d delay=%.3f ms / %d samps max_delay=%.3f ms / %d samps echo.max_delay_samples=%d\n", bus, delay_ms, delay_samples, max_delay_ms, max_delay_samples, amy_global.bus[bus]->echo.max_delay_samples);
 
     if (level > 0) {
         if (amy_global.bus[bus]->echo.echo_delay_lines[0] == NULL) {
             // Delay line len must be power of 2.
             if (!alloc_echo_delay_lines(bus, max_delay_samples)) return;
-            //fprintf(stderr, "config_echo: max_delay_samples=%d\n", max_delay_samples);
+            //amy_printf("config_echo: max_delay_samples=%d\n", max_delay_samples);
         }
         // Apply delay.  We have to stay 1 sample less than delay line length for FIR EQ delay.
         if (delay_samples > amy_global.bus[bus]->echo.max_delay_samples - 1) delay_samples = amy_global.bus[bus]->echo.max_delay_samples - 1;
@@ -306,7 +310,7 @@ void config_echo(uint8_t bus, float level, float delay_ms, float max_delay_ms, f
     // FIR filter potentially has gain > 1 for high frequencies, so discount the loop feedback to stop things exploding.
     if (filter_coef < 0)  feedback /= 1.f - filter_coef;
     amy_global.bus[bus]->echo.feedback = F2S(feedback);
-    //fprintf(stderr, "config_echo: delay_samples=%d level=%.3f feedback=%.3f filter_coef=%.3f fc0=%.3f\n", delay_samples, level, feedback, filter_coef, S2F(echo.filter_coef));
+    //amy_printf("config_echo: delay_samples=%d level=%.3f feedback=%.3f filter_coef=%.3f fc0=%.3f\n", delay_samples, level, feedback, filter_coef, S2F(echo.filter_coef));
 }
 
 void dealloc_chorus_delay_lines(uint8_t bus) {
@@ -341,7 +345,7 @@ void config_chorus(uint8_t bus, float level, uint16_t max_delay, float lfo_freq,
     if (AMY_IS_UNSET(max_delay)) max_delay = amy_global.bus[bus]->chorus.max_delay;
     if (AMY_IS_UNSET(lfo_freq)) lfo_freq = amy_global.bus[bus]->chorus.lfo_freq;
     if (AMY_IS_UNSET(depth)) depth = amy_global.bus[bus]->chorus.depth;
-    //fprintf(stderr, "config_chorus: osc %d level %.3f max_del %d lfo_freq %.3f depth %.3f\n",
+    //amy_printf("config_chorus: osc %d level %.3f max_del %d lfo_freq %.3f depth %.3f\n",
     //        CHORUS_MOD_SOURCE + bus, level, max_delay, lfo_freq, depth);
     if (level > 0) {
         // only allocate delay lines if chorus is more than inaudible.
@@ -404,7 +408,7 @@ void config_reverb(uint8_t bus, float level, float liveness, float damping, floa
     if (AMY_IS_UNSET(damping)) damping = amy_global.bus[bus]->reverb.damping;
     if (AMY_IS_UNSET(xover_hz)) xover_hz = amy_global.bus[bus]->reverb.xover_hz;
     if (level > 0) {
-        //printf("config_reverb: level %f liveness %f xover %f damping %f\n",
+        //amy_printf("config_reverb: level %f liveness %f xover %f damping %f\n",
         //      level, liveness, xover_hz, damping);
         if (amy_global.bus[bus]->reverb.level == 0) {
             if (!alloc_reverb_delay_lines(bus)) {
@@ -422,13 +426,13 @@ void config_reverb(uint8_t bus, float level, float liveness, float damping, floa
 
 
 int8_t check_init(amy_err_t (*fn)(), const char *name) {
-    //fprintf(stderr,"starting %s: ", name);
+    //amy_printf("starting %s: ", name);
     const amy_err_t ret = (*fn)();
     if(ret != AMY_OK) {
-        fprintf(stderr,"[error:%i]\n", ret);
+        amy_printf("[error:%i]\n", ret);
         return -1;
     }
-    //fprintf(stderr,"[ok]\n");
+    //amy_printf("[ok]\n");
     return 0;
 }
 
@@ -447,7 +451,7 @@ int peek_stack(const char *tag) {
         stack_baseline = get_sp();
     }
     int stack_depth = (int)(stack_baseline - get_sp());
-    fprintf(stderr, "stack: '%s': %d\n", tag, stack_depth);
+    amy_printf("stack: '%s': %d\n", tag, stack_depth);
     return stack_depth;
 }
 
@@ -645,7 +649,7 @@ float map_01_to_60dBf(float log) {
 
 // Add a API facing event, convert into delta directly
 void amy_event_to_deltas_queue(amy_event *e, uint16_t base_osc, struct delta **queue) {
-    // fprintf(stderr, "time %.3f amy_event_to_deltas: base_osc %d\n", amy_global.time, base_osc);
+    // amy_printf("time %.3f amy_event_to_deltas: base_osc %d\n", amy_global.time, base_osc);
     // fprintf_event_stderr(e);
     AMY_PROFILE_START(AMY_ADD_DELTA)
     struct delta d;
@@ -706,10 +710,10 @@ void amy_event_to_deltas_queue(amy_event *e, uint16_t base_osc, struct delta **q
     // If so, add the event to the stored patch queue, not the execution queue.
     if (AMY_IS_SET(e->patch_number)) {
         queue = queue_for_patch_number(e->patch_number);
-        //fprintf(stderr, "event added to patch %d: osc %d wave %d...\n", e->patch_number, e->osc, e->wave);
+        //amy_printf("event added to patch %d: osc %d wave %d...\n", e->patch_number, e->osc, e->wave);
         if (queue == NULL) {
             // The patch number was invalid (e.g., not in user range 1024+), so we got no queue, so ignore the event.
-            fprintf(stderr, "event ignored\n");
+            amy_printf("event ignored\n");
             goto end;
         }            
     }
@@ -990,12 +994,12 @@ void alloc_osc(int osc, uint8_t *max_num_breakpoints) {
         breakpoint_area += sizeof(float) * max_num_breakpoints[i];
     }
     reset_osc(osc);
-    //fprintf(stderr, "alloc_osc %d (0x%lx) num_breakpoints %d,%d\n", osc, (long)synth[osc], synth[osc]->max_num_breakpoints[0], synth[osc]->max_num_breakpoints[1]);
+    //amy_printf("alloc_osc %d (0x%lx) num_breakpoints %d,%d\n", osc, (long)synth[osc], synth[osc]->max_num_breakpoints[0], synth[osc]->max_num_breakpoints[1]);
 }
 
 void free_osc(int osc) {
     if (synth[osc] != NULL) {
-        //fprintf(stderr, "free_osc %d (0x%lx)\n", osc, (long)synth[osc]);
+        //amy_printf("free_osc %d (0x%lx)\n", osc, (long)synth[osc]);
         free(synth[osc]);
     }
     synth[osc] = NULL;
@@ -1024,7 +1028,7 @@ bool ensure_osc_allocd(int osc, uint8_t *max_num_breakpoints) {
             }
         }
         if (realloc_needed) {
-            //fprintf(stderr, "realloc for osc %d (breakpoints %d, %d -> %d, %d (wave=%d)\n", osc, synth[osc]->max_num_breakpoints[0], synth[osc]->max_num_breakpoints[1], max_num_breakpoints[0], max_num_breakpoints[1], synth[osc]->wave);
+            //amy_printf("realloc for osc %d (breakpoints %d, %d -> %d, %d (wave=%d)\n", osc, synth[osc]->max_num_breakpoints[0], synth[osc]->max_num_breakpoints[1], max_num_breakpoints[0], max_num_breakpoints[1], synth[osc]->wave);
             // Allocate the replacement before freeing the old block, so OOM
             // leaves the osc's state intact.
             struct synthinfo *old_synth = synth[osc];
@@ -1114,22 +1118,22 @@ int8_t oscs_init() {
         amy_external_in_block[i] = 0;
     }
 
-    //printf("AMY online with %d oscillators, %d block size, %d cores, %d channels, %d pcm samples\n",
+    //amy_printf("AMY online with %d oscillators, %d block size, %d cores, %d channels, %d pcm samples\n",
     //    AMY_OSCS, AMY_BLOCK_SIZE, AMY_CORES, AMY_NCHANS, pcm_samples);
     return 0;
 }
 
 void fprint_combo_coefs(char *name, float *coefs) {
-    fprintf(stderr, "  %s:", name);
+    amy_printf("  %s:", name);
     for (int i=0; i < NUM_COMBO_COEFS; ++i) {
-        fprintf(stderr, " %.3f", coefs[i]);
+        amy_printf(" %.3f", coefs[i]);
     }
-    fprintf(stderr, "\n");
+    amy_printf("\n");
 }
 
 void print_osc_debug(uint16_t i /* osc */, bool show_eg) {
-    if (synth[i] == NULL)  {fprintf(stderr, "osc %" PRIu16 " not defined\n", i); return; }
-    fprintf(stderr,"osc %" PRIu16 ": status %" PRIu8 " role %" PRIu8 " wave %" PRIu16 " mode %" PRIu16 " mod_source %" PRIu16 " velocity %f logratio %f feedback %f filtype %" PRIu8 " resonance %f portamento_alpha %f step %f chained %" PRIu16 " algo %" PRIu8 " algo_source %" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 "  \n",
+    if (synth[i] == NULL)  {amy_printf("osc %" PRIu16 " not defined\n", i); return; }
+    amy_printf("osc %" PRIu16 ": status %" PRIu8 " role %" PRIu8 " wave %" PRIu16 " mode %" PRIu16 " mod_source %" PRIu16 " velocity %f logratio %f feedback %f filtype %" PRIu8 " resonance %f portamento_alpha %f step %f chained %" PRIu16 " algo %" PRIu8 " algo_source %" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 "  \n",
             i, synth[i]->status, synth[i]->role, synth[i]->wave, synth[i]->mode, synth[i]->mod_source,
             synth[i]->velocity, synth[i]->logratio, synth[i]->feedback, synth[i]->filter_type, synth[i]->resonance, synth[i]->portamento_alpha, P2F(synth[i]->step), synth[i]->chained_osc,
             synth[i]->algorithm,
@@ -1141,13 +1145,13 @@ void print_osc_debug(uint16_t i /* osc */, bool show_eg) {
     fprint_combo_coefs("pan_coefs", synth[i]->pan_coefs);
     if(show_eg) {
         for(uint8_t j=0;j<MAX_BREAKPOINT_SETS;j++) {
-            fprintf(stderr,"  eg%" PRIu8 " (type %" PRIu8 "): ", j, synth[i]->eg_type[j]);
+            amy_printf("  eg%" PRIu8 " (type %" PRIu8 "): ", j, synth[i]->eg_type[j]);
             for(uint8_t k=0;k<synth[i]->max_num_breakpoints[j];k++) {
-                fprintf(stderr,"%" PRIi32 ": %f ", synth[i]->breakpoint_times[j][k], synth[i]->breakpoint_values[j][k]);
+                amy_printf("%" PRIi32 ": %f ", synth[i]->breakpoint_times[j][k], synth[i]->breakpoint_values[j][k]);
             }
-            fprintf(stderr,"\n");
+            amy_printf("\n");
         }
-        fprintf(stderr,"mod osc %" PRIu16 ": amp: %f, logfreq %f duty %f filter_logfreq %f resonance %f fb/bw %f pan %f state %" PRIu16 "\n", i, msynth[i]->amp, msynth[i]->logfreq, msynth[i]->duty, msynth[i]->filter_logfreq, msynth[i]->resonance, msynth[i]->feedback, msynth[i]->pan, msynth[i]->state);
+        amy_printf("mod osc %" PRIu16 ": amp: %f, logfreq %f duty %f filter_logfreq %f resonance %f fb/bw %f pan %f state %" PRIu16 "\n", i, msynth[i]->amp, msynth[i]->logfreq, msynth[i]->duty, msynth[i]->filter_logfreq, msynth[i]->resonance, msynth[i]->feedback, msynth[i]->pan, msynth[i]->state);
     }
 }
 
@@ -1165,16 +1169,16 @@ void show_debug(uint8_t type) {
         uint16_t q = amy_global.delta_qsize;
         if(q > 25) q = 25;
         for(uint16_t i=0;i<q;i++) {
-            fprintf(stderr,"%" PRIu16 " time %" PRIu32 " osc %" PRIu16 " param %d - %f %" PRIu32 "\n", i, ptr->time, ptr->osc, ptr->param, ptr->data.f, ptr->data.i);
+            amy_printf("%" PRIu16 " time %" PRIu32 " osc %" PRIu16 " param %d - %f %" PRIu32 "\n", i, ptr->time, ptr->osc, ptr->param, ptr->data.f, ptr->data.i);
             ptr = ptr->next;
         }
-        fprintf(stderr, "deltas_queue len %" PRIi32 ", free len %" PRIi32 "\n", delta_list_len(amy_global.delta_queue), delta_num_free());
+        amy_printf("deltas_queue len %" PRIi32 ", free len %" PRIi32 "\n", delta_list_len(amy_global.delta_queue), delta_num_free());
         sequencer_debug();
     }
     if(type>1) {
         // print out all the osc data
-        //printf("global: filter %f resonance %f volume %f bend %f status %d\n", amy_global.filter_freq, amy_global.resonance, amy_global.volume, amy_global.pitch_bend, amy_global.status);
-        fprintf(stderr,"global: volume %.3f %.3f %.3f %.3f bend %f bus 0 eq: %f %f %f \n", amy_global.volume[0], amy_global.volume[1], amy_global.volume[2], amy_global.volume[3], amy_global.pitch_bend, S2F(amy_global.bus[0]->eq.eq[0]), S2F(amy_global.bus[0]->eq.eq[1]), S2F(amy_global.bus[0]->eq.eq[2]));
+        //amy_printf("global: filter %f resonance %f volume %f bend %f status %d\n", amy_global.filter_freq, amy_global.resonance, amy_global.volume, amy_global.pitch_bend, amy_global.status);
+        amy_printf("global: volume %.3f %.3f %.3f %.3f bend %f bus 0 eq: %f %f %f \n", amy_global.volume[0], amy_global.volume[1], amy_global.volume[2], amy_global.volume[3], amy_global.pitch_bend, S2F(amy_global.bus[0]->eq.eq[0]), S2F(amy_global.bus[0]->eq.eq[1]), S2F(amy_global.bus[0]->eq.eq[2]));
         for(uint16_t i=0;i<10 /* AMY_OSCS */;i++) {
             print_osc_debug(i, (type > 3) /* show_eg */);
         }
@@ -1189,7 +1193,7 @@ void show_debug(uint8_t type) {
         if (type > 6) {
             for (int synth = 0; synth < 32 /* MAX_INSTRUMENTS */; ++synth) {
                 if (instrument_number_exists(synth, NULL)) {
-                    fprintf(stderr, "synth %d:\n", synth);
+                    amy_printf("synth %d:\n", synth);
                     void * state = NULL;
                     amy_event event = amy_default_event();
                     char s[MAX_MESSAGE_LEN];
@@ -1197,12 +1201,12 @@ void show_debug(uint8_t type) {
                     do {
                         state = yield_synth_events(synth, &event, include_fx, state);
                         sprint_event(&event, s, MAX_MESSAGE_LEN, false);
-                        fprintf(stderr, "%s\n", s);
+                        amy_printf("%s\n", s);
                     } while(state != NULL);
                 }
             }
         }
-        fprintf(stderr, "\n");
+        amy_printf("\n");
     }
 }
 
@@ -1243,7 +1247,7 @@ void oscs_deinit() {
 
 
 void osc_note_on(uint16_t osc, float initial_freq) {
-    //fprintf(stderr,"Note on: osc %d wav %d note %.3f vel %.3f\n",
+    //amy_printf("Note on: osc %d wav %d note %.3f vel %.3f\n",
     //        osc, synth[osc]->wave,
     //        synth[osc]->midi_note, synth[osc]->velocity);
     // take care of fm & ks first -- no special treatment for bp/mod
@@ -1284,7 +1288,7 @@ int chained_osc_would_cause_loop(uint16_t osc, uint16_t chained_osc) {
         // An osc we can't allocate can't be linked.
         if (!ensure_osc_allocd(next_osc, NULL)) return true;
         if (next_osc == osc) {
-            fprintf(stderr, "chaining osc %d to osc %d would cause loop.\n",
+            amy_printf("chaining osc %d to osc %d would cause loop.\n",
                     chained_osc, osc);
             return true;
         }
@@ -1304,7 +1308,7 @@ int mod_osc_would_cause_loop(uint16_t osc, uint16_t mod_osc) {
         // An osc we can't allocate can't be linked.
         if (!ensure_osc_allocd(next_osc, NULL)) return true;
         if (next_osc == osc) {
-            fprintf(stderr, "osc %d as mod_source for osc %d would cause loop.\n",
+            amy_printf("osc %d as mod_source for osc %d would cause loop.\n",
                     mod_osc, osc);
             return true;
         }
@@ -1330,7 +1334,7 @@ uint16_t alpha_to_portamento_ms(float alpha) {
 // play an delta, now -- tell the audio loop to start making noise
 void play_delta(struct delta *d) {
     AMY_PROFILE_START(PLAY_DELTA)
-    //fprintf(stderr,"play_delta: time %d osc %d param %d val 0x%x, qsize %d\n", amy_global.total_blocks, d->osc, d->param, d->data.i, amy_global.delta_qsize);
+    //amy_printf("play_delta: time %d osc %d param %d val 0x%x, qsize %d\n", amy_global.total_blocks, d->osc, d->param, d->data.i, amy_global.delta_qsize);
     //uint8_t trig=0;
     // todo: delta-only side effect, remove
 
@@ -1541,7 +1545,7 @@ void play_delta(struct delta *d) {
     // the only way a sound is made is if velocity (note on) is >0.
     // Ignore velocity deltas if we've already received one this frame.  This may be due to a loop in chained_oscs.
     if(d->param == VELOCITY) {
-        //fprintf(stderr, "play_delta velocity %.1f osc %d note %.1f time %d\n", d->data.f, d->osc, synth[d->osc]->midi_note, d->time);
+        //amy_printf("play_delta velocity %.1f osc %d note %.1f time %d\n", d->data.f, d->osc, synth[d->osc]->midi_note, d->time);
         if (d->data.f > 0) { // new note on (even if something is already playing on this osc)
             // Calculation common to all chained oscs.
             float note_logfreq = 0;
@@ -1551,9 +1555,9 @@ void play_delta(struct delta *d) {
             }
             // Loop through chained oscs
             uint16_t osc = d->osc;
-            //fprintf(stderr, "t %.3f: delta note_on: osc %d vel %.3f\n\r", amy_global.time, osc, d->data.f);
+            //amy_printf("t %.3f: delta note_on: osc %d vel %.3f\n\r", amy_global.time, osc, d->data.f);
             while(AMY_IS_SET(osc)) {
-                //fprintf(stderr, "osc: %d wave %d role %d\n\r", osc, synth[osc]->wave, synth[osc]->role);
+                //amy_printf("osc: %d wave %d role %d\n\r", osc, synth[osc]->wave, synth[osc]->role);
                 if (!(synth[osc]->role == SYNTH_IS_MOD_SOURCE
                       || synth[osc]->role == SYNTH_IS_ALGO_SOURCE
                       || synth[osc]->wave == PARTIAL)
@@ -1561,7 +1565,7 @@ void play_delta(struct delta *d) {
                         || synth[osc]->amp_coefs[COEF_VEL] == 0
                         || synth[osc]->amp_coefs[COEF_VEL] > AMP_THRESH)) {
                     synth[osc]->velocity = d->data.f;  // was map_60dB_to_01f
-                    //fprintf(stderr, "osc: %d status -> AUDIBLE\n\r", osc);
+                    //amy_printf("osc: %d status -> AUDIBLE\n\r", osc);
                     // Ignore velocity events for mod source or algo notes.
                     synth[osc]->status = SYNTH_AUDIBLE;
                     // ** no_amp_001
@@ -1740,7 +1744,7 @@ void hold_and_modify(uint16_t osc) {
     msynth[osc]->pan = combine_controls(ctrl_inputs, synth[osc]->pan_coefs);
     // Don't smear the pan on first frame of new note
     if (synth[osc]->note_on_clock == amy_global.total_samples) {
-        //fprintf(stderr, "time %.3f osc %d note on\n", amy_global.time, osc);
+        //amy_printf("time %.3f osc %d note on\n", amy_global.time, osc);
         // First frame for this osc since note-on, don't smooth-over the pan.
         // (showed up when panning drum sounds).
         msynth[osc]->last_pan = msynth[osc]->pan;
@@ -1768,7 +1772,7 @@ void hold_and_modify(uint16_t osc) {
     msynth[osc]->resonance = synth[osc]->resonance;
 
     if (osc == 999) {
-        fprintf(stderr, "h&m: time %f osc %d note %f vel %f eg0 %f eg1 %f ampc %.3f %.3f %.3f %.3f %.3f %.3f lfqc %.3f %.3f %.3f %.3f %.3f %.3f amp %f logfreq %f\n",
+        amy_printf("h&m: time %f osc %d note %f vel %f eg0 %f eg1 %f ampc %.3f %.3f %.3f %.3f %.3f %.3f lfqc %.3f %.3f %.3f %.3f %.3f %.3f amp %f logfreq %f\n",
                amy_global.time, osc,
                ctrl_inputs[COEF_NOTE], ctrl_inputs[COEF_VEL], ctrl_inputs[COEF_EG0], ctrl_inputs[COEF_EG1],
                synth[osc]->amp_coefs[0], synth[osc]->amp_coefs[1], synth[osc]->amp_coefs[2], synth[osc]->amp_coefs[3], synth[osc]->amp_coefs[4], synth[osc]->amp_coefs[5],
@@ -1832,7 +1836,7 @@ SAMPLE render_osc_wave(uint16_t osc, uint8_t core, SAMPLE* buf) {
     AMY_PROFILE_START(RENDER_OSC_WAVE)
     // Returns abs max of what it wrote.
         //if (osc < amy_global.config.max_oscs) // exclude chorus LFOs.
-        //fprintf(stderr, "+render_osc_wave: t=%ld core=%d buf=0x%lx (%f, %f, %f, %f...) osc=%d osc_t=%ld\n\r",
+        //amy_printf("+render_osc_wave: t=%ld core=%d buf=0x%lx (%f, %f, %f, %f...) osc=%d osc_t=%ld\n\r",
         //    amy_global.total_samples, core, buf, S2F(buf[0]), S2F(buf[1]), S2F(buf[2]), S2F(buf[3]),
         //    osc, synth[osc]->render_clock);
     SAMPLE max_val = 0;
@@ -1909,7 +1913,7 @@ SAMPLE render_osc_wave(uint16_t osc, uint8_t core, SAMPLE* buf) {
         // Stop oscillators if amp is zero for several frames in a row.
         // Note: We can't wait for the note off because we need to turn off PARTIAL oscs when envelopes end, even if no note off.
         if (OSC_IN_RELEASE(osc) && max_val < F2S(AMP_THRESH) && synth[osc]->terminate_on_silence) {
-            //printf("h&m: time %.3f osc %d OFF\n", amy_global.time, osc);
+            //amy_printf("h&m: time %.3f osc %d OFF\n", amy_global.time, osc);
             // Oscillator has fallen silent, stop executing it.
             uint16_t osc_to_stop = osc;  // Type must match synthinfo.chained_osc
             while (AMY_IS_SET(osc_to_stop)) {
@@ -1924,10 +1928,10 @@ SAMPLE render_osc_wave(uint16_t osc, uint8_t core, SAMPLE* buf) {
                 osc_to_stop = synth[osc_to_stop]->chained_osc;
             }
         }
-        //fprintf(stderr, "render_osc_wave: t=%.3f osc=%d max_val %.6f\n", amy_global.time, osc, S2F(max_val));
+        //amy_printf("render_osc_wave: t=%.3f osc=%d max_val %.6f\n", amy_global.time, osc, S2F(max_val));
     }
     AMY_PROFILE_STOP(RENDER_OSC_WAVE)
-    //fprintf(stderr, "-render_osc_wave: t=%ld core=%d buf=0x%lx (%f, %f, %f, %f...) osc=%d osc_t=%ld\n",
+    //amy_printf("-render_osc_wave: t=%ld core=%d buf=0x%lx (%f, %f, %f, %f...) osc=%d osc_t=%ld\n",
     //    amy_global.total_samples, core, buf, S2F(buf[0]), S2F(buf[1]), S2F(buf[2]), S2F(buf[3]),
     //    osc, synth[osc]->render_clock);
     return max_val;
@@ -2006,7 +2010,7 @@ AMY_IRAM_ATTR void amy_render(uint16_t start, uint16_t end, uint8_t core) {
     if (amy_global.debug_flag) {
         amy_global.debug_flag = 0;  // Only do this once each time debug_flag is set.
         SAMPLE smax = scan_max(fbl[core][0 /* bus */], AMY_BLOCK_SIZE);
-        fprintf(stderr, "time %" PRIu32 " core %d bus 0 max_max=%.3f post-eq max=%.3f\n", amy_global.total_samples, core, S2F(max_max), S2F(smax));
+        amy_printf("time %" PRIu32 " core %d bus 0 max_max=%.3f post-eq max=%.3f\n", amy_global.total_samples, core, S2F(max_max), S2F(smax));
     }
 
     AMY_PROFILE_STOP(AMY_RENDER)
@@ -2273,9 +2277,9 @@ struct delta *deltas_pool_alloc(int max_delta_pool_size, struct delta *tail) {
 }
 
 void deltas_add_pool_block(void) {
-    //fprintf(stderr, "deltas_add_pool_block %d\n", next_delta_block);
+    //amy_printf("deltas_add_pool_block %d\n", next_delta_block);
     if (next_delta_block >= MAX_DELTA_BLOCKS) {
-        fprintf(stderr, "**PANIC: Ran out of deltas (%d blocks of %d deltas)\n", MAX_DELTA_BLOCKS, DELTA_BLOCK_SIZE);
+        amy_printf("**PANIC: Ran out of deltas (%d blocks of %d deltas)\n", MAX_DELTA_BLOCKS, DELTA_BLOCK_SIZE);
         abort();
     }
     struct delta *block = deltas_pool_alloc(DELTA_BLOCK_SIZE, free_deltas_pool);

--- a/src/amy.h
+++ b/src/amy.h
@@ -29,6 +29,20 @@ static inline int __builtin_clz(unsigned int x) {
 #endif
 #include <inttypes.h>
 
+// Diagnostic prints -- warnings ("note off does not match note on"), parse
+// errors, debug dumps. On microcontrollers these blocking serial writes cost
+// render time, and their format strings cost flash, so they compile away
+// unless AMY_PRINT is defined. The CPython build (setup.py) defines it;
+// define it in your own build to get the messages back.
+#ifdef AMY_PRINT
+#define amy_printf(...) fprintf(stderr, __VA_ARGS__)
+#else
+// if (0): the arguments stay type- and format-checked and count as used
+// (no -Wunused warnings), but the call and its strings are dead code that
+// every optimizing build strips.
+#define amy_printf(...) do { if (0) fprintf(stderr, __VA_ARGS__); } while (0)
+#endif
+
 #ifndef __EMSCRIPTEN__
 #ifdef _WIN32
 #include <windows.h>

--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -107,18 +107,18 @@ void midi_clock_out_stop() {
 
 #if 0
 static void debug_print_midi_hex(const uint8_t *data, uint32_t len, uint8_t sysex) {
-    fprintf(stderr, "MIDI %s len=%u:", sysex ? "sysex" : "msg", (unsigned)len);
+    amy_printf("MIDI %s len=%u:", sysex ? "sysex" : "msg", (unsigned)len);
     for (uint32_t i = 0; i < len; ++i) {
-        fprintf(stderr, " %02X", data[i]);
+        amy_printf(" %02X", data[i]);
     }
-    fprintf(stderr, "\n");
+    amy_printf("\n");
 }
 #endif
 
 // Send a MIDI note on OUT
 void amy_send_midi_note_on(uint16_t osc) {
     // don't forward on a note coming in through MIDI IN 
-    //fprintf(stderr, "amy_send_midi_note_on: osc %d source %d note %.1f vel %.3f\n",
+    //amy_printf("amy_send_midi_note_on: osc %d source %d note %.1f vel %.3f\n",
     //        osc, synth[osc]->s_note_source_channel, synth[osc]->midi_note, synth[osc]->velocity);
     if(AMY_IS_UNSET(synth[osc]->s_note_source_channel)) {
         uint8_t bytes[3];
@@ -222,15 +222,15 @@ void midi_active_channel_set(uint8_t channel, bool state) {
 }
 
 void midi_active_channels_debug(void) {
-    fprintf(stderr, "Active MIDI channels:");
+    amy_printf("Active MIDI channels:");
     for (int channel = 1; channel < AMY_NUM_MIDI_CHANNELS + 1; ++channel) {
         if (_midi_channel_active[channel]) {
-            fprintf(stderr, " %2d", channel);
+            amy_printf(" %2d", channel);
         } else {
-            fprintf(stderr, " --");
+            amy_printf(" --");
         }
     }
-    fprintf(stderr, "\n");
+    amy_printf("\n");
 }
 
 
@@ -661,7 +661,7 @@ void on_pico_uart_rx() {
         i++;
     }
     //if (i >= midi_buffer_size)
-    //    fprintf(stderr, "midi_buffer_size %d of %d\n", i, midi_buffer_size);
+    //    amy_printf("midi_buffer_size %d of %d\n", i, midi_buffer_size);
     convert_midi_bytes_to_messages(bytes,i,0);
 }
 
@@ -725,7 +725,7 @@ void stop_midi() {
 }
 
 void run_midi() {
-    //fprintf(stderr, "no MIDI support on linux yet\n");
+    //amy_printf("no MIDI support on linux yet\n");
 }
 #endif
 
@@ -758,7 +758,7 @@ void midi_out(uint8_t * bytes, uint16_t len) {
         // tud_midi_stream_write uses a small FIFO (e.g. 64 bytes). For long
         // messages (e.g. zD sysex dumps) we must loop and yield until the
         // USB task flushes the FIFO, otherwise bytes are silently dropped.
-        if (len > 64) fprintf(stderr, "midi_out: USB gadget, want to send %d bytes\n", (int)len);
+        if (len > 64) amy_printf("midi_out: USB gadget, want to send %d bytes\n", (int)len);
         uint32_t sent = 0;
         int stall_ticks = 0;
         while (sent < len) {
@@ -774,7 +774,7 @@ void midi_out(uint8_t * bytes, uint16_t len) {
                 vTaskDelay(pdMS_TO_TICKS(1));
 #endif
                 if (++stall_ticks > 1000) {
-                    fprintf(stderr, "midi_out: STALLED after %u of %u bytes\n",
+                    amy_printf("midi_out: STALLED after %u of %u bytes\n",
                             (unsigned)sent, (unsigned)len);
                     break;
                 }
@@ -783,7 +783,7 @@ void midi_out(uint8_t * bytes, uint16_t len) {
             }
             sent += n;
         }
-        if (len > 64) fprintf(stderr, "midi_out: USB gadget sent %u/%u bytes\n",
+        if (len > 64) amy_printf("midi_out: USB gadget sent %u/%u bytes\n",
                               (unsigned)sent, (unsigned)len);
     }
 #endif

--- a/src/api.c
+++ b/src/api.c
@@ -442,7 +442,7 @@ float amy_get_render_load() {
 // CPU overload failsafe: silence and reset the synth so the host stays responsive,
 // then play a descending bleep so the user knows AMY stopped on purpose.
 void amy_overload_failsafe() {
-    fprintf(stderr, "AMY: CPU overload (render %" PRIu32 " us > %" PRIu32 " threshold), resetting synth\n", amy_global.render_us, amy_global.overload_threshold_us);
+    amy_printf("AMY: CPU overload (render %" PRIu32 " us > %" PRIu32 " threshold), resetting synth\n", amy_global.render_us, amy_global.overload_threshold_us);
     // Drop everything scheduled first -- an overloaded delta queue can hold
     // hundreds of pending events that would re-wedge us as they play out.
     amy_grab_lock();

--- a/src/cv_trigger.c
+++ b/src/cv_trigger.c
@@ -25,7 +25,7 @@ typedef struct cv_trigger {
 cv_trigger_t *cv_trigger_root = NULL;
 
 void cv_trigger_print(cv_trigger_t *cv_trig) {
-    fprintf(stderr, "cv_trigger: cv %d thresh %.2f reset %.2f pitch %d scale %.2f offs %.2f state %d msg %s\n", cv_trig->trigger_cv, cv_trig->thresh_trigger, cv_trig->thresh_reset, cv_trig->pitch_cv, cv_trig->pitch_scale, cv_trig->pitch_offset, cv_trig->state, cv_trig->message_template);
+    amy_printf("cv_trigger: cv %d thresh %.2f reset %.2f pitch %d scale %.2f offs %.2f state %d msg %s\n", cv_trig->trigger_cv, cv_trig->thresh_trigger, cv_trig->thresh_reset, cv_trig->pitch_cv, cv_trig->pitch_scale, cv_trig->pitch_offset, cv_trig->state, cv_trig->message_template);
 }
 
 void cv_trigger_new(uint8_t trigger_cv, float thresh_trigger, float thresh_reset, uint8_t pitch_cv, float pitch_scale, float pitch_offset, char *message_template) {
@@ -55,7 +55,7 @@ void cv_trigger_new(uint8_t trigger_cv, float thresh_trigger, float thresh_reset
 }
 
 void cv_trigger_debug(void) {
-    fprintf(stderr, "cv_trigger_debug:\n");
+    amy_printf("cv_trigger_debug:\n");
     cv_trigger_t *cv_trig =  cv_trigger_root;
     while(cv_trig) {
         cv_trigger_print(cv_trig);
@@ -115,7 +115,7 @@ void cv_trigger_generate_events(float *cv_inputs) {
                    }
                    char message[AMY_WIRE_COMMAND_LEN];
                    substitute_midi_special_values(message, cv_trig->message_template, 0, 0, note);
-                   //fprintf(stderr, "update_external_cv_in: message %s\n", message);
+                   //amy_printf("update_external_cv_in: message %s\n", message);
                    amy_add_message(message);
                 }
             }
@@ -123,7 +123,7 @@ void cv_trigger_generate_events(float *cv_inputs) {
             if (cv_trig->state != CV_TRIG_READY) {
                 // Reset
                 cv_trig->state = CV_TRIG_READY;
-                //fprintf(stderr, "update_external_cv_in: RESET message %s\n", cv_trig->message_template);
+                //amy_printf("update_external_cv_in: RESET message %s\n", cv_trig->message_template);
             }
         }
         cv_trig = cv_trig->next;
@@ -206,6 +206,6 @@ void set_cv_from_osc(int cv_channel, int osc) {
     osc_note_on(osc, freq_of_logfreq(synth[osc]->logfreq_coefs[COEF_CONST]));
     // Add the CV retrieval hook.
     if (amy_global.config.amy_external_coef_hook != NULL && amy_global.config.amy_external_coef_hook != cv_from_osc)
-        fprintf(stderr, "set_cv_from_osc: WARNING: overwriting existing amy_external_coef_hook\n");
+        amy_printf("set_cv_from_osc: WARNING: overwriting existing amy_external_coef_hook\n");
     amy_global.config.amy_external_coef_hook = cv_from_osc;
 }

--- a/src/delay.c
+++ b/src/delay.c
@@ -24,9 +24,9 @@ uint8_t __attribute__((section((".sdram_bss")))) qspi_heap[QSPI_HEAP_SIZE];
 uint32_t qspi_used = 0;
 
 void *qspi_malloc(size_t num_bytes) {
-    //fprintf(stderr, "qspi_malloc: %d bytes, used = %d\n", num_bytes, qspi_used);
+    //amy_printf("qspi_malloc: %d bytes, used = %d\n", num_bytes, qspi_used);
     if ((qspi_used + num_bytes) >= QSPI_HEAP_SIZE) {
-	fprintf(stderr, "qspi_malloc: out of heap\n");
+	amy_printf("qspi_malloc: out of heap\n");
 	abort();
     }
     // Save the size of this block.
@@ -42,9 +42,9 @@ void qspi_free(void *ptr) {
     if (ptr == (void *)(qspi_heap + (qspi_used - last_alloc))) {
 	// We're just freeing the last alloc, yay.
 	qspi_used -= last_alloc + sizeof(uint32_t);
-	//fprintf(stderr, "qspi_free: %ld bytes, used = %d\n", last_alloc, qspi_used);
+	//amy_printf("qspi_free: %ld bytes, used = %d\n", last_alloc, qspi_used);
     } else {
-	fprintf(stderr, "qspi_free: punt (ptr = qspi_heap + %d)\n", (uint8_t*)ptr - (uint8_t *)qspi_heap);
+	amy_printf("qspi_free: punt (ptr = qspi_heap + %d)\n", (uint8_t*)ptr - (uint8_t *)qspi_heap);
 	// Don't actually recover the memory.
     }
 }
@@ -56,15 +56,15 @@ void qspi_free(void *ptr) {
 
 delay_line_t *new_delay_line(int len, int fixed_delay, int ram_type) {
     // Check that len is a power of 2.
-    //printf("new_delay_line: len %d fixed_del %d\n", len, fixed_delay);
+    //amy_printf("new_delay_line: len %d fixed_del %d\n", len, fixed_delay);
     int log_2_len = is_power_of_two(len);
     if (log_2_len < 0) {
-        fprintf(stderr, "delay line len must be power of 2, not %d\n", len);
+        amy_printf("delay line len must be power of 2, not %d\n", len);
         abort();
     }
     delay_line_t *delay_line = (delay_line_t*)malloc_caps(sizeof(delay_line_t) + len * sizeof(SAMPLE), ram_type);
     if (delay_line == NULL) {
-	fprintf(stderr, "unable to alloc delay line of %d samples\n", len);
+	amy_printf("unable to alloc delay line of %d samples\n", len);
 	return NULL;
     }
     delay_line->samples = (SAMPLE*)(((uint8_t*)delay_line) + sizeof(delay_line_t));
@@ -75,12 +75,12 @@ delay_line_t *new_delay_line(int len, int fixed_delay, int ram_type) {
     for (int i = 0; i < len; ++i) {
         delay_line->samples[i] = 0;
     }
-    //fprintf(stderr, "new_delay_line: len %d fixed_del %d ->0x%x\n", len, fixed_delay, (uint32_t)delay_line);
+    //amy_printf("new_delay_line: len %d fixed_del %d ->0x%x\n", len, fixed_delay, (uint32_t)delay_line);
     return delay_line;
 }
 
 void free_delay_line(delay_line_t *delay_line) {
-    //printf("free_delay_line: 0x%x\n", (uint32_t)delay_line);
+    //amy_printf("free_delay_line: 0x%x\n", (uint32_t)delay_line);
     free(delay_line);  // the samples are part of the same malloc.
 }
 
@@ -208,7 +208,7 @@ void delete_reverb(reverb_params_t *rev) {
 }
 
 void config_stereo_reverb(reverb_params_t *rev, float a_liveness, float crossover_hz, float damping) {
-    //printf("config_stereo_reverb: liveness %f xover %f damping %f\n",
+    //amy_printf("config_stereo_reverb: liveness %f xover %f damping %f\n",
     //       a_liveness, crossover_hz, damping);
     // liveness (0..1) controls how much energy is preserved (larger = longer reverb).
     rev->liveness = F2S(a_liveness);
@@ -259,7 +259,7 @@ bool init_stereo_reverb(reverb_params_t *rev) {
     if (rev->delay_1 == NULL || rev->delay_2 == NULL || rev->delay_3 == NULL || rev->delay_4 == NULL ||
         rev->ref_1 == NULL || rev->ref_2 == NULL || rev->ref_3 == NULL ||
         rev->ref_4 == NULL || rev->ref_5 == NULL || rev->ref_6 == NULL) {
-        fprintf(stderr, "init_stereo_reverb: allocation failed, reverb disabled\n");
+        amy_printf("init_stereo_reverb: allocation failed, reverb disabled\n");
         deinit_stereo_reverb(rev);  // rolls back all partial allocations, NULLs all pointers
         return false;
     }

--- a/src/envelope.c
+++ b/src/envelope.c
@@ -108,7 +108,7 @@ AMY_IRAM_ATTR SAMPLE compute_breakpoint_scale(uint16_t osc, uint8_t bp_set, uint
             found = bp_r - 1; // segment before release defines sustain
             scale = F2S(synth[osc]->breakpoint_values[bp_set][found]);
             synth[osc]->last_scale[bp_set] = scale;
-            //printf("env: time %lld bpset %d seg %d SUSTAIN %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, bp_set, found, S2F(scale));
+            //amy_printf("env: time %lld bpset %d seg %d SUSTAIN %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, bp_set, found, S2F(scale));
             //return scale;
             goto return_label;
         }
@@ -121,7 +121,7 @@ AMY_IRAM_ATTR SAMPLE compute_breakpoint_scale(uint16_t osc, uint8_t bp_set, uint
         // Release starts from wherever we got to
         v0 = synth[osc]->last_scale[bp_set];
         if(elapsed > synth[osc]->breakpoint_times[bp_set][bp_r]) {
-            //printf("cbp: time %f osc %d amp %f OFF\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, osc, msynth[osc]->amp);
+            //amy_printf("cbp: time %f osc %d amp %f OFF\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, osc, msynth[osc]->amp);
             // Synth is now turned off in hold_and_modify, which tracks when the amplitude goes to zero (and waits a bit).
             //AMY_UNSET(synth[osc]->note_off_clock);
             scale = F2S(synth[osc]->breakpoint_values[bp_set][bp_r]);
@@ -197,7 +197,7 @@ AMY_IRAM_ATTR SAMPLE compute_breakpoint_scale(uint16_t osc, uint8_t bp_set, uint
                                          - exp2_lut(MUL4_SS(exponential_rate,
                                                             F2S(time_ratio)))));
             if (scale < 0)  scale = 0;  // Overshoot ramp-to-zero from limited resolution?
-            //printf("false_exponential time %lld bpset %d seg %d time_ratio %f scale %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, bp_set, found, time_ratio, S2F(scale));
+            //amy_printf("false_exponential time %lld bpset %d seg %d time_ratio %f scale %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, bp_set, found, time_ratio, S2F(scale));
         }
     }
  return_label:
@@ -209,7 +209,7 @@ AMY_IRAM_ATTR SAMPLE compute_breakpoint_scale(uint16_t osc, uint8_t bp_set, uint
     // Keep track of the most-recently returned non-release scale.
     //static int last_seg = -1;
     //if (osc < AMY_OSCS && found != -1 && last_seg != found) {
-    //  fprintf(stderr, "\renv: time %f osc %d bpset %d seg %d type %d t0 %d t1 %d elapsed %d v0 %f v1 %f scale %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, osc, bp_set, found, eg_type, t0, t1, elapsed, S2F(v0), S2F(v1), S2F(scale));
+    //  amy_printf("\renv: time %f osc %d bpset %d seg %d type %d t0 %d t1 %d elapsed %d v0 %f v1 %f scale %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, osc, bp_set, found, eg_type, t0, t1, elapsed, S2F(v0), S2F(v1), S2F(scale));
     //  last_seg = found;
     //}
     AMY_PROFILE_STOP(COMPUTE_BREAKPOINT_SCALE)

--- a/src/examples.c
+++ b/src/examples.c
@@ -154,7 +154,7 @@ void example_patches() {
         e.patch_number = i;
         e.synth = 1;
         e.num_voices = 1;
-        fprintf(stderr, "sending patch %d\n", i);
+        amy_printf("sending patch %d\n", i);
         amy_add_event(&e);
         delay_ms(250);
 
@@ -498,11 +498,11 @@ void example_fm(uint32_t start) {
 // Minimal custom oscillator
 
 void beeper_init(void) {
-    //printf("Beeper init\n");
+    //amy_printf("Beeper init\n");
 }
 
 void beeper_deinit(void) {
-    //printf("Beeper deinit\n");
+    //amy_printf("Beeper deinit\n");
 }
 
 void beeper_note_on(uint16_t osc, float freq) {

--- a/src/filters.c
+++ b/src/filters.c
@@ -69,7 +69,7 @@ int8_t dsps_biquad_gen_lpf_f32(SAMPLE *coeffs, float f, float qFactor)
     // Where exactly are those poles?  Impose minima on (1 - r) and w0.
     float r = -99, ww = 0;
     if (false && a2 > 0) { 
-        printf("before: r %f a %f %f %f\n", sqrtf(a2 / a0), a0, a1, a2);
+        amy_printf("before: r %f a %f %f %f\n", sqrtf(a2 / a0), a0, a1, a2);
         // Limit how close complex poles can get to the unit circle.
         r = MIN(0.99f, sqrtf(a2 / a0));
         float alphadash = (1 - r * r) / (1 + r * r);
@@ -78,7 +78,7 @@ int8_t dsps_biquad_gen_lpf_f32(SAMPLE *coeffs, float f, float qFactor)
             ww = acosf(cosww);
             a1 = a0 * (-2 * r * cosf(ww));
             a2 = a0 * r * r;
-            printf(" after: r %f a %f %f %f\n", r, a0, a1, a2);
+            amy_printf(" after: r %f a %f %f %f\n", r, a0, a1, a2);
         }
     }
 
@@ -88,9 +88,9 @@ int8_t dsps_biquad_gen_lpf_f32(SAMPLE *coeffs, float f, float qFactor)
     coeffs[3] = F2S(a1 / a0);
     coeffs[4] = F2S(a2 / a0);
 
-    //printf("Flpf t=%f f=%f q=%f alpha %f b0 %f b1 %f b2 %f a1 %f a2 %f r %f theta %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, f * AMY_SAMPLE_RATE, qFactor, alpha, 
+    //amy_printf("Flpf t=%f f=%f q=%f alpha %f b0 %f b1 %f b2 %f a1 %f a2 %f r %f theta %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, f * AMY_SAMPLE_RATE, qFactor, alpha, 
     //       b0 / a0, b1 / a0, b2 / a0, a1 / a0, a2 / a0, r, w0);
-    //printf("Slpf t=%f f=%f q=%f b0 %f b1 %f b2 %f a1 %f a2 %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, f * AMY_SAMPLE_RATE, qFactor,
+    //amy_printf("Slpf t=%f f=%f q=%f b0 %f b1 %f b2 %f a1 %f a2 %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, f * AMY_SAMPLE_RATE, qFactor,
     //       S2F(coeffs[0]), S2F(coeffs[1]), S2F(coeffs[2]), S2F(coeffs[3]), S2F(coeffs[4]));
 
     return 0;
@@ -304,7 +304,7 @@ int8_t dsps_biquad_f32_ansi_split_fb(const SAMPLE *input, SAMPLE *output, int le
     SAMPLE y2 = w[3];
     SAMPLE e = F2S(2.0f) + coef[3];  // So coef[3] = -2 + e
     SAMPLE f = F2S(1.0f) - coef[4];  // So coef[4] = 1 - f
-    //fprintf(stderr, "e=%f (%d) f=%f\n", S2F(e), (e < F2S(0.0625)), S2F(f));
+    //amy_printf("e=%f (%d) f=%f\n", S2F(e), (e < F2S(0.0625)), S2F(f));
     for (int i = 0 ; i < len ; i++) {
         SAMPLE x0 = SHIFTL(input[i], FILTER_SCALEUP_BITS);
         SAMPLE w0 = FILT_MUL_SS(coef[0], x0) + FILT_MUL_SS(coef[1], x1) + FILT_MUL_SS(coef[2], x2);
@@ -600,7 +600,7 @@ AMY_IRAM_ATTR SAMPLE dsps_biquad_f32_ansi_split_fb_twice_fixedzeros(const SAMPLE
     SAMPLE a = coef[0];
     SAMPLE e = F2S(2.0f) + coef[3];  // So coef[3] = -2 + e
     SAMPLE f = F2S(1.0f) - coef[4];  // So coef[4] = 1 - f
-    //fprintf(stderr, "e=%f (%d) f=%f\n", S2F(e), (e < F2S(0.0625)), S2F(f));
+    //amy_printf("e=%f (%d) f=%f\n", S2F(e), (e < F2S(0.0625)), S2F(f));
     SAMPLE max_out = 0;
     for (int i = 0 ; i < len ; i++) {
         SAMPLE x0, w0, v0;
@@ -863,7 +863,7 @@ void check_overflow(SAMPLE* block, int osc, char *msg) {
         if (val > max)  max = val;
     }
     if (maxdiff > F2S(0.2f))
-        fprintf(stderr, "Overflow at timeframe %.3f max=%.3f maxdiff=%.3f osc=%d msg=%s\n",
+        amy_printf("Overflow at timeframe %.3f max=%.3f maxdiff=%.3f osc=%d msg=%s\n",
                 (float)(amy_global.total_blocks*AMY_BLOCK_SIZE) / AMY_SAMPLE_RATE,
                 S2F(max), S2F(maxdiff), osc, msg);
 
@@ -952,13 +952,13 @@ AMY_IRAM_ATTR SAMPLE filter_process(SAMPLE * block, uint16_t osc, SAMPLE max_val
     else if(synth[osc]->filter_type==FILTER_NOTCH)
         dsps_biquad_gen_notch_f32(coeffs, ratio, msynth[osc]->resonance);
     else {
-        fprintf(stderr, "Unrecognized filter type %d\n", synth[osc]->filter_type);
+        amy_printf("Unrecognized filter type %d\n", synth[osc]->filter_type);
         return 0;
     }
     AMY_PROFILE_STOP(FILTER_PROCESS_STAGE0)
 
 #ifdef NOTDEF
-    printf("FlPr t=%.3f f=%.3f q=%.3f %.3f %.3f %.3f %.3f %.3f ST %.6f %.6f %.6f %.6f %.6f %.6f %.6f %.6f B %.6f %.6f %.6f %.6f\n",
+    amy_printf("FlPr t=%.3f f=%.3f q=%.3f %.3f %.3f %.3f %.3f %.3f ST %.6f %.6f %.6f %.6f %.6f %.6f %.6f %.6f B %.6f %.6f %.6f %.6f\n",
            amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE,
            ratio * AMY_SAMPLE_RATE, msynth[osc]->resonance, 
            S2F(coeffs[0]), S2F(coeffs[1]), S2F(coeffs[2]), S2F(coeffs[3]), S2F(coeffs[4]),
@@ -985,7 +985,7 @@ AMY_IRAM_ATTR SAMPLE filter_process(SAMPLE * block, uint16_t osc, SAMPLE max_val
     normbits = MIN(normbits, synth[osc]->last_filt_norm_bits + 1);  // Increase at most one bit per block.
     normbits = MIN(8, normbits);  // Without this, I get a weird sign flip at the end of TestLFO - intermediate overflow?
 #endif
-    //printf("time %f max_val %f filtmax %f lastfiltnormbits %d filtnormbits %d normbits %d\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, S2F(max_val), S2F(filtmax), synth[osc]->last_filt_norm_bits, filtnormbits, normbits);
+    //amy_printf("time %f max_val %f filtmax %f lastfiltnormbits %d filtnormbits %d normbits %d\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, S2F(max_val), S2F(filtmax), synth[osc]->last_filt_norm_bits, filtnormbits, normbits);
     if(synth[osc]->filter_type==FILTER_LPF24) {
         // 24 dB/oct by running the same filter twice.
         max_val = dsps_biquad_f32_ansi_split_fb_twice_fixedzeros(block, block, AMY_BLOCK_SIZE, coeffs, synth[osc]->filter_delay, max_val);
@@ -1009,7 +1009,7 @@ AMY_IRAM_ATTR SAMPLE filter_process(SAMPLE * block, uint16_t osc, SAMPLE max_val
     AMY_PROFILE_STOP(FILTER_PROCESS_STAGE1)
     AMY_PROFILE_STOP(FILTER_PROCESS)
 #ifdef NOTDEF
-    printf("FlP2 t=%.3f f=%.3f q=%.3f %.3f %.3f %.3f %.3f %.3f ST %.6f %.6f %.6f %.6f %.6f %.6f %.6f %.6f B %.6f %.6f %.6f %.6f\n",
+    amy_printf("FlP2 t=%.3f f=%.3f q=%.3f %.3f %.3f %.3f %.3f %.3f ST %.6f %.6f %.6f %.6f %.6f %.6f %.6f %.6f B %.6f %.6f %.6f %.6f\n",
            amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE,
            ratio * AMY_SAMPLE_RATE, msynth[osc]->resonance, 
            S2F(coeffs[0]), S2F(coeffs[1]), S2F(coeffs[2]), S2F(coeffs[3]), S2F(coeffs[4]),

--- a/src/i2s.c
+++ b/src/i2s.c
@@ -360,7 +360,11 @@ void esp_fill_audio_buffer_task() {
             _rl_render_us += (_rl_render_us_unsmooth - _rl_render_us) >> 5;  // 0.03125 * delta, settle time ~30 steps
             if (_rl_now - _rl_last_print > 500000) {
                 _rl_last_print = _rl_now;
-                amy_printf("RENDER_LOAD ms=%lu render_us=%d\n", (unsigned long)(_rl_now/1000), _rl_render_us);
+                // Raw fprintf, not amy_printf: this is the load-sweep bench's
+                // instrumentation output (measure.py parses these lines over
+                // serial), already opt-in via ARDUINO_SPEEDTEST -- it must
+                // print whether or not AMY_PRINT is set.
+                fprintf(stderr, "RENDER_LOAD ms=%lu render_us=%d\n", (unsigned long)(_rl_now/1000), _rl_render_us);
                 fflush(stderr);
             }
         }

--- a/src/i2s.c
+++ b/src/i2s.c
@@ -213,13 +213,13 @@ amy_err_t esp32_setup_i2s(void) {
             ret = i2c_master_bus_add_device(bus_handle, &dev_conf, &dev_handle);
         }
         if (ret != ESP_OK) {
-            fprintf(stderr, "PCM9211: I2C init failed: %s\n", esp_err_to_name(ret));
+            amy_printf("PCM9211: I2C init failed: %s\n", esp_err_to_name(ret));
         } else {
             for (int i = 0; i < sizeof(pcm9211_regs) / sizeof(pcm9211_regs[0]); i++) {
                 uint8_t buf[2] = { pcm9211_regs[i][0], pcm9211_regs[i][1] };
                 ret = i2c_master_transmit(dev_handle, buf, 2, 100);
                 if (ret != ESP_OK) {
-                    fprintf(stderr, "PCM9211: reg 0x%02x write 0x%02x failed: %s\n",
+                    amy_printf("PCM9211: reg 0x%02x write 0x%02x failed: %s\n",
                         buf[0], buf[1], esp_err_to_name(ret));
                 }
             }
@@ -308,7 +308,7 @@ void esp_read_i2s_input() {
     i2s_channel_read(rx_handle, amy_in_block, AMY_BLOCK_SIZE * AMY_NCHANS * sizeof(output_sample_type), &read, portMAX_DELAY);
 #endif
     if(read != AMY_BLOCK_SIZE * AMY_NCHANS * I2S_BYTES_PER_SAMPLE) {
-        fprintf(stderr,"i2s input underrun: %d vs %d\n", read, AMY_BLOCK_SIZE * AMY_NCHANS * I2S_BYTES_PER_SAMPLE);
+        amy_printf("i2s input underrun: %d vs %d\n", read, AMY_BLOCK_SIZE * AMY_NCHANS * I2S_BYTES_PER_SAMPLE);
     }
 }
 
@@ -360,7 +360,7 @@ void esp_fill_audio_buffer_task() {
             _rl_render_us += (_rl_render_us_unsmooth - _rl_render_us) >> 5;  // 0.03125 * delta, settle time ~30 steps
             if (_rl_now - _rl_last_print > 500000) {
                 _rl_last_print = _rl_now;
-                fprintf(stderr, "RENDER_LOAD ms=%lu render_us=%d\n", (unsigned long)(_rl_now/1000), _rl_render_us);
+                amy_printf("RENDER_LOAD ms=%lu render_us=%d\n", (unsigned long)(_rl_now/1000), _rl_render_us);
                 fflush(stderr);
             }
         }
@@ -477,7 +477,7 @@ size_t amy_i2s_write(const uint8_t *buffer, size_t nbytes) {
 #endif
 
     if(written != AMY_BLOCK_SIZE * AMY_NCHANS * I2S_BYTES_PER_SAMPLE) {
-        fprintf(stderr,"i2s output underrun: %d vs %d\n", written, AMY_BLOCK_SIZE * AMY_NCHANS * I2S_BYTES_PER_SAMPLE);
+        amy_printf("i2s output underrun: %d vs %d\n", written, AMY_BLOCK_SIZE * AMY_NCHANS * I2S_BYTES_PER_SAMPLE);
     }
     return 1;
 }

--- a/src/instrument.c
+++ b/src/instrument.c
@@ -23,18 +23,18 @@ struct voice_fifo {
 // Fifo must provide init, put, get, remove, empty
 
 void voice_fifo_debug(struct voice_fifo *fifo) {
-    fprintf(stderr, "fifo %s entries 0x%lx len %d head %d tail %d: ", fifo->name, (long)fifo->entries, fifo->length, fifo->head, fifo->tail);
+    amy_printf("fifo %s entries 0x%lx len %d head %d tail %d: ", fifo->name, (long)fifo->entries, fifo->length, fifo->head, fifo->tail);
     uint8_t current = fifo->tail;
     while(current != fifo->head) {
-        fprintf(stderr, "%d ", fifo->entries[current]);
+        amy_printf("%d ", fifo->entries[current]);
         current = (current + 1) % fifo->length;
     }
-    fprintf(stderr, "\n");
+    amy_printf("\n");
 }
 
 struct voice_fifo *voice_fifo_init(int size, const char *name) {
     if (size <=0 || size > MAX_VOICES_PER_INSTRUMENT) {
-        fprintf(stderr, "init_voice_fifo: size %d value error (max size is %d)\n", size, MAX_VOICES_PER_INSTRUMENT);
+        amy_printf("init_voice_fifo: size %d value error (max size is %d)\n", size, MAX_VOICES_PER_INSTRUMENT);
         return NULL;
     }
     struct voice_fifo *result = (struct voice_fifo *)malloc_caps(sizeof(struct voice_fifo), amy_global.config.ram_caps_synth);
@@ -61,27 +61,27 @@ void voice_fifo_put(struct voice_fifo *fifo, uint8_t val) {
     fifo->entries[fifo->head++] = val;
     if (fifo->head == fifo->length)  fifo->head = 0;
     if (fifo->head == fifo->tail) {
-        fprintf(stderr, "**fifo %s: overflow\n", fifo->name);
+        amy_printf("**fifo %s: overflow\n", fifo->name);
         // Drop the entry we just overwrote.
         fifo->tail = (fifo->tail + 1) % fifo->length;
     }
-    //fprintf(stderr, "I: fifo %s: put %d\n", fifo->name, val);
+    //amy_printf("I: fifo %s: put %d\n", fifo->name, val);
 }
 
 uint8_t voice_fifo_get(struct voice_fifo *fifo) {
     if (voice_fifo_empty(fifo)) {
-        fprintf(stderr, "**fifo %s: get on empty\n", fifo->name);
+        amy_printf("**fifo %s: get on empty\n", fifo->name);
         return 0;
     }
     uint8_t val = fifo->entries[fifo->tail++];
     if (fifo->tail == fifo->length)  fifo->tail = 0;
-    //fprintf(stderr, "I: fifo %s: get %d\n", fifo->name, val);
+    //amy_printf("I: fifo %s: get %d\n", fifo->name, val);
     return val;
 }
 
 void voice_fifo_remove(struct voice_fifo *fifo, uint8_t val) {
     // Remove the oldest instance of val in the fifo and close up.
-    //fprintf(stderr, "I: fifo %s: remove %d\n", fifo->name, val);
+    //amy_printf("I: fifo %s: remove %d\n", fifo->name, val);
     uint8_t index;
     for (index = fifo->tail; index != fifo->head; index = (index + 1) % fifo->length) {
         if (fifo->entries[index] == val) {
@@ -96,7 +96,7 @@ void voice_fifo_remove(struct voice_fifo *fifo, uint8_t val) {
             return;
         }
     }
-    fprintf(stderr, "**fifo %s: remove did not find %d (#entries=%d)\n", fifo->name, val, (fifo->head - fifo->tail) % fifo->length);
+    amy_printf("**fifo %s: remove did not find %d (#entries=%d)\n", fifo->name, val, (fifo->head - fifo->tail) % fifo->length);
 }
 
 // How many forgotten note-ons (due to repeated onsets, or note stealing) do we remember
@@ -130,11 +130,11 @@ struct instrument_info {
 };
 
 void instrument_debug(struct instrument_info *instrument) {
-    fprintf(stderr, "**instrument 0x%lx id %d bus %d num_voices %d patch %d oscs %d bank %d flags %" PRIu32 " noteon_delay_ms %d in_sustain %d grab_midi %d\n",
+    amy_printf("**instrument 0x%lx id %d bus %d num_voices %d patch %d oscs %d bank %d flags %" PRIu32 " noteon_delay_ms %d in_sustain %d grab_midi %d\n",
             (unsigned long)instrument, instrument->id, instrument->bus, instrument->num_voices, instrument->patch_number, instrument->oscs_per_voice, instrument->bank_number, instrument->flags,
             instrument->noteon_delay_ms, instrument->in_sustain, instrument->grab_midi_notes);
     for (int i = 0; i < instrument->num_voices; ++i)
-        fprintf(stderr, "voice %d amy_voice %d note_per_voice %d pending_release %d\n",
+        amy_printf("voice %d amy_voice %d note_per_voice %d pending_release %d\n",
                 i, instrument->amy_voices[i], instrument->note_per_voice[i], instrument->pending_release[i]);
     voice_fifo_debug(instrument->active_voices);
     voice_fifo_debug(instrument->released_voices);
@@ -179,7 +179,7 @@ struct instrument_info *instrument_init(int id, int num_voices, uint16_t* amy_vo
     }
     instrument->id = id;
     if (num_voices <= 0 || num_voices > MAX_VOICES_PER_INSTRUMENT) {
-        fprintf(stderr, "num_voices %d not within 1 .. MAX_VOICES_PER_INSTRUMENT %d\n", num_voices, MAX_VOICES_PER_INSTRUMENT);
+        amy_printf("num_voices %d not within 1 .. MAX_VOICES_PER_INSTRUMENT %d\n", num_voices, MAX_VOICES_PER_INSTRUMENT);
         abort();
         return NULL;
     }
@@ -227,7 +227,7 @@ void _instrument_push_note_forgotten(struct instrument_info *instrument, uint16_
     for (int i = 0; i < FORGOTTEN_POOL_SIZE; ++i) {
         if (instrument->forgotten_notes[i] == note) {
             ++instrument->forgotten_note_count[i];
-            //fprintf(stderr, "synth %d: caching existing forgotten note %d/%d (%d, count %d)\n",
+            //amy_printf("synth %d: caching existing forgotten note %d/%d (%d, count %d)\n",
             //        instrument->id, note / 128, note & 0x7F, i, instrument->forgotten_note_count[i]);
             return;
         }
@@ -239,10 +239,10 @@ void _instrument_push_note_forgotten(struct instrument_info *instrument, uint16_
     if (available_index >= 0) {
         instrument->forgotten_notes[available_index] = note;
         instrument->forgotten_note_count[available_index] = 1;
-        //fprintf(stderr, "synth %d: caching new forgotten note %d/%d (%d, count %d)\n",
+        //amy_printf("synth %d: caching new forgotten note %d/%d (%d, count %d)\n",
         //        instrument->id, note / 128, note & 0x7F, available_index, instrument->forgotten_note_count[available_index]);
     } else {
-        fprintf(stderr, "**_instrument_push_forgotten_note: forgotten pool overflow synth %d note %d/%d\n",
+        amy_printf("**_instrument_push_forgotten_note: forgotten pool overflow synth %d note %d/%d\n",
                 instrument->id, note / 128, note & 0x7F);
     }
 }
@@ -251,7 +251,7 @@ bool _instrument_pop_note_forgotten(struct instrument_info *instrument, uint16_t
     // Checks forgotten_notes for this note; if found, remove it and return true; else false.
     for (int i = 0; i < FORGOTTEN_POOL_SIZE; ++i) {
         if (instrument->forgotten_notes[i] == note) {
-            //fprintf(stderr, "synth %d: uncaching forgotten note %d/%d (%d, count %d)\n",
+            //amy_printf("synth %d: uncaching forgotten note %d/%d (%d, count %d)\n",
             //        instrument->id, note / 128, note & 0x7F, i, instrument->forgotten_note_count[i]);
             --instrument->forgotten_note_count[i];
             if (instrument->forgotten_note_count[i] == 0)
@@ -295,7 +295,7 @@ uint16_t instrument_note_off(struct instrument_info *instrument, uint16_t note) 
     if (voice == _INSTRUMENT_NO_VOICE) {
         // Don't report an unmatched note-off if it was a victim of stealing.
         if (!_instrument_pop_note_forgotten(instrument, note))
-            fprintf(stderr, "note off for %d/%d does not match note on\n", note / 128, note & 0x7F);
+            amy_printf("note off for %d/%d does not match note on\n", note / 128, note & 0x7F);
         //instrument_debug(instrument);
         return _INSTRUMENT_NO_VOICE;  // We could just fall through, but this is more explicit.
     }
@@ -303,7 +303,7 @@ uint16_t instrument_note_off(struct instrument_info *instrument, uint16_t note) 
         instrument->pending_release[voice] = true;
         return _INSTRUMENT_NO_VOICE;
     }
-    //fprintf(stderr, "instr 0x%lx: patch %d voice %d note %d/%d off\n", (unsigned long)instrument, instrument->patch_number, instrument->amy_voices[voice], note / 128, note & 0x7F);
+    //amy_printf("instr 0x%lx: patch %d voice %d note %d/%d off\n", (unsigned long)instrument, instrument->patch_number, instrument->amy_voices[voice], note / 128, note & 0x7F);
     return _instrument_voice_off(instrument, voice);
 }
 
@@ -312,7 +312,7 @@ int _instrument_all_notes_off(struct instrument_info *instrument, uint16_t *amy_
     int num_voices_turned_off = 0;
     for (uint16_t voice = 0; voice < instrument->num_voices; ++voice)
         if (instrument->note_per_voice[voice] != _INSTRUMENT_NO_NOTE) {
-            //fprintf(stderr, "voice %d note %d/%d all-off\n", instrument->amy_voices[voice], instrument->note_per_voice[voice] / 128, instrument->note_per_voice[voice] & 0x7F);
+            //amy_printf("voice %d note %d/%d all-off\n", instrument->amy_voices[voice], instrument->note_per_voice[voice] / 128, instrument->note_per_voice[voice] & 0x7F);
             _instrument_voice_off(instrument, voice);
             *amy_voices++ = instrument->amy_voices[voice];
             ++num_voices_turned_off;
@@ -324,7 +324,7 @@ int _instrument_all_notes_off(struct instrument_info *instrument, uint16_t *amy_
 uint16_t instrument_note_on(struct instrument_info *instrument, uint16_t note, bool *pstolen) {
     if ((note & 0x7F) == 0) {
         // note == 0 is for all-notes-off, it's not allowed for note-on (sorry, C-1).
-        fprintf(stderr, "note-on for note 0: ignored.\n");
+        amy_printf("note-on for note 0: ignored.\n");
         return _INSTRUMENT_NO_VOICE;
     }
     uint16_t voice = _instrument_voice_for_note(instrument, note);
@@ -338,7 +338,7 @@ uint16_t instrument_note_on(struct instrument_info *instrument, uint16_t note, b
     }
     instrument->note_per_voice[voice] = note;
     instrument->pending_release[voice] = false;
-    //fprintf(stderr, "instr 0x%lx: patch %d voice %d note %d/%d on\n", (unsigned long)instrument, instrument->patch_number, instrument->amy_voices[voice], note);
+    //amy_printf("instr 0x%lx: patch %d voice %d note %d/%d on\n", (unsigned long)instrument, instrument->patch_number, instrument->amy_voices[voice], note);
     //instrument_debug(instrument);
     return instrument->amy_voices[voice];
 }
@@ -394,7 +394,7 @@ void instrument_release(int instrument_number) {
 
 bool instrument_number_ok(int instrument_number, const char *tag) {
     if (instrument_number < 0 || instrument_number >= max_instruments) {
-        if (tag) fprintf(stderr, "instrument_number %d is out of range 0..%d (%s)\n", instrument_number, max_instruments, tag);
+        if (tag) amy_printf("instrument_number %d is out of range 0..%d (%s)\n", instrument_number, max_instruments, tag);
         return false;
     }
     return true;
@@ -405,7 +405,7 @@ bool instrument_number_exists(int instrument_number, const char *tag) {
         if (instruments[instrument_number])
             return true;
         if (tag)
-            fprintf(stderr, "synth %d not defined (%s)\n", instrument_number, tag);
+            amy_printf("synth %d not defined (%s)\n", instrument_number, tag);
     }
     return false;
 }
@@ -439,7 +439,7 @@ int instrument_get_num_voices(int instrument_number, uint16_t *amy_voices) {
     int num_voices = 0;
     struct instrument_info *instrument = instruments[instrument_number];
     if (instrument == NULL) {
-        //fprintf(stderr, "get_num_voices: instrument_number %d is not defined.\n", instrument_number);
+        //amy_printf("get_num_voices: instrument_number %d is not defined.\n", instrument_number);
     } else {
         num_voices = instrument->num_voices;
         if (amy_voices != NULL)
@@ -491,7 +491,7 @@ int instrument_sustain(int instrument_number, bool sustain, uint16_t *amy_voices
     int num_voices_turned_off = 0;
     for (uint16_t voice = 0; voice < instrument->num_voices; ++voice)
         if (instrument->pending_release[voice]) {
-            //fprintf(stderr, "voice %d note %d pedal-released\n", instrument->amy_voices[voice], instrument->note_per_voice[voice]);
+            //amy_printf("voice %d note %d pedal-released\n", instrument->amy_voices[voice], instrument->note_per_voice[voice]);
             _instrument_voice_off(instrument, voice);
             *amy_voices++ = instrument->amy_voices[voice];
             ++num_voices_turned_off;

--- a/src/interp_partials.c
+++ b/src/interp_partials.c
@@ -147,7 +147,7 @@ AMY_IRAM_ATTR void partials_hold_and_modify(uint16_t osc) {
     //msynth[osc]->pan = p_combine_controls(ctrl_inputs, synth[osc]->pan_coefs);
     // Don't smear the pan on first frame of new note
     ///if (synth[osc]->note_on_clock == amy_global.total_samples) {
-    //    //fprintf(stderr, "time %.3f osc %d note on\n", amy_global.time, osc);
+    //    //amy_printf("time %.3f osc %d note on\n", amy_global.time, osc);
     //    // First frame for this osc since note-on, don't smooth-over the pan.
     //    // (showed up when panning drum sounds).
     //    msynth[osc]->last_pan = msynth[osc]->pan;
@@ -197,7 +197,7 @@ AMY_IRAM_ATTR SAMPLE render_partials(SAMPLE *buf, uint16_t osc) {
 
     // now, render everything, add it up
     float midi_note = midi_note_for_logfreq(msynth[osc]->logfreq);
-    //fprintf(stderr, "t=%u partials o=%d msynth[osc]->logfreq=%f midi_note=%f msynth[amp]=%f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, osc, msynth[osc]->logfreq, midi_note, msynth[osc]->amp);
+    //amy_printf("t=%u partials o=%d msynth[osc]->logfreq=%f midi_note=%f msynth[amp]=%f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, osc, msynth[osc]->logfreq, midi_note, msynth[osc]->amp);
     assert(osc < AMY_OSCS - (num_oscs + 1));  // We won't overrun.
     for(uint16_t o = osc + 1; o < osc + 1 + num_oscs; o++) {
         if(synth[o]->role == SYNTH_IS_ALGO_SOURCE) {
@@ -209,10 +209,10 @@ AMY_IRAM_ATTR SAMPLE render_partials(SAMPLE *buf, uint16_t osc) {
             // envelope value are delayed by 1 frame compared to other oscs
             // so that partials fade in over one frame from zero amp.
             partials_hold_and_modify(o);
-            //printf("[%d %d] %d amp %f (%f) freq %f (%f) on %d off %d bp0 %d %f bp1 %d %f wave %d\n", amy_global.total_blocks*AMY_BLOCK_SIZE, ms_since_started, o, synth[o]->amp, msynth[o]->amp, synth[o]->freq, msynth[o]->freq, synth[o]->note_on_clock, synth[o]->note_off_clock, synth[o]->breakpoint_times[0][0], 
+            //amy_printf("[%d %d] %d amp %f (%f) freq %f (%f) on %d off %d bp0 %d %f bp1 %d %f wave %d\n", amy_global.total_blocks*AMY_BLOCK_SIZE, ms_since_started, o, synth[o]->amp, msynth[o]->amp, synth[o]->freq, msynth[o]->freq, synth[o]->note_on_clock, synth[o]->note_off_clock, synth[o]->breakpoint_times[0][0], 
             //    synth[o]->breakpoint_values[0][0], synth[o]->breakpoint_times[1][0], synth[o]->breakpoint_values[1][0], synth[o]->wave);
             SAMPLE value = render_partial(buf, o);
-            //fprintf(stderr, "render_partials: time %.3f osc %d ctl ampt %.6f msynth_amp %.6f max_val=%.6f\n", amy_global.time, o, msynth[osc]->amp, msynth[o]->amp, S2F(value));
+            //amy_printf("render_partials: time %.3f osc %d ctl ampt %.6f msynth_amp %.6f max_val=%.6f\n", amy_global.time, o, msynth[osc]->amp, msynth[o]->amp, S2F(value));
             if (value > max_value) max_value = value;
         }
     }
@@ -340,7 +340,7 @@ void interp_partials_note_on(uint16_t osc) {
     int harmonic_base_index_ph_vh =
         _harmonic_base_index_for_pitch_vel(pitch_index + 1, vel_index + 1, partials_voice);
     float alpha_ph_vh = (pitch_alpha) * (vel_alpha);
-    //fprintf(stderr, "interp_partials@%u: osc %d note %.1f vel %.1f pitch_x %d vel_x %d numh %d harm_bi_ll %d pitch_a %.3f vel_a %.3f alphas %.2f %.2f %.2f %.2f\n",
+    //amy_printf("interp_partials@%u: osc %d note %.1f vel %.1f pitch_x %d vel_x %d numh %d harm_bi_ll %d pitch_a %.3f vel_a %.3f alphas %.2f %.2f %.2f %.2f\n",
     //        amy_global.total_blocks*AMY_BLOCK_SIZE, osc, midi_note, midi_vel, pitch_index, vel_index, num_harmonics,
     //        harmonic_base_index_pl_vl, pitch_alpha, vel_alpha,
     //        alpha_pl_vl, alpha_pl_vh, alpha_ph_vl, alpha_ph_vh);
@@ -364,7 +364,7 @@ void interp_partials_note_on(uint16_t osc) {
                                              alpha_ph_vl, partials_voice);
             _cumulate_scaled_harmonic_params(harm_param, harmonic_base_index_ph_vh + h,
                                              alpha_ph_vh, partials_voice);
-            //fprintf(stderr, "harm %d freq %.2f bps %.3f %.3f %.3f %.3f\n", h, harm_param[0], harm_param[1], harm_param[2], harm_param[3], harm_param[4]);
+            //amy_printf("harm %d freq %.2f bps %.3f %.3f %.3f %.3f\n", h, harm_param[0], harm_param[1], harm_param[2], harm_param[3], harm_param[4]);
             ++partial_osc;
             _osc_on_with_harm_param(partial_osc, harm_param, partials_voice);
         }

--- a/src/libminiaudio-audio.c
+++ b/src/libminiaudio-audio.c
@@ -85,7 +85,7 @@ int16_t *amy_render_audio() {
 void amy_print_devices() {
     ma_context context;
     if (ma_context_init(NULL, 0, NULL, &context) != MA_SUCCESS) {
-        fprintf(stderr,"Failed to setup context for device list.\n");
+        amy_printf("Failed to setup context for device list.\n");
         exit(1);
     }
 
@@ -94,17 +94,17 @@ void amy_print_devices() {
     ma_device_info* pCaptureInfos;
     ma_uint32 captureCount;
     if (ma_context_get_devices(&context, &pPlaybackInfos, &playbackCount, &pCaptureInfos, &captureCount) != MA_SUCCESS) {
-        fprintf(stderr,"Failed to get device list.\n");
+        amy_printf("Failed to get device list.\n");
         exit(1);
     }
-    fprintf(stderr, "output devices:\n");
+    amy_printf("output devices:\n");
     for (ma_uint32 iDevice = 0; iDevice < playbackCount; iDevice += 1) {
-        fprintf(stderr,"\t%d - %s\n", iDevice, pPlaybackInfos[iDevice].name);
+        amy_printf("\t%d - %s\n", iDevice, pPlaybackInfos[iDevice].name);
     }
 
-    fprintf(stderr, "input devices:\n");
+    amy_printf("input devices:\n");
     for (ma_uint32 iDevice = 0; iDevice < captureCount; iDevice += 1) {
-        fprintf(stderr,"\t%d - %s\n", iDevice, pCaptureInfos[iDevice].name);
+        amy_printf("\t%d - %s\n", iDevice, pCaptureInfos[iDevice].name);
     }
 
     ma_context_uninit(&context);
@@ -179,7 +179,7 @@ ma_uint32 captureCount;
 amy_err_t miniaudio_init() {
     leftover_buf = malloc_caps(sizeof(int16_t)*AMY_BLOCK_SIZE*AMY_NCHANS, amy_global.config.ram_caps_fbl);
 
-    //fprintf(stderr, "miniaudio_init: has_audio_in %d playback_id %d capture_id %d\n",
+    //amy_printf("miniaudio_init: has_audio_in %d playback_id %d capture_id %d\n",
     //        AMY_HAS_AUDIO_IN, amy_global.config.playback_device_id, amy_global.config.capture_device_id);
 
 #ifdef _WIN32
@@ -191,22 +191,22 @@ amy_err_t miniaudio_init() {
 #else
     if (ma_context_init(NULL, 0, NULL, &context) != MA_SUCCESS) {
 #endif
-        printf("Failed to setup context for device list.\n");
+        amy_printf("Failed to setup context for device list.\n");
         exit(1);
     }
     if (ma_context_get_devices(&context, &pPlaybackInfos, &playbackCount, &pCaptureInfos, &captureCount) != MA_SUCCESS) {
-        printf("Failed to get device list.\n");
+        amy_printf("Failed to get device list.\n");
         exit(1);
     }
 
     if(AMY_HAS_AUDIO_IN) {
         if (amy_global.config.playback_device_id >= (int32_t)playbackCount || amy_global.config.capture_device_id >= (int32_t)captureCount) {
-            printf("invalid device\n");
+            amy_printf("invalid device\n");
             exit(1);
         }
     } else {
         if (amy_global.config.playback_device_id >= (int32_t)playbackCount) {
-            printf("invalid device\n");
+            amy_printf("invalid device\n");
             exit(1);
         }
     }
@@ -252,7 +252,7 @@ amy_err_t miniaudio_init() {
 #endif
     
     if (ma_device_init(&context, &deviceConfig, &device) != MA_SUCCESS) {
-        printf("Failed to open playback device.\n");
+        amy_printf("Failed to open playback device.\n");
         exit(1);
     }
 
@@ -278,7 +278,7 @@ amy_err_t miniaudio_init() {
     for(uint16_t i=0;i<OUTPUT_RING_LENGTH;i++) output_ring[i] = 0;
 
     if (ma_device_start(&device) != MA_SUCCESS) {
-        printf("Failed to start playback device.\n");
+        amy_printf("Failed to start playback device.\n");
         ma_device_uninit(&device);
         exit(1);
     }

--- a/src/log2_exp2.c
+++ b/src/log2_exp2.c
@@ -50,7 +50,7 @@ AMY_IRAM_ATTR SAMPLE sin_lut(SAMPLE x) {
         x_frac2 = F2S(1.f) - x_frac2;
     if (quadrant & 2)
         sign = -1;
-    //printf("x=%f quadrant=%d x_frac=%f x_frac2=%f\n", S2F(x), quadrant, S2F(x_frac), S2F(x_frac2));
+    //amy_printf("x=%f quadrant=%d x_frac=%f x_frac2=%f\n", S2F(x), quadrant, S2F(x_frac), S2F(x_frac2));
     return -sign * lut_val(x_frac2, qsin_fxpt_lutable, 8);
 }
 

--- a/src/midi_mappings.c
+++ b/src/midi_mappings.c
@@ -66,7 +66,7 @@ struct midi_mapping default_note_mapping = {
 
 
 void midi_mapping_print(struct midi_mapping *mapping) {
-    fprintf(stderr, "mapping 0x%lx chan %d type %d code 0x%x log %d min %.1f max %.1f offs %.1f msg %s\n",
+    amy_printf("mapping 0x%lx chan %d type %d code 0x%x log %d min %.1f max %.1f offs %.1f msg %s\n",
             (unsigned long)mapping, mapping->channel, mapping->type, mapping->code, mapping->is_log, mapping->min_val, mapping->max_val, mapping->offset_val, mapping->message_template);
 }
 
@@ -95,7 +95,7 @@ struct midi_mapping *midi_mapping_init(int channel, int type, int code, int is_l
 }
 
 void midi_mapping_debug(void) {
-    fprintf(stderr, "midi_mapping_debug:\n");
+    amy_printf("midi_mapping_debug:\n");
     for (int channel = 1; channel < AMY_NUM_MIDI_CHANNELS + 1; ++channel) {
         struct midi_mapping **p_mapping = &midi_cc_mapping_root_by_chan[channel];
         while (*p_mapping != NULL) {
@@ -215,7 +215,7 @@ int midi_store_mapping(int channel, int type, int code, int is_log, float min_va
     //char tmp[256];
     //strncpy(tmp, message, message_len);
     //tmp[message_len] = '\0';
-    //fprintf(stderr, "midi_store_mapping: ch %d type %d code %d L %d N %.3f X %.3f O %.3f CMD (%d) '%s'\n",
+    //amy_printf("midi_store_mapping: ch %d type %d code %d L %d N %.3f X %.3f O %.3f CMD (%d) '%s'\n",
     //        channel, type, code, is_log, min_val, max_val, offset_val, message_len, tmp);
     // Strip trailing wire protocol terminator(s) so they don't accumulate on round-trips.
     while (message_len > 0 && message[message_len - 1] == 'Z') {
@@ -245,7 +245,7 @@ int midi_store_mapping(int channel, int type, int code, int is_log, float min_va
 
 bool midi_fetch_mapping_command(int channel, int type, int code, char *s, size_t len) {
     struct midi_mapping **p_mapping = midi_mapping_find(channel, type, code);
-    //fprintf(stderr, "midi_fetch_mapping_command chan %d type %d code %d mapping 0x%llx\n", channel, type, code, (uint64_t)p_mapping);
+    //amy_printf("midi_fetch_mapping_command chan %d type %d code %d mapping 0x%llx\n", channel, type, code, (uint64_t)p_mapping);
     if (p_mapping == NULL)
         return false;
     // Format the control code - ic<C>,<L>,<N>,<X>,<O>,<CODE>
@@ -307,7 +307,7 @@ void substitute_midi_special_values(char *dest, const char *src, int channel, in
         } else if (src[0] == 'n') {  // 'n' is for note.
             sprintf(dest, "%d", code);
         } else {
-            fprintf(stderr, "substitute_midi: unrecognized '%%%c' in %s\n", src[0], entry_src);
+            amy_printf("substitute_midi: unrecognized '%%%c' in %s\n", src[0], entry_src);
         }
         ++src;  // skip over the code char
         nchars = strlen(dest);
@@ -324,7 +324,7 @@ struct midi_cmd_yield_state {
 };
 
 void *yield_midi_message_handler_events(uint8_t * bytes, uint16_t len, uint32_t time, amy_event *event, void *state) {
-    //fprintf(stderr, "time %.3f midi_msg_handler: 0x%x 0x%x 0x%x\n", amy_global.time, bytes[0], bytes[1], bytes[2]);
+    //amy_printf("time %.3f midi_msg_handler: 0x%x 0x%x 0x%x\n", amy_global.time, bytes[0], bytes[1], bytes[2]);
     //fprintf_event_stderr(event);
     //
     struct midi_cmd_yield_state *yield_state = (struct midi_cmd_yield_state *)state;
@@ -376,7 +376,7 @@ void *yield_midi_message_handler_events(uint8_t * bytes, uint16_t len, uint32_t 
 }
 
 void midi_message_handler_to_queue(uint8_t * bytes, uint16_t len, uint32_t time, amy_event *base_event, struct delta **queue) {
-    //fprintf(stderr, "time %.3f midi_msg_handler: 0x%x 0x%x 0x%x base_event 0x%lx queue 0x%lx\n", amy_global.time, bytes[0], bytes[1], bytes[2], (unsigned long)base_event, (unsigned long)queue);
+    //amy_printf("time %.3f midi_msg_handler: 0x%x 0x%x 0x%x base_event 0x%lx queue 0x%lx\n", amy_global.time, bytes[0], bytes[1], bytes[2], (unsigned long)base_event, (unsigned long)queue);
     //fprintf_event_stderr(base_event);
     //
     void *state = NULL;

--- a/src/oscillators.c
+++ b/src/oscillators.c
@@ -48,7 +48,7 @@ const LUT *choose_from_lutset(float period, const LUT *lutset) {
         // skipping lut_hop samples per sample, its bandwidth will increase 
         // proportionately.
         float interp_bandwidth = lut_bandwidth * lut_hop;
-        //printf("period=%f freq=%f lut_size=%d interp_bandwidth=%f\n", period, ((float)AMY_SAMPLE_RATE)/period, lut_size, interp_bandwidth);
+        //amy_printf("period=%f freq=%f lut_size=%d interp_bandwidth=%f\n", period, ((float)AMY_SAMPLE_RATE)/period, lut_size, interp_bandwidth);
         if (interp_bandwidth < 0.9f) {
             // No aliasing, even with a 10% buffer (i.e., 19.8 kHz).
             break;
@@ -304,7 +304,7 @@ void pulse_note_on(uint16_t osc, float freq) {
 }
 
 void _pulse_note_on(uint16_t osc) {
-    //printf("pulse_note_on: time %lld osc %d logfreq %f amp %f last_amp %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, osc, synth[osc]->logfreq, msynth[osc]->amp, msynth[osc]->last_amp);
+    //amy_printf("pulse_note_on: time %lld osc %d logfreq %f amp %f last_amp %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, osc, synth[osc]->logfreq, msynth[osc]->amp, msynth[osc]->last_amp);
     if (synth[osc]->lut == NULL) {
         float freq = freq_of_logfreq(msynth[osc]->logfreq);
         float period_samples = (float)AMY_SAMPLE_RATE / freq;
@@ -375,7 +375,7 @@ void saw_note_on(uint16_t osc, int8_t direction_notused, float freq) {
 }
 
 void _saw_note_on(uint16_t osc) {
-    //printf("saw_note_on: time %lld osc %d freq %f logfreq %f amp %f last_amp %f phase %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, osc, freq, synth[osc]->logfreq, msynth[osc]->amp, msynth[osc]->last_amp, P2F(synth[osc]->phase));
+    //amy_printf("saw_note_on: time %lld osc %d freq %f logfreq %f amp %f last_amp %f phase %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, osc, freq, synth[osc]->logfreq, msynth[osc]->amp, msynth[osc]->last_amp, P2F(synth[osc]->phase));
     if (synth[osc]->lut == NULL) {
         float freq = freq_of_logfreq(msynth[osc]->logfreq);
         float period_samples = ((float)AMY_SAMPLE_RATE / freq);
@@ -393,7 +393,7 @@ void saw_up_note_on(uint16_t osc, float freq) {
 SAMPLE render_saw(SAMPLE* buf, uint16_t osc, int8_t direction) {
     _saw_note_on(osc);
     return render_lpf_lut(buf, osc, false, direction, /* dc offset */ 0);
-    //printf("render_saw: time %lld osc %d buf[]=%f %f %f %f %f %f %f %f\n",
+    //amy_printf("render_saw: time %lld osc %d buf[]=%f %f %f %f %f %f %f %f\n",
     //       amy_global.total_blocks*AMY_BLOCK_SIZE, osc, S2F(buf[0]), S2F(buf[1]), S2F(buf[2]), S2F(buf[3]), S2F(buf[4]), S2F(buf[5]), S2F(buf[6]), S2F(buf[7]));
 }
 
@@ -543,7 +543,7 @@ void sine_note_on(uint16_t osc, float freq) {
 }
 
 void _sine_note_on(uint16_t osc, float freq) {
-    //fprintf(stderr, "sine_note_on: time %f osc %d freq %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, osc, freq_of_logfreq(synth[osc]->logfreq_coefs[0]));
+    //amy_printf("sine_note_on: time %f osc %d freq %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, osc, freq_of_logfreq(synth[osc]->logfreq_coefs[0]));
     // There's really only one sine table, but for symmetry with the other ones...
     if (synth[osc]->lut == NULL) {
         float period_samples = (float)AMY_SAMPLE_RATE / freq;
@@ -557,7 +557,7 @@ SAMPLE render_sine(SAMPLE* buf, uint16_t osc) {
     PHASOR step = F2P(freq / (float)AMY_SAMPLE_RATE);  // cycles per sec / samples per sec -> cycles per sample
     SAMPLE amp = F2S(msynth[osc]->amp);
     SAMPLE last_amp = F2S(msynth[osc]->last_amp);
-    //fprintf(stderr, "render_sine: time %f osc %d freq %f last_amp %f amp %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, osc, AMY_SAMPLE_RATE * P2F(step), S2F(last_amp), S2F(amp));
+    //amy_printf("render_sine: time %f osc %d freq %f last_amp %f amp %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, osc, AMY_SAMPLE_RATE * P2F(step), S2F(last_amp), S2F(amp));
     SAMPLE max_value;
     //synth[osc]->phase = render_lut(buf, synth[osc]->phase, step, last_amp, amp, synth[osc]->lut, &max_value);
     synth[osc]->phase = render_lut_256(buf, synth[osc]->phase, step, last_amp, amp, /* synth[osc]->lut */ &sine_fxpt_lutset[0], &max_value);
@@ -662,7 +662,7 @@ SAMPLE compute_mod_noise(uint16_t osc) {
         // phase wrapped, take new sample.
         synth[osc]->last_two[0] = MULA_SS(amy_get_random(), amp);
     }
-    //printf("mod_noise: time %lld fstep %f samp %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, fstep, S2F(synth[osc]->last_two[0]));
+    //amy_printf("mod_noise: time %lld fstep %f samp %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, fstep, S2F(synth[osc]->last_two[0]));
     return synth[osc]->last_two[0];
 }
 
@@ -705,7 +705,7 @@ AMY_IRAM_ATTR SAMPLE render_partial(SAMPLE * buf, uint16_t osc) {
     PHASOR step = F2P(freq / (float)AMY_SAMPLE_RATE);  // cycles per sec / samples per sec -> cycles per sample
     SAMPLE amp = F2S(msynth[osc]->amp);
     SAMPLE last_amp = F2S(msynth[osc]->last_amp);
-    //printf("render_partial: time %.3f logfreq %f freq %f last_amp %f amp %f step %f\n", (float)amy_global.total_blocks*AMY_BLOCK_SIZE/(float)AMY_SAMPLE_RATE, msynth[osc]->logfreq, freq, S2F(last_amp), S2F(amp), P2F(step) * synth[osc]->lut->table_size);
+    //amy_printf("render_partial: time %.3f logfreq %f freq %f last_amp %f amp %f step %f\n", (float)amy_global.total_blocks*AMY_BLOCK_SIZE/(float)AMY_SAMPLE_RATE, msynth[osc]->logfreq, freq, S2F(last_amp), S2F(amp), P2F(step) * synth[osc]->lut->table_size);
     SAMPLE max_value;
     //synth[osc]->phase = render_lut(buf, synth[osc]->phase, step, last_amp, amp, /* synth[osc]->lut */ &sine_fxpt_lutset[0], &max_value);
     synth[osc]->phase = render_lut_256(buf, synth[osc]->phase, step, last_amp, amp, /* synth[osc]->lut */ &sine_fxpt_lutset[0], &max_value);
@@ -754,7 +754,7 @@ SAMPLE render_ks(SAMPLE * buf, uint16_t osc) {
             }
         }
     }
-    //fprintf(stderr, "render_ks time %u osc %d freq %.1f amp %.3f maxval %.3f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, osc, freq, S2F(amp), S2F(max_value));
+    //amy_printf("render_ks time %u osc %d freq %.1f amp %.3f maxval %.3f\n", amy_global.total_blocks*AMY_BLOCK_SIZE, osc, freq, S2F(amp), S2F(max_value));
     return max_value;
 }
 
@@ -777,7 +777,7 @@ void ks_note_on(uint16_t osc) {
     }
     ks_polyphony_index++;
     if(ks_polyphony_index == AMY_KS_OSCS) ks_polyphony_index = 0;
-    //fprintf(stderr, "ks_note_on: osc %d buflen %d poly_index %d\n", osc, buflen, ks_polyphony_index);
+    //amy_printf("ks_note_on: osc %d buflen %d poly_index %d\n", osc, buflen, ks_polyphony_index);
 }
 
 void ks_note_off(uint16_t osc) {
@@ -801,7 +801,7 @@ void ks_deinit(void) {
 
 #ifdef AMY_WAVETABLE
 void wavetable_note_on(uint16_t osc, float freq) {
-    //fprintf(stderr, "wavetable_note_on: time %f osc %d freq %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, osc, freq_of_logfreq(synth[osc]->logfreq_coefs[0]));
+    //amy_printf("wavetable_note_on: time %f osc %d freq %f\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, osc, freq_of_logfreq(synth[osc]->logfreq_coefs[0]));
     //float period_samples = (float)AMY_SAMPLE_RATE / freq;
     //synth[osc]->lut = wavetable_lut;  // TODO(dpwe): choose based on synth[osc]->preset.
 }
@@ -823,7 +823,7 @@ SAMPLE render_wavetable(SAMPLE* buf, uint16_t osc) {
     PHASOR step = F2P(freq / (float)AMY_SAMPLE_RATE);
     SAMPLE amp = F2S(msynth[osc]->amp);
     SAMPLE last_amp = F2S(msynth[osc]->last_amp);
-    //fprintf(stderr, "render_wavetable: time %f osc %d freq %f last_amp %f amp %f preset %d\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, osc, AMY_SAMPLE_RATE * P2F(step), S2F(last_amp), S2F(amp), synth[osc]->preset);
+    //amy_printf("render_wavetable: time %f osc %d freq %f last_amp %f amp %f preset %d\n", amy_global.total_blocks*AMY_BLOCK_SIZE / (float)AMY_SAMPLE_RATE, osc, AMY_SAMPLE_RATE * P2F(step), S2F(last_amp), S2F(amp), synth[osc]->preset);
     int16_t wavetable_preset = synth[osc]->preset;
     if (AMY_IS_UNSET(wavetable_preset))
         wavetable_preset = PCM_WAVETABLE_BASE;

--- a/src/parse.c
+++ b/src/parse.c
@@ -41,7 +41,7 @@ float atoff(const char *s) {
         frac /= powf(10.f, (float)fraclen);
         if (is_negative) frac = -frac;
     }
-    //fprintf(stderr, "input was %s output is %f + %f = %f\n", s_in, whole, frac, whole+frac);
+    //amy_printf("input was %s output is %f + %f = %f\n", s_in, whole, frac, whole+frac);
     return whole + frac;
 }
 
@@ -88,7 +88,7 @@ float atoff(const char *s) {
             ++num_vals_received; \
         } \
         if (c < stop) { \
-            fprintf(stderr, "WARNING: parse__list_##type: More than %d values in \"%s\"\n", \
+            amy_printf("WARNING: parse__list_##type: More than %d values in \"%s\"\n", \
             max_num_vals, message); \
         } else { /* pad to end */       \
             for (int i = num_vals_received; i < max_num_vals; ++i) {  \
@@ -361,7 +361,7 @@ int midi_mapping_from_message(char *message, char cmd, int instr_num, int skip_c
         if (*(message + pos + skip_chars) != ',') {
             if (AMY_IS_UNSET(code) || AMY_IS_SET(is_log)) {
                 // Either parsing bailed without even a CC code, or it got past the is_log, meaning it wasn't a bare ic<NUM> command.
-                fprintf(stderr, "synth_layer: midi mapping payload didn't parse for %s.\n", message - 1);
+                amy_printf("synth_layer: midi mapping payload didn't parse for %s.\n", message - 1);
                 return pos + skip_chars;  // maybe the rest will parse?
             }
             // Else we got an incomplete message with a valid CC code - clear it
@@ -414,7 +414,7 @@ int cv_trigger_from_message(char *message, int instr_num, int skip_chars) {
     if (*(message + skip_chars) != ',') {
         if (AMY_IS_UNSET(gate_cv) || AMY_IS_SET(thresh_high)) {
             // Either parsing bailed without even a gate CV, or it got past the thresh, meaning it wasn't a bare ic<NUM> command.
-            fprintf(stderr, "cv_trigger: payload didn't parse for %s.\n", message - 1);
+            amy_printf("cv_trigger: payload didn't parse for %s.\n", message - 1);
             return skip_chars;  // maybe the rest will parse?
         }
         // Else we got an incomplete message with a valid gate_cv - clear all triggers for that CV.
@@ -457,7 +457,7 @@ int amy_parse_synth_layer_message(char *message, amy_event *e) {
     else if (cmd == 'V')  e->synth_level = atoff(message);  // Per-instrument level, default 1.
     else if (cmd == 'y')  e->bus = atoi(message);  // 'i1iy1' is the same as 'i1y1'.
     else if (cmd == 'c' || cmd == 'o') skip_chars = midi_mapping_from_message(message, cmd, e->synth, skip_chars);
-    else fprintf(stderr, "Unrecognized synth-level command '%s'\n", message - 1);
+    else amy_printf("Unrecognized synth-level command '%s'\n", message - 1);
     return skip_chars;
 }
 
@@ -604,7 +604,7 @@ uint16_t amy_parse_transfer_layer_message(char *message) {
         amy_external_midi_sync((uint8_t)atoi(message));
         return 1;
     }
-    else fprintf(stderr, "Unrecognized transfer-level command '%s'\n", message - 1);
+    else amy_printf("Unrecognized transfer-level command '%s'\n", message - 1);
     return 0;
 }
 
@@ -622,11 +622,11 @@ int _next_alpha(char *s) {
 
 
 size_t yield_event_from_message(char *message, amy_event *e, size_t pos) {
-    //fprintf(stderr, "yield_event_from_message in:  pos %d message %s\n", pos, message);
+    //amy_printf("yield_event_from_message in:  pos %d message %s\n", pos, message);
     // Parse the wire string into an event
     if (message[pos] == '\0')  pos = 0;  // Hit end of string
     else pos += amy_parse_message(message + pos, e);
-    //fprintf(stderr, "yield_event_from_message out: pos %d event\n", pos);
+    //amy_printf("yield_event_from_message out: pos %d event\n", pos);
     //fprintf_event_stderr(e);
     return pos;
 }
@@ -805,7 +805,7 @@ int amy_parse_message(char * message, amy_event *e) {
         }
         // Skip over arg, line up for the next cmd.
         ++pos;  // move over the current command.
-        if (pos > length) fprintf(stderr, "parse string overrun %d %d %s\n", pos, length, message);
+        if (pos > length) amy_printf("parse string overrun %d %d %s\n", pos, length, message);
         pos += _next_alpha(message + pos);  // Skip over any non-alpha argument to the current command.
     }
  end:

--- a/src/patches.c
+++ b/src/patches.c
@@ -43,7 +43,7 @@ void patches_init(int max_memory_patches) {
 void patches_reset_patch(int patch_number) {
     int patch_index = patch_number - _PATCHES_FIRST_USER_PATCH;
     if (patch_index < 0 || patch_index >= (int)max_num_memory_patches) {
-        fprintf(stderr, "reset patch number %" PRId32 " is out of range (%" PRId32 " .. %" PRId32 ")\n",
+        amy_printf("reset patch number %" PRId32 " is out of range (%" PRId32 " .. %" PRId32 ")\n",
                 (int32_t)(patch_index + _PATCHES_FIRST_USER_PATCH),
                 (int32_t)_PATCHES_FIRST_USER_PATCH,
                 (int32_t)(_PATCHES_FIRST_USER_PATCH + (int32_t)max_num_memory_patches));
@@ -72,32 +72,32 @@ void patches_debug() {
     // so this loop did not terminate.
     for(uint16_t v = 0; v < amy_global.config.max_voices; v++) {
         if (AMY_IS_SET(voice_to_base_osc[v]))
-            fprintf(stderr, "voice %" PRIu16 " base osc %" PRIu16 "\n", v, voice_to_base_osc[v]);
+            amy_printf("voice %" PRIu16 " base osc %" PRIu16 "\n", v, voice_to_base_osc[v]);
     }
-    fprintf(stderr, "osc_to_voice:\n");
+    amy_printf("osc_to_voice:\n");
     for(uint16_t i=0;i<AMY_OSCS;) {
         uint16_t j = 0;
-        fprintf(stderr, "%" PRIu16 ": ", i);
+        amy_printf("%" PRIu16 ": ", i);
         for (j=0; j < 16; ++j) {
             if ((i + j) >= AMY_OSCS)  break;
-            fprintf(stderr, "%" PRIu16 " ", osc_to_voice[i + j]);
+            amy_printf("%" PRIu16 " ", osc_to_voice[i + j]);
         }
         i += j;
-        fprintf(stderr, "\n");
+        amy_printf("\n");
     }
     for(uint8_t i = 0; i < max_num_memory_patches; i++) {
         if(memory_patch_oscs[i])
-            fprintf(stderr, "memory_patch %" PRIu16 " oscs %" PRIu16 " #deltas %" PRIi32 "\n",
+            amy_printf("memory_patch %" PRIu16 " oscs %" PRIu16 " #deltas %" PRIi32 "\n",
                     (uint16_t)(i + _PATCHES_FIRST_USER_PATCH), memory_patch_oscs[i], delta_list_len(memory_patch_deltas[i]));
     }
     uint16_t voices[MAX_VOICES_PER_INSTRUMENT];
     for (uint8_t i = 0; i < 32 /* MAX_INSTRUMENTS */; ++i) {
         int num_voices = instrument_get_num_voices(i, voices);
         if (num_voices) {
-            fprintf(stderr, "synth %" PRIu8 " num_voices %" PRId32 " patch_num %" PRId32 " flags %" PRIu32 " voice #s",
+            amy_printf("synth %" PRIu8 " num_voices %" PRId32 " patch_num %" PRId32 " flags %" PRIu32 " voice #s",
                     i, (int32_t)num_voices, (int32_t)instrument_get_patch_number(i), instrument_get_flags(i));
-            for (int j = 0; j < num_voices; ++j)  fprintf(stderr, " %" PRIu16, voices[j]);
-            fprintf(stderr, "\n");
+            for (int j = 0; j < num_voices; ++j)  amy_printf(" %" PRIu16, voices[j]);
+            amy_printf("\n");
         }
     }
 }
@@ -105,7 +105,7 @@ void patches_debug() {
 struct delta **queue_for_patch_number(int patch_number) {
     int patch_index = patch_number - _PATCHES_FIRST_USER_PATCH;
     if (patch_index < 0 || patch_index >= (int)max_num_memory_patches) {
-        fprintf(stderr, "queue for patch number %" PRId32 " is out of range (%" PRId32 " .. %" PRId32 ")\n",
+        amy_printf("queue for patch number %" PRId32 " is out of range (%" PRId32 " .. %" PRId32 ")\n",
                 (int32_t)(patch_index + _PATCHES_FIRST_USER_PATCH),
                 (int32_t)_PATCHES_FIRST_USER_PATCH,
                 (int32_t)(_PATCHES_FIRST_USER_PATCH + (int32_t)max_num_memory_patches));
@@ -117,7 +117,7 @@ struct delta **queue_for_patch_number(int patch_number) {
 void update_num_oscs_for_patch_number(int patch_number) {
     int patch_index = patch_number - _PATCHES_FIRST_USER_PATCH;
     if (patch_index < 0 || patch_index >= (int)max_num_memory_patches) {
-        fprintf(stderr, "queue for patch number %" PRId32 " is out of range (%" PRId32 " .. %" PRId32 ")\n",
+        amy_printf("queue for patch number %" PRId32 " is out of range (%" PRId32 " .. %" PRId32 ")\n",
                 (int32_t)(patch_index + _PATCHES_FIRST_USER_PATCH),
                 (int32_t)_PATCHES_FIRST_USER_PATCH,
                 (int32_t)(_PATCHES_FIRST_USER_PATCH + (int32_t)max_num_memory_patches));
@@ -143,7 +143,7 @@ void all_notes_off() {
 }
 
 void add_deltas_to_queue_with_baseosc(struct delta *d, int base_osc, struct delta **queue, uint32_t time) {
-    //fprintf(stderr, "add_deltas_to_queue_with_baseosc: added %d baseosc %d time %d\n", delta_list_len(d), base_osc, time);
+    //amy_printf("add_deltas_to_queue_with_baseosc: added %d baseosc %d time %d\n", delta_list_len(d), base_osc, time);
     struct delta d_offset;
     while(d) {
         d_offset = *d;
@@ -387,7 +387,7 @@ void fprintf_event_stderr(amy_event *e) {
     if (e == NULL) return;
     char s[1024];
     sprint_event(e, s, 1024, /* wirecode */ false);
-    fprintf(stderr, "%s\n", s);
+    amy_printf("%s\n", s);
 }
 
 #define _RET_TRUE_IF_SET(FIELD) if (AMY_IS_SET(e->FIELD)) return true;
@@ -747,7 +747,7 @@ void *yield_synth_events(uint8_t instr_num, struct amy_event *event, bool includ
     uint16_t voices[MAX_VOICES_PER_INSTRUMENT];
     int num_voices = instrument_get_num_voices(instr_num, voices);
     if (num_voices < 1) {
-        fprintf(stderr, "yield_synth_events: synth %" PRId32" has no voices.\n", (int32_t)instr_num);
+        amy_printf("yield_synth_events: synth %" PRId32" has no voices.\n", (int32_t)instr_num);
         return NULL;  // instrument not allocated.
     }
     uint32_t flags = instrument_get_flags(instr_num);
@@ -757,7 +757,7 @@ void *yield_synth_events(uint8_t instr_num, struct amy_event *event, bool includ
     int num_oscs = num_oscs_for_voice(voice);
     // The "state" indicates which osc within the voice we're going to report for.
     int state_val = (intptr_t)state;
-    //fprintf(stderr, "yield_synth_events(%d) voice=%d num_oscs=%d state_val=%d\n", instr_num, voice, num_oscs, (int)state_val);
+    //amy_printf("yield_synth_events(%d) voice=%d num_oscs=%d state_val=%d\n", instr_num, voice, num_oscs, (int)state_val);
     amy_clear_event(event);
     // Always use first output (state val 0) as preamble.
     int first_osc_state_val = 1;
@@ -774,7 +774,7 @@ void *yield_synth_events(uint8_t instr_num, struct amy_event *event, bool includ
         if (!include_fx && bus != 0)  event->bus = bus;
     } else if (state_val >= first_osc_state_val && state_val < last_osc_state_val) {
         event->osc = state_val - first_osc_state_val;
-        //fprintf(stderr, "2 base_osc %d, event->osc %d, state_val %d first_osc_state_val %d last_osc_state_val %d\n",
+        //amy_printf("2 base_osc %d, event->osc %d, state_val %d first_osc_state_val %d last_osc_state_val %d\n",
         //    base_osc, event->osc, state_val, first_osc_state_val, last_osc_state_val);
         set_event_for_osc(base_osc, event->osc, event);
     } else if (include_fx && (state_val == last_osc_state_val)) {
@@ -792,7 +792,7 @@ void *yield_synth_events(uint8_t instr_num, struct amy_event *event, bool includ
 void *yield_synth_commands(uint8_t instr_num, char *s, size_t len, bool include_fx, void *state) {
     // Generator to return multiple wirecode strings to reconfigure a synth.
     int state_val = (intptr_t)state;
-    //fprintf(stderr, "yield_synth_commands: synth %d state %d\n", instr_num, state_val);
+    //amy_printf("yield_synth_commands: synth %d state %d\n", instr_num, state_val);
     s[0] = '\0';  // By default, return an empty string.
     if (state_val < STATE_START_OF_MIDI_TPLT_CMDS) {
         amy_event event = amy_default_event();
@@ -848,7 +848,7 @@ void *yield_bus_commands(char *s, size_t len, void *state) {
 void parse_patch_string_to_queue(char *message, int base_osc, struct delta **queue, uint8_t synth, uint32_t time, bool is_first_voice) {
     // Work though the patch string and send to voices.
     // Now actually initialize the newly-allocated osc blocks with the patch
-    //fprintf(stderr, "parse_patch_string: message %s base_osc %d synth %d time %d is_first_voice %d\n", message, base_osc, synth, time, is_first_voice);
+    //amy_printf("parse_patch_string: message %s base_osc %d synth %d time %d is_first_voice %d\n", message, base_osc, synth, time, is_first_voice);
     amy_event e;
     size_t pos = 0;
     do {
@@ -875,16 +875,16 @@ void patches_store_patch(amy_event *e, char * patch_string) {
     peek_stack("store_patch");
     // amy patch string. Either pull patch_number from e, or allocate a new one and write it to e.
     // Patch is stored in ram.
-    //fprintf(stderr, "store_patch: synth %d patch_num %d patch '%s'\n", e->synth, e->patch, patch_string);
+    //amy_printf("store_patch: synth %d patch_num %d patch '%s'\n", e->synth, e->patch, patch_string);
     if (!AMY_IS_SET(e->patch_number)) {
         // We need to allocate a new number.
         e->patch_number = next_user_patch_index + _PATCHES_FIRST_USER_PATCH;
         // next_user_patch_index is updated as needed at the bottom of the function (so it can reflect user-defined numbers too).
-        //fprintf(stderr, "store_patch: auto-assigning patch number %d for '%s'\n", e->patch_number, patch_string);
+        //amy_printf("store_patch: auto-assigning patch number %d for '%s'\n", e->patch_number, patch_string);
     }
     int patch_index = (int)e->patch_number - _PATCHES_FIRST_USER_PATCH;
     if (patch_index < 0 || patch_index >= (int)max_num_memory_patches) {
-        fprintf(stderr, "patch number %" PRId32 " is out of range (%" PRId32 " .. %" PRId32 ")\n",
+        amy_printf("patch number %" PRId32 " is out of range (%" PRId32 " .. %" PRId32 ")\n",
                 (int32_t)(patch_index + _PATCHES_FIRST_USER_PATCH),
                 (int32_t)_PATCHES_FIRST_USER_PATCH,
                 (int32_t)(_PATCHES_FIRST_USER_PATCH + (int32_t)max_num_memory_patches));
@@ -894,7 +894,7 @@ void patches_store_patch(amy_event *e, char * patch_string) {
     // Store the patch as deltas and find out how many oscs this message uses
     parse_patch_string_to_queue(patch_string, 0, &memory_patch_deltas[patch_index], e->synth, e->time, true);
     update_num_oscs_for_patch_number(patch_index + _PATCHES_FIRST_USER_PATCH);
-    //fprintf(stderr, "store_patch: patch %d max_osc %d patch %s #deltas %d (e->num_vx=%d)\n", patch_index, max_osc, patch_string, delta_list_len(memory_patch_deltas[patch_index]), e->num_voices);
+    //amy_printf("store_patch: patch %d max_osc %d patch %s #deltas %d (e->num_vx=%d)\n", patch_index, max_osc, patch_string, delta_list_len(memory_patch_deltas[patch_index]), e->num_voices);
 }
 
 extern int32_t parse_list_uint16_t(char *message, uint16_t *vals, int32_t max_num_vals, uint16_t skipped_val);
@@ -923,7 +923,7 @@ uint8_t patches_voices_for_note_onoff_event(amy_event *e, uint16_t voices[], uin
         // velocity without midi_note is valid for velocity==0 => all-notes-off.
         if (e->velocity != 0) {
             // Attempted a note-on to all voices, suppress.
-            fprintf(stderr, "note-on with no note for synth %" PRId32 " - ignored.\n", (int32_t)e->synth);
+            amy_printf("note-on with no note for synth %" PRId32 " - ignored.\n", (int32_t)e->synth);
             return 0;
         }
         // All notes off - find out which voices are actually currently active, so we can turn them off.
@@ -942,13 +942,13 @@ uint8_t patches_voices_for_note_onoff_event(amy_event *e, uint16_t voices[], uin
         voices[0] = instrument_voice_for_note_event(e->synth, note, is_note_off, pstolen);
         if (voices[0] == _INSTRUMENT_NO_VOICE) {
             // For now, I think this can only happen with a note-off that has no matching note-on.
-            //fprintf(stderr, "synth %d did not find a voice, dropping message.\n", e->synth);
+            //amy_printf("synth %d did not find a voice, dropping message.\n", e->synth);
             // No, it also happens with note-offs when pedal is down.
             return 0;
         }
         num_voices = 1;
     }
-    //fprintf(stderr, "instrument %d vel %d note %d voice %d\n", e->synth, (int)roundf(127.f * e->velocity), (int)roundf(e->midi_note), voices[0]);
+    //amy_printf("instrument %d vel %d note %d voice %d\n", e->synth, (int)roundf(127.f * e->velocity), (int)roundf(e->midi_note), voices[0]);
     return num_voices;
 }
 
@@ -1004,7 +1004,7 @@ uint8_t patches_voices_for_event(amy_event *e, uint16_t voices[]) {
         if (num_voices) {
             e->velocity = 0;
         }
-        //fprintf(stderr, "synth %d pedal %d num_voices %d\n", e->synth, e->pedal, num_voices);
+        //amy_printf("synth %d pedal %d num_voices %d\n", e->synth, e->pedal, num_voices);
     } else if (AMY_IS_SET(e->velocity)) {
         bool stolen = false;
         synth_flags = instrument_get_flags(e->synth);
@@ -1019,7 +1019,7 @@ uint8_t patches_voices_for_event(amy_event *e, uint16_t voices[]) {
                 .next = NULL,
             };
             add_delta_to_queue(&d, &amy_global.delta_queue);
-            //fprintf(stderr, "synth %d note %d: voice %d stolen, osc %d time %d added note-off\n", e->synth, (int)roundf(e->midi_note), voices[0], d.osc, d.time);
+            //amy_printf("synth %d note %d: voice %d stolen, osc %d time %d added note-off\n", e->synth, (int)roundf(e->midi_note), voices[0], d.osc, d.time);
         }
         // Apply noteon_delay_ms to note-on events.
         if (instrument_noteon_delay_ms(e->synth)) {
@@ -1029,7 +1029,7 @@ uint8_t patches_voices_for_event(amy_event *e, uint16_t voices[]) {
             // See amy_process_event(): dodge the u32 "unset" sentinel.
             if(AMY_IS_UNSET(playback_time)) playback_time++;
             e->time = playback_time;
-            //fprintf(stderr, "synth %d note %d delay %d time %d\n", e->synth, (int)roundf(e->midi_note), instrument_noteon_delay_ms(e->synth), e->time);
+            //amy_printf("synth %d note %d delay %d time %d\n", e->synth, (int)roundf(e->midi_note), instrument_noteon_delay_ms(e->synth), e->time);
         }
     } else {
         // Not note on/off, treat the synth as a shorthand for *all* the voices.
@@ -1046,7 +1046,7 @@ uint8_t patches_voices_for_event(amy_event *e, uint16_t voices[]) {
 // So i know that the patch / voice alloc already exists and the patch has already been set!
 void patches_event_has_voices(amy_event *e, struct delta **queue) {
     peek_stack("has_voices");
-    //fprintf(stderr, "patches_event_has_voices:\n");
+    //amy_printf("patches_event_has_voices:\n");
     //fprintf_event_stderr(e);
 
     patches_grab_synth_tier(e);
@@ -1072,7 +1072,7 @@ void patches_event_has_voices(amy_event *e, struct delta **queue) {
         uint8_t velocity = 255;   // fake-note-on magic value.
         if (AMY_IS_SET(e->velocity)) velocity = (uint8_t) MIN(127, 127.1f * e->velocity);
         bytes[2] = velocity;
-        //fprintf(stderr, "time %.3f synth %d flags %d note %.1f vel %.3f: MIDI cmd 0x%02x 0x%02x 0x%02x\n", amy_global.time, instrument, synth_flags, e->midi_note, e->velocity, bytes[0], bytes[1], bytes[2]);
+        //amy_printf("time %.3f synth %d flags %d note %.1f vel %.3f: MIDI cmd 0x%02x 0x%02x 0x%02x\n", amy_global.time, instrument, synth_flags, e->midi_note, e->velocity, bytes[0], bytes[1], bytes[2]);
         // Remove the note and vel that we've put in the MIDI event, but keep any other event flags.
         AMY_UNSET(e->midi_note);
         AMY_UNSET(e->velocity);
@@ -1106,7 +1106,7 @@ void patches_event_has_voices(amy_event *e, struct delta **queue) {
                     }
                     AMY_UNSET(e->osc);
                 }
-                //fprintf(stderr, "patches: synth %d voice %d osc %d wav %d note %d vel %d\n", synth, voices[i], target_osc, e->wave, (int)e->midi_note, (int)(127.f * e->velocity));
+                //amy_printf("patches: synth %d voice %d osc %d wav %d note %d vel %d\n", synth, voices[i], target_osc, e->wave, (int)e->midi_note, (int)(127.f * e->velocity));
             }
         }
     }
@@ -1136,11 +1136,11 @@ void schedule_osc_reset(uint32_t time, uint16_t osc, struct delta **queue) {
 
 void release_voice_oscs(int32_t voice, uint32_t time) {
     if(AMY_IS_SET(voice_to_base_osc[voice])) {
-        //fprintf(stderr, "Already set voice %d, removing it\n", voice);
+        //amy_printf("Already set voice %d, removing it\n", voice);
         // Remove the oscs for this old voice
         for(uint16_t i=0;i<AMY_OSCS;i++) {
             if(osc_to_voice[i]==voice) {
-                //fprintf(stderr, "Already set voice %d osc %d, removing it\n", voices[v], i);
+                //amy_printf("Already set voice %d osc %d, removing it\n", voices[v], i);
                 AMY_UNSET(osc_to_voice[i]);
                 // Make sure the osc is cleared.
                 schedule_osc_reset(time, i, NULL);
@@ -1156,7 +1156,7 @@ uint8_t patches_voices_for_load_synth(amy_event *e, uint16_t voices[]) {
     uint16_t requested_voices = e->num_voices;
     // If the instrument is alread initialized, copy the voice numbers.
     int num_voices = instrument_get_num_voices(e->synth, voices);
-    //fprintf(stderr, "patches_voices_for_load: e->num_voices %d num_voices %d\n", e->num_voices, num_voices);
+    //amy_printf("patches_voices_for_load: e->num_voices %d num_voices %d\n", e->num_voices, num_voices);
     if (num_voices == 0 && AMY_IS_UNSET(requested_voices)) {
         // New alloc without specifying num_voices - default to 1
         requested_voices = 1;
@@ -1175,7 +1175,7 @@ uint8_t patches_voices_for_load_synth(amy_event *e, uint16_t voices[]) {
                 ++v;
             }
             if (v == amy_global.config.max_voices)  {
-                fprintf(stderr, "ran out of voices allocating %" PRId32 " voices to synth %" PRId32 ", ignoring.",
+                amy_printf("ran out of voices allocating %" PRId32 " voices to synth %" PRId32 ", ignoring.",
                         (int32_t)requested_voices, (int32_t)e->synth);
                 patches_debug();
                 return 0;
@@ -1195,12 +1195,12 @@ uint8_t patches_voices_for_load_synth(amy_event *e, uint16_t voices[]) {
             AMY_UNSET(e->synth);
             return 0;
         }
-        //fprintf(stderr, "Allocated %d voices to instrument %d\n", num_voices, e->synth);
+        //amy_printf("Allocated %d voices to instrument %d\n", num_voices, e->synth);
     }
     //for (int i = 0; i < num_voices; ++i) {
-    //    fprintf(stderr, "%d; ", voices[i]);
+    //    amy_printf("%d; ", voices[i]);
     //}
-    //fprintf(stderr, "\n");
+    //amy_printf("\n");
     return num_voices;
 }
 
@@ -1215,12 +1215,12 @@ void patches_load_patch(amy_event *e) {
     uint8_t num_voices = 0;
     uint16_t oscs_per_voice = 0;
     uint16_t patch_number = e->patch_number;   // Need to match type of e->patch_number so AMY_IS_UNSET(patch_number) will work.
-    //fprintf(stderr, "load_patch synth %d patch_number %d num_voices %d oscs_per_voice %d\n", e->synth, e->patch_number, e->num_voices, e->oscs_per_voice);
+    //amy_printf("load_patch synth %d patch_number %d num_voices %d oscs_per_voice %d\n", e->synth, e->patch_number, e->num_voices, e->oscs_per_voice);
     num_voices = patches_voices_for_load_synth(e, voices);
     if (num_voices == 0) {
         if (AMY_IS_UNSET(e->num_voices)) {
             // Print a warning unless we deliberately set the voices to zero to release the synth.
-            fprintf(stderr, "synth %" PRId32 ": no voices selected, ignored (e->num_voices %" PRId32 "...)\n",
+            amy_printf("synth %" PRId32 ": no voices selected, ignored (e->num_voices %" PRId32 "...)\n",
                     (int32_t)e->synth, (int32_t)e->num_voices);
         }
         return;
@@ -1245,7 +1245,7 @@ void patches_load_patch(amy_event *e) {
     if (AMY_IS_SET(e->oscs_per_voice)) {
         oscs_per_voice = e->oscs_per_voice;
         if (AMY_IS_SET(patch_number)) {
-            fprintf(stderr, "WARN: synth %" PRId32 ": oscs_per_voice %" PRIu16 " made me ignore patch number %" PRIu16 "\n",
+            amy_printf("WARN: synth %" PRId32 ": oscs_per_voice %" PRIu16 " made me ignore patch number %" PRIu16 "\n",
                     (int32_t)e->synth, e->oscs_per_voice, patch_number);
         }
     } else {
@@ -1256,7 +1256,7 @@ void patches_load_patch(amy_event *e) {
             // before the drum kit bank at 384 -- and ends well before the user
             // range, so check both before dereferencing.
             if (patch_number >= _PATCHES_NUM_BUILTIN || patch_commands[patch_number] == NULL) {
-                fprintf(stderr, "patch_number %" PRIu16 " is not a defined built-in patch (synth %" PRId32 "), ignored\n",
+                amy_printf("patch_number %" PRIu16 " is not a defined built-in patch (synth %" PRId32 "), ignored\n",
                         patch_number, (int32_t)e->synth);
                 return;
             }
@@ -1269,7 +1269,7 @@ void patches_load_patch(amy_event *e) {
             if(oscs_per_voice > 0){
                 deltas = memory_patch_deltas[patch_index];
             } else {
-                fprintf(stderr, "patch_number %" PRIu16 " has %" PRIu16 " num_deltas %" PRIi32 " (synth %" PRId32 " num_voices %" PRId32 "), ignored\n",
+                amy_printf("patch_number %" PRIu16 " has %" PRIu16 " num_deltas %" PRIi32 " (synth %" PRId32 " num_voices %" PRId32 "), ignored\n",
                         patch_number, oscs_per_voice, delta_list_len(memory_patch_deltas[patch_index]),
                         (int32_t)e->synth, (int32_t)e->num_voices);
                 return;
@@ -1307,10 +1307,10 @@ void patches_load_patch(amy_event *e) {
                 ++available_oscs;
             }
             if(available_oscs == oscs_per_voice) {
-                //fprintf(stderr, "found %d consecutive oscs starting at %d for voice %d\n", oscs_per_voice, base_osc, voices[v]);
+                //amy_printf("found %d consecutive oscs starting at %d for voice %d\n", oscs_per_voice, base_osc, voices[v]);
                 voice_to_base_osc[voices[v]] = base_osc;
                 for(uint16_t osc = base_osc; osc < base_osc + oscs_per_voice; ++osc) {
-                    //fprintf(stderr, "setting osc %d for voice %d to amy osc %d\n", osc - base_osc, voices[v], osc);
+                    //amy_printf("setting osc %d for voice %d to amy osc %d\n", osc - base_osc, voices[v], osc);
                     osc_to_voice[osc] = voices[v];
                     schedule_osc_reset(e->time, osc, NULL);
                 }
@@ -1319,7 +1319,7 @@ void patches_load_patch(amy_event *e) {
             }
         }
         if(!found) {
-            fprintf(stderr, "cannot find %" PRIu16 " oscs for patch %" PRIu16 " for voice %" PRIu16 ". not setting this voice\n",
+            amy_printf("cannot find %" PRIu16 " oscs for patch %" PRIu16 " for voice %" PRIu16 ". not setting this voice\n",
                     oscs_per_voice, patch_number, voices[v]);
         }
     }  // end of loop setting up voice_to_base_osc for all voices[v]

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -231,7 +231,7 @@ void pcm_note_off(uint16_t osc) {
 
 
 uint32_t fill_sample_from_file(memorypcm_preset_t *preset_p, uint32_t frames_needed) {
-    //fprintf(stderr, "fsff %ld frames\n", frames_needed);
+    //amy_printf("fsff %ld frames\n", frames_needed);
     uint32_t bytes_per_frame = preset_p->channels * 2;
     uint32_t frames_available = 0;
     if (bytes_per_frame > 0) {
@@ -350,7 +350,7 @@ SAMPLE render_pcm(SAMPLE* buf, uint16_t osc) {
             if (value < 0) value = -value;
             if (value > max_value) max_value = value;  
         }
-        //printf("render_pcm: osc %d preset %d len %d base_ix %d phase %f step %f tablestep %f amp %f\n",
+        //amy_printf("render_pcm: osc %d preset %d len %d base_ix %d phase %f step %f tablestep %f amp %f\n",
         //       osc, synth[osc]->preset, preset->length, base_index, P2F(synth[osc]->phase), P2F(step), (1 << PCM_INDEX_BITS) * P2F(step), S2F(msynth[osc]->amp));
         return max_value; 
         // i don't believe we ever need to detect silence in a sample. it will shut itself off at the end.
@@ -381,18 +381,18 @@ int pcm_load_file() {
         return 0;
     }
     if (amy_global.config.amy_external_fopen_hook == NULL || amy_global.config.amy_external_fclose_hook == NULL) {
-        fprintf(stderr, "fopen hook not enabled on platform\n");
+        amy_printf("fopen hook not enabled on platform\n");
         return 0;
     }
     uint32_t handle = amy_global.config.amy_external_fopen_hook((char *)filename, "rb");
     if (handle == 0) {
-        fprintf(stderr, "Could not open file %s\n", filename);
+        amy_printf("Could not open file %s\n", filename);
         return 0;
     }
     wave_info_t info = {0};
     uint32_t data_bytes = 0;
     if (!wave_parse_header(handle, &info, &data_bytes)) {
-        fprintf(stderr, "Could not parse WAVE file %s\n", filename);
+        amy_printf("Could not parse WAVE file %s\n", filename);
         amy_global.config.amy_external_fclose_hook(handle);
         return 0;
     }
@@ -405,7 +405,7 @@ int pcm_load_file() {
         sizeof(memorypcm_ll_t) + sizeof(memorypcm_preset_t) + buffer_frames * sizeof(int16_t),
         amy_global.config.ram_caps_sample);
     if (new_preset_pointer == NULL) {
-        fprintf(stderr, "No RAM left for sample load\n");
+        amy_printf("No RAM left for sample load\n");
         return 0;
     }
     new_preset_pointer->next = memorypcm_ll_start;
@@ -426,7 +426,7 @@ int pcm_load_file() {
     memory_preset->sample_ram = malloc_caps(buffer_frames * info.channels * sizeof(int16_t),
                                                      amy_global.config.ram_caps_sample);
     new_preset_pointer->preset = memory_preset;
-    //fprintf(stderr, "read file %s frames %ld channels %d preset %d handle %ld\n", filename, total_frames, info.channels, preset_number, handle);
+    //amy_printf("read file %s frames %ld channels %d preset %d handle %ld\n", filename, total_frames, info.channels, preset_number, handle);
     return 1;
 }
 
@@ -441,7 +441,7 @@ int16_t * pcm_load(uint16_t preset_number, uint32_t length, uint32_t samplerate,
     memorypcm_ll_t *new_preset_pointer = malloc_caps(sizeof(memorypcm_ll_t) + sizeof(memorypcm_preset_t) + length * channels * sizeof(int16_t),
 						     amy_global.config.ram_caps_sample);
     if(new_preset_pointer  == NULL) {
-        fprintf(stderr, "No RAM left for sample load\n");
+        amy_printf("No RAM left for sample load\n");
         return NULL; // no ram for sample
     }
     new_preset_pointer->next = memorypcm_ll_start;
@@ -484,7 +484,7 @@ void pcm_unload_preset(uint16_t preset_number) {
             preset_pointer = &(*preset_pointer)->next;
         }
     }
-    //fprintf(stderr, "pcm_unload_preset: preset %d not found\n", preset_number);  // This happens during a routine load_preset.
+    //amy_printf("pcm_unload_preset: preset %d not found\n", preset_number);  // This happens during a routine load_preset.
 }
 
 void pcm_unload_all_presets() {

--- a/src/sequencer.c
+++ b/src/sequencer.c
@@ -96,10 +96,10 @@ void sequencer_deinit() {
 void sequencer_debug() {
     int32_t n_active = 0;
     for (int32_t t = first_active; t != -1; t = sequences[t].next_active) ++n_active;
-    fprintf(stderr, "sequencer: max_sequences %" PRIi32" active %" PRIi32 "\n", max_sequences, n_active);
+    amy_printf("sequencer: max_sequences %" PRIi32" active %" PRIi32 "\n", max_sequences, n_active);
     for (int32_t tag = first_active; tag != -1; tag = sequences[tag].next_active) {
         if (sequences[tag].wire) {
-            fprintf(stderr, "sequence tag %" PRIi32"%s tick %" PRIu32 " period %"PRIu32 " wire \"%s\"\n",
+            amy_printf("sequence tag %" PRIi32"%s tick %" PRIu32 " period %"PRIu32 " wire \"%s\"\n",
                     tag, tag >= max_sequences ? " (anon)" : "", sequences[tag].tick, sequences[tag].period, sequences[tag].wire);
         }
     }
@@ -179,7 +179,7 @@ uint8_t sequencer_add_wire(uint32_t tick, uint32_t period, uint32_t tag, bool ha
     }
     if (has_tag) {
         if (tag >= (uint32_t)max_sequences) {
-            fprintf(stderr, "sequencer tag %" PRIu32" (with tick %" PRIu32", period %" PRIu32") is greater than or eq max_sequences %" PRIi32"\n",
+            amy_printf("sequencer tag %" PRIu32" (with tick %" PRIu32", period %" PRIu32") is greater than or eq max_sequences %" PRIi32"\n",
                     tag, tick, period, max_sequences);
             free(wire);
             return 0;

--- a/src/transfer.c
+++ b/src/transfer.c
@@ -235,12 +235,12 @@ void start_receiving_file_transfer(uint32_t length, const char *filename) {
     }
     if (amy_global.config.amy_external_fopen_hook == NULL || amy_global.config.amy_external_fwrite_hook == NULL || amy_global.config.amy_external_fclose_hook == NULL) {
 
-        fprintf(stderr, "file transfer hooks not enabled on platform\n");
+        amy_printf("file transfer hooks not enabled on platform\n");
         return;
     }
         uint32_t handle = amy_global.config.amy_external_fopen_hook((char *)filename, "wb");
     if (handle == HANDLE_INVALID) {
-        fprintf(stderr, "could not open file for transfer: %s\n", filename);
+        amy_printf("could not open file for transfer: %s\n", filename);
         return;
     }
     amy_global.transfer_flag = AMY_TRANSFER_TYPE_FILE;
@@ -553,7 +553,7 @@ static int _zdump_stream_init(_zdump_stream *c) {
     c->enc     = (uint8_t *)malloc_caps(ZDUMP_CHUNK_B64_MAX + 4, amy_global.config.ram_caps_sysex);
     c->frame   = (uint8_t *)malloc_caps(ZDUMP_CHUNK_B64_MAX + 6, amy_global.config.ram_caps_sysex);
     if (!c->raw_buf || !c->enc || !c->frame) {
-        fprintf(stderr, "zD: stream init malloc failed (raw=%p enc=%p frame=%p)\n",
+        amy_printf("zD: stream init malloc failed (raw=%p enc=%p frame=%p)\n",
                 (void *)c->raw_buf, (void *)c->enc, (void *)c->frame);
         return -1;
     }
@@ -652,13 +652,13 @@ void amy_dump_file_to_sysex(const char *filename) {
     if (!amy_global.config.amy_external_fopen_hook ||
         !amy_global.config.amy_external_fread_hook  ||
         !amy_global.config.amy_external_fclose_hook) {
-        fprintf(stderr, "zD: file I/O hooks unavailable\n");
+        amy_printf("zD: file I/O hooks unavailable\n");
         sequencer_midi_start();
         return;
     }
     uint32_t fh = amy_global.config.amy_external_fopen_hook((char *)filename, "r");
     if (!fh) {
-        fprintf(stderr, "zD: could not open '%s'\n", filename);
+        amy_printf("zD: could not open '%s'\n", filename);
         sequencer_midi_start();
         return;
     }
@@ -670,7 +670,7 @@ void amy_dump_file_to_sysex(const char *filename) {
     }
     uint8_t *read_buf = (uint8_t *)malloc_caps(ZDUMP_STREAM_RAW_CHUNK, amy_global.config.ram_caps_sysex);
     if (!read_buf) {
-        fprintf(stderr, "zD: malloc read_buf(%d) FAILED\n", ZDUMP_STREAM_RAW_CHUNK);
+        amy_printf("zD: malloc read_buf(%d) FAILED\n", ZDUMP_STREAM_RAW_CHUNK);
         _zdump_stream_destroy(&stream);
         amy_global.config.amy_external_fclose_hook(fh);
         sequencer_midi_start();


### PR DESCRIPTION
AMY's warnings — "note off does not match note on", parse errors, the debug dumps — were unconditional `fprintf(stderr, ...)`/`printf(...)` calls. On microcontrollers those are blocking serial writes in or near the render path, and their format strings cost flash.

## The change

All **245** diagnostic print sites in the core sources now go through one macro, `amy_printf()` in amy.h:

- **`AMY_PRINT` defined** → `fprintf(stderr, ...)`, exactly as before.
- **Not defined (the default)** → the call sits behind `if (0)`, so the arguments stay type- and format-checked and count as used (no `-Wunused-*` warnings on any of the strict targets), while every optimizing build strips both the call and its strings. Verified with `strings` on the desktop binary: with `AMY_PRINT` unset, "does not match note on" et al. are gone from the executable — so this saves flash as well as runtime.

## Who prints, by default

- **CPython** (`setup.py`): `-DAMY_PRINT` — behavior unchanged, warnings still appear.
- **Everything else** (Arduino, web, Godot, the desktop Makefile targets): silent. Opt back in with `-DAMY_PRINT` in your build flags.

## Deliberately untouched

- `amy_oom()` still **counts** OOMs unconditionally (`amy_get_oom_count()` keeps working headlessly); only its one-time report is gated.
- `AMY_PROFILE_PRINT` only exists under `AMY_DEBUG`, an explicit developer build, so it keeps its raw `fprintf`.
- `amy-example` / `amy-message` / `amy-piano` / `pyamy.c` are desktop-only user-facing programs and keep their own prints, as do the ctests in `tests/`.
- Vendored `miniaudio.h` untouched.

## Testing

- `make test`: **122 WAV tests pass bit-exact** (CPython build, prints on).
- `make ctest`: all three suites pass (built without `AMY_PRINT`, so they also prove the behavior-not-output contract of the sequencer tests).
- `make amy-example`: builds warning-free with the macro compiled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)