### PR TITLE
Remove leftover osc==999 debug print from hold_and_modify

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -1865,15 +1865,6 @@ void hold_and_modify(uint16_t osc) {
     msynth[osc]->feedback = synth[osc]->feedback;
     msynth[osc]->resonance = synth[osc]->resonance;
 
-    if (osc == 999) {
-        fprintf(stderr, "h&m: time %f osc %d note %f vel %f eg0 %f eg1 %f ampc %.3f %.3f %.3f %.3f %.3f %.3f lfqc %.3f %.3f %.3f %.3f %.3f %.3f amp %f logfreq %f\n",
-               amy_global.time, osc,
-               ctrl_inputs[COEF_NOTE], ctrl_inputs[COEF_VEL], ctrl_inputs[COEF_EG0], ctrl_inputs[COEF_EG1],
-               synth[osc]->amp_coefs[0], synth[osc]->amp_coefs[1], synth[osc]->amp_coefs[2], synth[osc]->amp_coefs[3], synth[osc]->amp_coefs[4], synth[osc]->amp_coefs[5],
-               synth[osc]->logfreq_coefs[0], synth[osc]->logfreq_coefs[1], synth[osc]->logfreq_coefs[2], synth[osc]->logfreq_coefs[3], synth[osc]->logfreq_coefs[4], synth[osc]->logfreq_coefs[5],
-               msynth[osc]->amp, msynth[osc]->logfreq);
-
-    }
     AMY_PROFILE_STOP(HOLD_AND_MODIFY)
 
 }


### PR DESCRIPTION
`hold_and_modify` carries a hard-coded `if (osc == 999)` that prints a 280-char diagnostic to stderr **every block** for any audible osc numbered 999.

Found the hard way on Tulip's ESP32-P4: its allocator hands raw oscs out top-down from the 1024 pool, so the third app to take raw oscs lands on 999, plays a note, and the print alone (280 chars at 115200-baud stderr ≈ 24 ms against the 5.8 ms block budget) trips the overload failsafe. Measured: three bare sine oscs at 998–1000, render_load 1.4–1.9, `AMY: CPU overload (render 11230 us > 5687 threshold), resetting synth` — entirely printf.

Deletion only; clean `make amy-example`, zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)