### PR TITLE
Don't tear down AMY before validating live() kwargs

### DIFF
--- a/src/api.c
+++ b/src/api.c
@@ -526,7 +526,15 @@ extern void miniaudio_start();
 extern void miniaudio_stop();
 #endif
 
+// Tracks whether the allocations made by amy_start() are still live, so that
+// amy_stop() is idempotent: calling it twice in a row (e.g. a rejected live()
+// followed by another live(), or amy.stop() twice from Python) would otherwise
+// double-free the bus, filter, and osc arrays, which the deinit paths free
+// without NULLing.
+static uint8_t amy_started = 0;
+
 void amy_start(amy_config_t c) {
+    amy_started = 1;
     global_init(c);
     amy_profiles_init();
     transfer_init();
@@ -547,6 +555,8 @@ void amy_start(amy_config_t c) {
 }
 
 void amy_stop() {
+    if (!amy_started) return;
+    amy_started = 0;
 #if !defined(ESP_PLATFORM) && !defined(PICO_ON_DEVICE) && !defined(ARDUINO) && !defined(AMY_NO_MINIAUDIO)
     if (amy_global.config.audio == AMY_AUDIO_IS_MINIAUDIO)
         miniaudio_stop();

--- a/src/pyamy.c
+++ b/src/pyamy.c
@@ -140,7 +140,9 @@ static int parse_live_kwarg(amy_config_t *cfg, const char *key, PyObject *value)
 }
 
 static PyObject * live_wrapper(PyObject *self, PyObject *args, PyObject *kwargs) {
-    amy_stop();
+    // Parse and validate every kwarg into a local config BEFORE tearing down the
+    // running AMY: a rejected kwarg then leaves audio playing instead of
+    // silently killing it (and leaving AMY stopped for the next live() call).
     amy_config_t amy_config = amy_default_config();
     Py_ssize_t pos = 0;
     PyObject *key_obj = NULL;
@@ -160,7 +162,8 @@ static PyObject * live_wrapper(PyObject *self, PyObject *args, PyObject *kwargs)
     }
 
     amy_config.audio = AMY_AUDIO_IS_MINIAUDIO;
-    amy_start(amy_config); // initializes amy 
+    amy_stop();
+    amy_start(amy_config); // initializes amy
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
## The bug

`live_wrapper()` in `src/pyamy.c` called `amy_stop()` as its very first statement, before parsing or validating any config kwargs. If a kwarg was rejected, AMY was left stopped, and a second `live()` call ran `amy_stop()` again with no intervening `amy_start()`.

That double-stop is a double-free: `global_deinit()` frees `amy_global.bus[0]` and `filters_deinit()` frees the EQ coef/delay arrays without NULLing the pointers, and `oscs_deinit()` frees `fbl`/`per_osc_fb`/`synth`/`msynth` the same way. The second `live()` killed the interpreter with SIGABRT.

```python
import amy
try: amy.live(max_oscs=-5)
except Exception as e: print('1st:', e)
try: amy.live(max_oscs=-5)   # <-- crashed the interpreter
except Exception as e: print('2nd:', e)
```

Pre-existing on `main`, reproducible with any invalid kwarg.

## What changed

**`src/pyamy.c`** — `live_wrapper()` parses and validates every kwarg into the local `amy_config_t` first, and only calls `amy_stop()` immediately before `amy_start()`, once the config is known good. A rejected kwarg now leaves the running AMY untouched instead of silently killing audio.

**`src/api.c`** — `amy_stop()` is idempotent, guarded by a new file-static `amy_started` flag set in `amy_start()`. This also fixes a second reachable crash on the same double-free: `c_amy.stop()` twice in a row, since `amystop_wrapper()` calls `amy_stop()` unguarded.

## Reviewer notes

- I added a new flag rather than reusing `amy_global.running` — that one is the miniaudio audio-thread flag, not an "initialized" flag.
- Every existing `amy_stop()` caller pairs it with a start (`parse.c`'s `RESET_AMY` path, `amy-example.c`, the Godot extension's `stop()`/destructor, both of which already guard on their own `initialized`), so the new guard is a no-op for them.
- The guard is a file-static in `api.c`, so no change to `amy_config_t`/`amy_global` layout — nothing for the Godot or Arduino builds to pick up.

## Verification

All on the same interpreter (the Makefile's `${PYTHON}`; note a bare `python3` may resolve to a different install with a stale `c_amy.so`):

- The repro above exits **133** on the stashed/pre-fix build and **0** after.
- Four consecutive rejected `live()` calls (`max_oscs=-5` twice, `ks_oscs=999`, an unknown kwarg), then `amy.render(0.1)` still returns 4352 samples — confirming AMY stayed running through the rejections.
- `stop(); stop(); stop()` and a `start()`/`stop()` round trip are clean.
- `make qtest`: 124 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)