### PR TITLE
daisy: stagger midi_polyphony in real time; local libDaisy paths [skip release]

### DIFF
--- a/daisy/Makefile
+++ b/daisy/Makefile
@@ -13,8 +13,8 @@ C_SOURCES = ${AMY}/amy.c ${AMY}/oscillators.c ${AMY}/algorithms.c ${AMY}/envelop
 C_INCLUDES += -I${AMY} -DAMY_DAISY -Wno-strict-aliasing -Wextra -Wno-unused-parameter -Wpointer-arith -Wno-float-conversion -Wno-missing-declarations
 
 # Library Locations
-LIBDAISY_DIR = ${HOME}/Desktop/DaisyExamples/libDaisy
-DAISYSP_DIR = ${HOME}/Desktop/DaisyExamples/DaisySP
+LIBDAISY_DIR = ${HOME}/github/electro-smith/libDaisy
+DAISYSP_DIR = ${HOME}/github/electro-smith/DaisySP
 
 # Core location, and generic makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core

--- a/daisy/amy_daisy.cpp
+++ b/daisy/amy_daisy.cpp
@@ -52,15 +52,13 @@ void test_audio_in() {
 
 void midi_polyphony(uint16_t patch) {
     // Play mulitple notes via note-ons to MIDI channel 1.
-    // These all sound at once: a MIDI message carries no scheduling time, it
-    // plays when it arrives. To stagger them, space the calls in real time --
-    // or drive amy_events with e.time, as event_polyphony() below does.
     uint8_t data[3] = {0x90, 0x00, 0x7f};
     uint8_t note = 40;
     for(uint8_t i=0;i<15;i++) {
 	data[1] = note;
 	amy_event_midi_message_received(data, 3, 0);
         note += 2;
+        System::DelayMs(1000);
     }
 }
 


### PR DESCRIPTION
Two small Daisy-only changes. Nothing here is compiled by any CI target — the Daisy port builds out of tree against a local libDaisy — hence `[skip release]`.

### `midi_polyphony()` gets its stagger back

#1040 removed the `time` argument from `amy_event_midi_message_received()`, because a live MIDI message carries no scheduling time — it plays when it arrives. That left `midi_polyphony()` firing all 15 notes at once, where it used to space them a second apart.

Restores the spacing with `System::DelayMs(1000)`, which does in real time what the old argument only appeared to do.

### Local libDaisy paths

Points `LIBDAISY_DIR` / `DAISYSP_DIR` at `~/github/electro-smith/{libDaisy,DaisySP}`.

Worth being explicit: these are just as machine-specific as the `~/Desktop/DaisyExamples/...` paths they replace. There's no in-tree default — whoever builds the Daisy port edits these to wherever they keep libDaisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
