### PR TITLE
PCM: raise index fractional bits 8 -> 12 - fixes audible detune on pitched-down samples

### DIFF
--- a/src/pcm.c
+++ b/src/pcm.c
@@ -143,8 +143,12 @@ void pcm_deinit() {
     pcm_unload_all_presets();
 }
 
-// How many bits used for fractional part of PCM table index.
-#define PCM_INDEX_FRAC_BITS 8
+// How many bits used for fractional part of PCM table index. With 8 bits the
+// step quantizes to ratio * 256 LSBs - an audible pitch offset that grows as
+// a sample is shifted down (up to ~-85 cents three octaves below native).
+// 12 bits measures within 2 cents; 19 index bits still cover 524287 frames
+// (~10.9 s at 48 kHz), enforced in pcm_load().
+#define PCM_INDEX_FRAC_BITS 12
 // The number of bits used to hold the table index.
 #define PCM_INDEX_BITS (31 - PCM_INDEX_FRAC_BITS)
 
@@ -240,7 +244,7 @@ void pcm_note_on(uint16_t osc) {
             // note-on (start_frame / 2^PCM_INDEX_BITS).
             synth[osc]->phase = F2P(synth[osc]->trigger_phase);
         } else {
-            synth[osc]->phase = 0; // s16.15 index into the table; as if a PHASOR into a 16 bit sample table.
+            synth[osc]->phase = 0; // PCM_INDEX_BITS.PCM_INDEX_FRAC_BITS fixed-point index into the table.
         }
         // Copy the looping mode from the wave mode field.  Can be updated on note_off.
         msynth[osc]->state = synth[osc]->mode;
@@ -489,6 +493,13 @@ int pcm_load_file() {
 // set loopstart, loopend, midinote, samplerate (and log2sr)
 // return the allocated sample ram that AMY will fill in.
 int16_t * pcm_load(uint16_t preset_number, uint32_t length, uint32_t samplerate, uint8_t channels, uint8_t midinote, uint32_t loopstart, uint32_t loopend) {
+    // A length that overflows PCM_INDEX_BITS would wrap the phase
+    // accumulator during playback; refuse it up front.
+    if (length > (uint32_t)((1UL << PCM_INDEX_BITS) - 1)) {
+        fprintf(stderr, "Sample too long for PCM index (%u > %u frames)\n",
+                (unsigned)length, (unsigned)((1UL << PCM_INDEX_BITS) - 1));
+        return NULL;
+    }
     // if preset was already a memorypcm, we need to unload it
     pcm_unload_preset(preset_number); // this is a no-op if preset doesn't exist or is a const pcm
     // now alloc a new LL entry and preset (the old LL entry is removed with pcm_unload_preset)


### PR DESCRIPTION
## Summary

The PCM phase accumulator splits its 31 bits as 23 index / 8 fraction. Eight
fractional bits mean the playback step quantizes to `ratio * 256` LSBs and
the interpolation coefficient has only 256 levels. That quantization is
audible as a constant pitch offset that grows as the sample is pitched down.

Measured with a 22050 Hz sample (the TR-808 Bass Drum 1 ROM preset) on a
48 kHz engine, comparing rendered pitch against intent:

| played at | error, 8 frac bits | error, 12 frac bits |
|---|---|---|
| native pitch (midinote 60) | -8.9 cents | <= 2 cents |
| one octave down | -18 cents | <= 2 cents |
| three octaves down (drum floor) | -84.5 cents | <= 2 cents |

Worse than the absolute offset: at the bottom of the range the
*representable-pitch grid* is 90-120 cents coarse, so adjacent semitones
detune by wildly different amounts and pitched bass lines play out of tune
with themselves. (Octave ratios are exactly representable, which hides the
bug in octave-based tests.)

## Change

Split the phase 19.12 instead of 23.8: 16x finer step and interpolation
resolution. The index still covers 524287 frames (~10.9 s at 48 kHz), far
above every baked-in preset. `pcm_load()` now rejects lengths that would
wrap the smaller index range up front instead of glitching silently during
playback.

Zero render cost: the shift amounts are compile-time constants, the
per-sample instruction sequence is unchanged.

## Notes for review

- Noise floor is unchanged (the interp-coefficient zipper at 8 bits was
  already ~-90 dB on bass content; the audible defect is purely the pitch
  quantization).
- `trigger_phase` API interaction: a caller that sets a PCM start frame via
  `trigger_phase` computes it as `start_frame / 2^PCM_INDEX_BITS`, so the
  scaling of that value shifts 16x with this change. Grep of this repo found
  no first-party use that bakes the old constant, but external callers that
  hardcoded `2^23` would need the header constant instead.
- Verified by host-rendering the real ROM preset through the actual render
  path at device rates and measuring zero-crossing pitch against an
  exact-arithmetic reference; steady-state SNR table identical before/after
  except the corrected pitch.
