### PR TITLE
sequencer: a due or overdue one-off ticks= plays now, not never

### DIFF
--- a/src/sequencer.c
+++ b/src/sequencer.c
@@ -172,6 +172,9 @@ void sequencer_recompute() {
 // instead of the given tag value, so it's stored but not addressable or
 // individually cancelable. has_tag true is the normal tag-indexed form: tick
 // and period both zero clears that tag's entry (the only way to cancel one).
+//
+// A one-off whose tick is already due or overdue is not stored at all -- it
+// plays immediately, before returning.  See the comment at that branch.
 uint8_t sequencer_add_wire(uint32_t tick, uint32_t period, uint32_t tag, bool has_tag, char *wire) {
     if (sequences == NULL) {  // sequencer_init hasn't run
         free(wire);
@@ -201,11 +204,30 @@ uint8_t sequencer_add_wire(uint32_t tick, uint32_t period, uint32_t tag, bool ha
     sequences[tag].tick = 0;
     sequences[tag].period = 0;
     active_unlink(tag);   // out of the list while it has nothing in it
-    if ((tick == 0 && period == 0) ||  // Non-schedulable event: just clear the tag.
-        (tick != 0 && period == 0 && tick <= amy_global.sequencer_tick_count)) {  // don't schedule things in the past.
+    if (tick == 0 && period == 0) {  // Non-schedulable event: just clear the tag.
         amy_release_lock();
         free(wire);
         return 0;
+    }
+    if (period == 0 && tick <= amy_global.sequencer_tick_count) {
+        // A one-off that is already due or overdue.  Play it NOW rather than
+        // dropping it: a caller that reads the tick clock and schedules
+        // relative to it always runs a little after the tick it read (every
+        // Python path arrives via a deferred callback), and at 48 PPQ any
+        // offset under a tick rounds straight back onto the current count.
+        // Dropping made that lost race silent -- it is what made the Tulip
+        // arpeggiator play nothing at all.  Late by a fraction of a tick beats
+        // never, and it restores what the old millisecond time= did with a
+        // past-due event.  NB tick==0 is the cancel form, handled above, so it
+        // never reaches here.
+        //
+        // Play outside the lock and free after, exactly as the tick loop does:
+        // amy_queue_lock is a plain non-recursive mutex and amy_play_message()
+        // re-enters the parser, which can land back in this function.
+        amy_release_lock();
+        amy_play_message(wire);
+        free(wire);
+        return 1;
     }
     sequences[tag].tick = tick;
     sequences[tag].period = period;
@@ -235,8 +257,15 @@ static void sequencer_process_tick(void) {
                 uint32_t offset = amy_global.sequencer_tick_count % sequences[tag].period;
                 if (offset == sequences[tag].tick) hit = true;
             } else {
-                // Test for absolute tick (no period set)
-                if (sequences[tag].tick == amy_global.sequencer_tick_count) { hit = true; delete = true; }
+                // Test for absolute tick (no period set).  <= rather than ==:
+                // the walk above runs without the lock, and a stale link can
+                // make it skip an entry for a single tick (see the thread
+                // safety note).  Under ==, a slot skipped on exactly its tick
+                // would sit there forever, holding an anon slot and never
+                // playing.  <= lets it fire on the next tick instead, matching
+                // the play-it-late rule sequencer_add_wire() uses for a
+                // one-off that is already due when it arrives.
+                if (sequences[tag].tick <= amy_global.sequencer_tick_count) { hit = true; delete = true; }
             }
             if(hit) {
                 // Take the message out (one-shot) or a copy of it (repeating)


### PR DESCRIPTION
## The problem

A one-off `ticks=` whose tick has already passed is **silently dropped**:

```c
(tick != 0 && period == 0 && tick <= amy_global.sequencer_tick_count)  // don't schedule things in the past.
    -> free(wire); return 0;
```

and belt-and-braces, the tick loop only fired one-offs on exact equality (`tick == count`), so even a stored past tick could never play.

This race is easy to lose and impossible to see:

- Every Python path into the sequencer arrives via a deferred callback (`mp_sched_schedule`, `tulip.defer`, MIDI callbacks), so a caller that reads the tick clock and schedules relative to it **always** runs a little after the tick it read.
- At 48 PPQ, any offset under one tick (~11.6 ms at the default 108 BPM) rounds straight back onto the current count.

It's what made the Tulip arpeggiator play *nothing at all*, with no error to go on — see shorepine/tulipcc#1266. It's also a regression against the millisecond `time=` this replaced, which played a past-due event immediately.

## The change

Play it, a fraction of a tick late, rather than dropping it.

- `sequencer_add_wire()` plays a due/overdue one-off immediately instead of storing or dropping it. The play happens **outside the lock** with the wire freed after, exactly as the tick loop does — `amy_queue_lock` is a plain non-recursive mutex and `amy_play_message()` re-enters the parser, which can land back in this function.
- The tick loop fires one-offs at `tick <= count`. The active-list walk runs without the lock and a stale link can make it skip an entry for a single tick (already documented in the thread-safety note); under `==` such an entry would sit there forever, holding an anonymous slot and never playing.

`tick == 0 && period == 0` is the **cancel** form and is handled before the new branch, so cancelling a tag still cancels — tick 0 is in the past for any running sequencer, and must not be swallowed by the new rule.

## Testing

`make test`: **122 tests pass, bit-exact** (`err=-100.0 dB`), including `TestSequencer`, `TestSequencedSynthDrums`, `TestSequencerOsc`.

Behavior, verified directly (peak amplitude over 1s, note scheduled relative to a tick count of 25):

| case | tick | before | after |
|---|---|---|---|
| future (+20) | 45 | 0.1227 | 0.1227 |
| current tick | 25 | **0.0000** | 0.1224 |
| past (-5) | 20 | **0.0000** | 0.1224 |
| past (-20) | 5 | **0.0000** | 0.1224 |
| cancelled tag | — | 0.0000 | 0.0000 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)