### PR TITLE
PCM: cancel the retrigger phase-snap click with a short decaying compensator

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -914,6 +914,8 @@ void reset_osc_state(struct synthinfo *psynth) {
     psynth->last_two[1] = 0;
     for(int j = 0; j < 2 * FILT_NUM_DELAYS; ++j) psynth->filter_delay[j] = 0;
     psynth->last_filt_norm_bits = 0;
+    psynth->pcm_last_out = 0;
+    psynth->pcm_declick = 0;
 }
 
 void reset_osc_by_pointer(struct synthinfo *psynth, struct mod_synthinfo *pmsynth) {

--- a/src/amy.h
+++ b/src/amy.h
@@ -642,6 +642,9 @@ struct synthinfo {
     uint8_t status;  // not in event
     uint8_t role;  // not in event
     PHASOR phase;  // not in event
+    // PCM retrigger declick (see pcm.c PCM_DECLICK_SHIFT)
+    SAMPLE pcm_last_out;  // not in event: last value this osc contributed
+    SAMPLE pcm_declick;   // not in event: decaying step compensator
     float step;  // not in event
     float substep;  // not in event
     uint32_t render_clock;

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -148,6 +148,12 @@ void pcm_deinit() {
 // The number of bits used to hold the table index.
 #define PCM_INDEX_BITS (31 - PCM_INDEX_FRAC_BITS)
 
+// Retrigger declick: re-onset of a still-sounding PCM osc snaps the phase,
+// stepping the output hard. Cancel the step with a decaying compensator
+// (declick -= declick >> shift per sample; shift 6 = tau 1.3 ms at 48 kHz,
+// completing within one block). Zero except just after a phase jump.
+#define PCM_DECLICK_SHIFT 6
+
 static void fclose_if_file(memorypcm_preset_t *preset) {
     if (preset == NULL) {
         return;
@@ -235,6 +241,9 @@ void pcm_note_on(uint16_t osc) {
             if(synth[osc]->preset >= pcm_samples) synth[osc]->preset = 0;
         }
         
+        // Arm the declick before the phase snap below steps the output.
+        if (synth[osc]->status == SYNTH_AUDIBLE)
+            synth[osc]->pcm_declick += synth[osc]->pcm_last_out;
         if (AMY_IS_SET(synth[osc]->trigger_phase)) {
             // trigger_phase (P) sets the sample start point for this
             // note-on (start_frame / 2^PCM_INDEX_BITS).
@@ -339,6 +348,9 @@ SAMPLE render_pcm(SAMPLE* buf, uint16_t osc) {
         PHASOR step = F2P((playback_freq / (float)AMY_SAMPLE_RATE) / (float)(1 << PCM_INDEX_BITS));
         const LUTSAMPLE* table = preset->sample_ram;
         uint32_t base_index = INT_OF_P(synth[osc]->phase, PCM_INDEX_BITS);
+        // Retrigger declick state, see PCM_DECLICK_SHIFT.
+        SAMPLE declick = synth[osc]->pcm_declick;
+        SAMPLE last_out = synth[osc]->pcm_last_out;
         for(uint16_t i=0; i < AMY_BLOCK_SIZE; i++) {
             SAMPLE frac = S_FRAC_OF_P(synth[osc]->phase, PCM_INDEX_BITS);
             LUTSAMPLE b = 0;
@@ -348,7 +360,10 @@ SAMPLE render_pcm(SAMPLE* buf, uint16_t osc) {
                 if (preset->type != AMY_PCM_TYPE_FILE) {
                     synth[osc]->status = SYNTH_OFF;
                 }
-                buf[i] = 0;
+                // Silent past the end, but let an armed compensator decay.
+                buf[i] = declick;
+                declick -= declick >> PCM_DECLICK_SHIFT;
+                last_out = 0;
                 continue;
             }
             if (preset->channels == 2) {
@@ -399,11 +414,17 @@ SAMPLE render_pcm(SAMPLE* buf, uint16_t osc) {
                     }
                 }
             }
-            SAMPLE value = buf[i] + MUL4_SS(amp, sample);
-            buf[i] = value;   
+            last_out = MUL4_SS(amp, sample);
+            SAMPLE value = buf[i] + last_out + declick;
+            declick -= declick >> PCM_DECLICK_SHIFT;
+            buf[i] = value;
             if (value < 0) value = -value;
-            if (value > max_value) max_value = value;  
+            if (value > max_value) max_value = value;
         }
+        // Snap sub-audible residue to zero so the shift decay terminates.
+        if (declick > -(1 << 8) && declick < (1 << 8)) declick = 0;
+        synth[osc]->pcm_declick = declick;
+        synth[osc]->pcm_last_out = last_out;
         //printf("render_pcm: osc %d preset %d len %d base_ix %d phase %f step %f tablestep %f amp %f\n",
         //       osc, synth[osc]->preset, preset->length, base_index, P2F(synth[osc]->phase), P2F(step), (1 << PCM_INDEX_BITS) * P2F(step), S2F(msynth[osc]->amp));
         return max_value; 


### PR DESCRIPTION
## Summary

Retriggering a PCM osc that is still sounding snaps the phase back to the
start point. The output steps instantaneously from wherever the old waveform
was to the new start value - a hard, audible click whenever a long tail gets
cut mid-swing. Sequenced drums are the worst case: every step retriggers the
same osc (same-note re-onset reuses the voice), and with a pitched-down
sample the tail is long and loud when the cut lands.

Measured retriggering the TR-808 Bass Drum 1 ROM preset three octaves down:
the phase snap produces discontinuities of ~40% of full scale where the
natural sample-to-sample slew of that material is ~2%.

## Change

Track the last value each PCM osc contributed (`pcm_last_out`). On re-onset
of a sounding osc, add that value into a per-osc compensator
(`pcm_declick`), which the render loop adds to the output and decays
exponentially: `declick -= declick >> PCM_DECLICK_SHIFT` per sample. Shift 6
gives tau = 64 samples (1.3 ms at 48 kHz), so the audible decay completes
within one render block. Sub-audible residue snaps to zero so the shift
decay terminates instead of freezing as a tiny DC offset; the past-the-end
branch keeps decaying an armed compensator so it can finish after the sample
runs out.

Host-verified: the retrigger discontinuity drops to the natural-slew floor
at every pitch tested (e.g. 7511 -> 800 LSB at three octaves down,
12125 -> 1606 one octave up from there), the native-pitch attack transient
is untouched, and steady-state pitch/SNR measurements are byte-identical
with the compensator in place - it is exactly zero except for ~100 samples
after a phase jump.

Cost: two SAMPLE fields per synthinfo, plus branchless decay arithmetic in
the render loop. Measured on-target with an interleaved A/B against this
branch's base commit (ESP32-S3 @ 240 MHz, fixed-point, LTO, 48 kHz /
256-sample blocks, free-run render, 3 captures per side, both firmwares
resident in OTA slots and alternated by boot-partition switch):

| Scene | base cyc/block | this PR | delta | noise | notes |
|---|---:|---:|---:|---:|---|
| pcm4 - 4 PCM one-shots, retriggered ~229 ms | 142,273 | 144,100 | +1.28% | ±0.08% | pure PCM load |
| pcm4lo - same, 2 octaves down, retriggered ~112 ms (every re-onset mid-tail, compensator active) | 141,200 | 142,923 | +1.22% | ±0.02% | worst case |
| sine8 - 8 sine oscs (control, no PCM) | 141,793 | 141,748 | -0.03% | - | bit-identical output |
| juno6 - 6-voice Juno patch (control, no PCM) | 907,662 | 908,968 | +0.14% | ±0.23% | bit-identical output |

That works out to ~1.8 cycles per sample per PCM osc: +1.3% relative to a
pure 4-voice PCM scene's own cycles, which is +0.14% of the 5.33 ms block
budget (these scenes run at ~89% headroom); non-PCM scenes are unchanged.
pcm4 and pcm4lo cost the same, confirming the branchless design: the decay
runs unconditionally because a per-sample branch would cost more than the
arithmetic it skips, so an idle compensator costs exactly what an active
one does. Audio output differs only on the PCM scenes (the compensator
firing on mid-tail retriggers - the fix working); the control scenes are
bit-identical.

## Follow up?

Note-off of a PCM_PLAY_STOP osc stops it via `SYNTH_OFF`, which cuts a
sounding tail to silence with the same kind of step. The same compensator
could cancel that click too, but it needs the osc to render for one more
block after the stop, which touches note-off semantics - happy to follow up
if there's interest.
