### PR TITLE
Don't advance the sequencer from `amy_event_to_deltas_queue()` - fixes a tick race and hook-thread surprise for multithreaded embedders

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -643,6 +643,8 @@ float map_01_to_60dBf(float log) {
 #define EVENT_TO_DELTA_FREQ_COEFS(FIELD, FLAG) \
     EVENT_TO_DELTA_COEFS_COEF0_SPECIAL(FIELD, FLAG, logfreq_of_freq)
 
+static void flush_due_deltas();  // definition next to amy_execute_deltas()
+
 // Add a API facing event, convert into delta directly
 void amy_event_to_deltas_queue(amy_event *e, uint16_t base_osc, struct delta **queue) {
     // fprintf(stderr, "time %.3f amy_event_to_deltas: base_osc %d\n", amy_global.time, base_osc);
@@ -694,7 +696,10 @@ void amy_event_to_deltas_queue(amy_event *e, uint16_t base_osc, struct delta **q
     // you must set both synth & load_patch together to load a patch 
     if (AMY_IS_SET(e->synth)) {
         if (AMY_IS_SET(e->patch_number) || AMY_IS_SET(e->num_voices) || AMY_IS_SET(e->oscs_per_voice)) {
-            amy_execute_deltas();
+            // Settle pending deltas without running the sequencer tick
+            // service - this can execute on any sending thread (see
+            // flush_due_deltas).
+            flush_due_deltas();
             patches_load_patch(e);
         }
         // Execute any other commands in this event.
@@ -2031,15 +2036,13 @@ AMY_IRAM_ATTR void amy_render(uint16_t start, uint16_t end, uint8_t core) {
 }
 
 
-// this takes scheduled deltas and plays them at the right time
-void amy_execute_deltas() {
-    AMY_PROFILE_START(AMY_EXECUTE_DELTAS)
-    // Advance the sequencer on AMY (sample) time and play any due sequence
-    // events, so sequencing works in any rendering context, real-time or not.
-    sequencer_check_and_fill();
-    // Make sure any CV-triggered events are added to delta queue
-    update_external_cv_in();
-
+// Play any deltas that are due, without advancing the sequencer. Split out
+// of amy_execute_deltas() so the event-ingest path can settle deltas before
+// a patch load: events may arrive on any thread, and the sequencer tick
+// service is rendering-context-only (unguarded RMW on next_amy_tick_us, and
+// the external hook expects audio-thread context). Everything here is under
+// the queue lock - safe from any thread.
+static void flush_due_deltas() {
     // check to see which sounds to play
     uint32_t sysclock = amy_sysclock();
     amy_grab_lock();
@@ -2054,7 +2057,17 @@ void amy_execute_deltas() {
     amy_global.delta_queue = d;
 
     amy_release_lock();
+}
 
+// this takes scheduled deltas and plays them at the right time
+void amy_execute_deltas() {
+    AMY_PROFILE_START(AMY_EXECUTE_DELTAS)
+    // Advance the sequencer on AMY (sample) time and play any due sequence
+    // events, so sequencing works in any rendering context, real-time or not.
+    sequencer_check_and_fill();
+    // Make sure any CV-triggered events are added to delta queue
+    update_external_cv_in();
+    flush_due_deltas();
     AMY_PROFILE_STOP(AMY_EXECUTE_DELTAS)
 
 }


### PR DESCRIPTION
## Summary

When an event carries `patch_number` / `num_voices` / `oscs_per_voice`,
`amy_event_to_deltas_queue()` calls the full `amy_execute_deltas()`
before `patches_load_patch()`:

```c
if (AMY_IS_SET(e->synth)) {
    if (AMY_IS_SET(e->patch_number) || AMY_IS_SET(e->num_voices) || AMY_IS_SET(e->oscs_per_voice)) {
        amy_execute_deltas();
        patches_load_patch(e);
    }
```

What this call site needs is only the third thing `amy_execute_deltas()`
does: apply already-due deltas, so they land on the old voice topology
before the patch load reconfigures oscillators. But it also gets the
first two: `sequencer_check_and_fill()` (sequencer clock advance, tick
processing, the external sequencer hook) and `update_external_cv_in()`.
`amy_execute_deltas()`'s own comment scopes the sequencer advance to
rendering contexts ("so sequencing works in any rendering context,
real-time or not") - and `amy_event_to_deltas_queue()` runs in the
*sender's* context, which on any multithreaded embedder is not the
rendering thread.

This PR splits the due-delta flush into a static helper and calls only
that from the patch-load path. `amy_execute_deltas()` itself is
unchanged in behavior for every rendering caller.

## Bug 1: double/skipped sequencer ticks (data race)

`sequencer_check_and_fill()` does an unguarded check-then-advance on
`amy_global.next_amy_tick_us`:

```c
while(now_us >= amy_global.next_amy_tick_us) {
    if (sequencer_running) sequencer_process_tick();
    else midi_clock_out_tick();
    amy_global.next_amy_tick_us = amy_global.next_amy_tick_us + (uint64_t)amy_global.us_per_tick;
}
```

That is safe while only rendering calls it. But sending a patch event
from any other thread (UI, MIDI callback, network - the setups
`amy_grab_lock()` exists to support) runs this loop concurrently with
the audio thread's per-block call. Both threads can see the same due
tick: the tick is processed twice (sequence events double-emitted,
`sequencer_tick_count` double-counted, MIDI clock double-pulsed) and
`next_amy_tick_us` advances twice, so a later tick is silently skipped.
On 32-bit targets the 64-bit load/store isn't even single-copy-atomic,
so a torn read of `next_amy_tick_us` is also possible.

The race window is small per call but the trigger is routine: loading a
patch while the sequencer runs.

## Bug 2: the sequencer hook runs on the sender's thread

`sequencer_process_tick()` ends with:

```c
if(amy_global.config.amy_external_sequencer_hook != NULL) {
    amy_global.config.amy_external_sequencer_hook(amy_global.sequencer_tick_count);
}
```

With the current call site, an embedder's hook can fire in the middle of
that embedder's own `amy_add_event()` call, on whatever thread sent the
patch event. Hooks reasonably assume audio-thread context (that is where
every rendering-driven tick runs); a hook that emits events - the normal
thing for a sequencer callback to do - ends up calling `amy_add_event()`
from inside `amy_add_event()`. Nothing in the API surface suggests
registering a hook signs you up for arbitrary-thread reentrant callbacks.

## Why not fix it embedder-side?

An embedder has three ways to avoid this without a library change, and
each is worse than the two-line fix:

- Send all patch/voice events from the audio thread: patch-string
  parsing is a multi-millisecond, multi-KB-stack operation; putting it
  inside the render deadline causes dropouts on exactly the platforms
  (MCUs) most likely to hit this.
- Wrap all sends and rendering in one big exclusion lock: removes the
  data race but the hook still fires on the sending thread mid-send, and
  senders now block for up to a full render block.
- Stop the sequencer around patch loads: turns a supported concurrent
  operation into a transport glitch.

The root cause is that one function bundles "apply due deltas" (safe from
any thread, already guarded by `amy_grab_lock`) with "advance the
sequencer clock" (rendering-context-only by design). This PR just
separates the two.

## Fix

```c
// Apply any deltas that are already due. Safe to call from any thread
// (guarded by amy_grab_lock); unlike amy_execute_deltas() it does not
// advance the sequencer, which must only happen from rendering contexts.
static void flush_due_deltas() {
    uint32_t sysclock = amy_sysclock();
    amy_grab_lock();
    struct delta *d = amy_global.delta_queue;
    while(d && AMY_TIME_GEQ(sysclock, d->time)) {
        play_delta(d);
        d = delta_release(d);
        amy_global.delta_qsize--;
    }
    amy_global.delta_queue = d;
    amy_release_lock();
}

void amy_execute_deltas() {
    AMY_PROFILE_START(AMY_EXECUTE_DELTAS)
    // Advance the sequencer on AMY (sample) time and queue any due sequence
    // events, so sequencing works in any rendering context, real-time or not.
    sequencer_check_and_fill();
    // Make sure any CV-triggered events are added to delta queue
    update_external_cv_in();
    flush_due_deltas();
    AMY_PROFILE_STOP(AMY_EXECUTE_DELTAS)
}
```

and in `amy_event_to_deltas_queue()`:

```c
        if (AMY_IS_SET(e->patch_number) || AMY_IS_SET(e->num_voices) || AMY_IS_SET(e->oscs_per_voice)) {
            // Settle already-due deltas on the old voice topology, without
            // running the sequencer tick service in the sender's thread.
            flush_due_deltas();
            patches_load_patch(e);
        }
```

(A forward declaration of `flush_due_deltas` is needed above
`amy_event_to_deltas_queue`.)

## Behavior change

For rendering callers (`amy_render_audio`, `amy_simple_fill_buffer`,
the web worklet loop): none - `amy_execute_deltas()` is refactored, not
changed.

For the send path: loading a patch no longer advances the sequencer
clock as a side effect; ticks now advance only at rendering cadence. On
single-threaded builds that can delay a due tick by at most one render
block relative to today, and only when a patch load happens to land in
that window. An app that sends events but never renders would no longer
see its sequencer advance during sends - but such an app also produces
no audio, so nothing observable is lost. Flagging it for review in case
anyone knows of a setup relying on send-time tick advance.

## Testing

- Built and running on ESP32-S3 (FreeRTOS, patch events sent from a
  non-audio task while the sequencer runs and audio renders on another
  core) - the configuration that exposed both bugs.
- The race is deterministic to reason about but hard to catch in a unit
  test (sub-microsecond window); happy to add a test if there's an
  existing harness pattern for threaded sends you'd like it in.
