### PR TITLE
patches: memory-patch slots are recycled, and a dry pool cannot crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ amy-message: $(OBJECTS) src/amy-message.o
 # Plain C tests for things the audio-rendering suite can't reach -- e.g. clock
 # rollovers 50 days out, which you can only hit by fast-forwarding the counters.
 CTESTS = tests/test_clock_wrap tests/test_sequencer_active tests/test_sequencer_bounds \
-         tests/test_bus_config
+         tests/test_bus_config tests/test_patch_slots
 
 # Static pattern rules, so these win over the generic %.o: %.c above (which
 # would compile without -Isrc and fail to find amy.h).

--- a/src/patches.c
+++ b/src/patches.c
@@ -12,6 +12,13 @@
 uint32_t max_num_memory_patches = 0;
 struct delta **memory_patch_deltas = NULL;
 uint16_t *memory_patch_oscs = NULL;
+// Nonzero when the slot's number was invented by patches_store_patch
+// rather than chosen by the caller. Only auto-assigned slots may be
+// recycled (reused on a re-store to the same instrument, freed when
+// that instrument is released): an explicitly numbered patch may be
+// loaded again later by anyone who knows the number, so it is never
+// freed behind the caller's back.
+uint8_t *memory_patch_auto = NULL;
 uint16_t next_user_patch_index = 0;
 uint16_t * osc_to_voice = NULL;
 uint16_t *voice_to_base_osc = NULL;
@@ -19,6 +26,7 @@ uint16_t *voice_to_base_osc = NULL;
 void patches_deinit() {
     memory_patch_deltas = NULL;
     memory_patch_oscs = NULL;
+    memory_patch_auto = NULL;
     osc_to_voice = NULL;
     voice_to_base_osc = NULL;
 }
@@ -29,14 +37,17 @@ void patches_init(int max_memory_patches) {
             max_num_memory_patches * sizeof(struct delta *)
 	    + max_num_memory_patches * sizeof(uint16_t)
             + AMY_OSCS * sizeof(uint16_t)
-            + amy_global.config.max_voices * sizeof(uint16_t),
+            + amy_global.config.max_voices * sizeof(uint16_t)
+            + max_num_memory_patches * sizeof(uint8_t),
 	    amy_global.config.ram_caps_synth
     );
     memory_patch_deltas = (struct delta **)alloc_base;
     memory_patch_oscs = (uint16_t *)(memory_patch_deltas + max_num_memory_patches);
     osc_to_voice = (uint16_t *)(memory_patch_oscs + max_num_memory_patches);
     voice_to_base_osc = (uint16_t *)(osc_to_voice + AMY_OSCS);
+    memory_patch_auto = (uint8_t *)(voice_to_base_osc + amy_global.config.max_voices);
     bzero(memory_patch_deltas, max_num_memory_patches * sizeof(struct delta *));
+    bzero(memory_patch_auto, max_num_memory_patches * sizeof(uint8_t));
     patches_reset();
 }
 
@@ -52,6 +63,7 @@ void patches_reset_patch(int patch_number) {
     if (memory_patch_deltas[patch_index] != NULL)  delta_release_list(memory_patch_deltas[patch_index]);
     memory_patch_deltas[patch_index] = NULL;
     memory_patch_oscs[patch_index] = 0;
+    memory_patch_auto[patch_index] = 0;
 }
 
 void patches_reset() {
@@ -866,10 +878,35 @@ void patches_store_patch(amy_event *e, char * patch_string) {
     // amy patch string. Either pull patch_number from e, or allocate a new one and write it to e.
     // Patch is stored in ram.
     //fprintf(stderr, "store_patch: synth %d patch_num %d patch '%s'\n", e->synth, e->patch, patch_string);
-    if (!AMY_IS_SET(e->patch_number)) {
-        // We need to allocate a new number.
-        e->patch_number = next_user_patch_index + _PATCHES_FIRST_USER_PATCH;
-        // next_user_patch_index is updated as needed at the bottom of the function (so it can reflect user-defined numbers too).
+    bool auto_assigned = !AMY_IS_SET(e->patch_number);
+    if (auto_assigned) {
+        // We need a number. Recycle before extending, in this order:
+        // (a) the addressed instrument's own auto-assigned patch — a
+        //     reconfigure (a sample change, a re-sent config) sends a
+        //     fresh patch_string for the same synth, and burning a new
+        //     slot each time emptied the whole pool in
+        //     max_num_memory_patches sends;
+        // (b) any free slot (never used, or freed when its instrument
+        //     was released);
+        // (c) refusal — the deliberately out-of-range number falls to
+        //     the range check below, which prints and drops the store.
+        if (AMY_IS_SET(e->synth) && instrument_number_exists(e->synth, NULL)) {
+            int prev = instrument_get_patch_number(e->synth);
+            int prev_index = prev - _PATCHES_FIRST_USER_PATCH;
+            if (prev_index >= 0 && prev_index < (int)max_num_memory_patches
+                && memory_patch_auto[prev_index])
+                e->patch_number = prev;
+        }
+        if (!AMY_IS_SET(e->patch_number)) {
+            for (uint32_t i = 0; i < max_num_memory_patches; ++i) {
+                if (memory_patch_deltas[i] == NULL && memory_patch_oscs[i] == 0) {
+                    e->patch_number = i + _PATCHES_FIRST_USER_PATCH;
+                    break;
+                }
+            }
+        }
+        if (!AMY_IS_SET(e->patch_number))
+            e->patch_number = _PATCHES_FIRST_USER_PATCH + max_num_memory_patches;
         //fprintf(stderr, "store_patch: auto-assigning patch number %d for '%s'\n", e->patch_number, patch_string);
     }
     int patch_index = (int)e->patch_number - _PATCHES_FIRST_USER_PATCH;
@@ -881,6 +918,12 @@ void patches_store_patch(amy_event *e, char * patch_string) {
         return;
     }
     if (patch_index >= next_user_patch_index)  next_user_patch_index = patch_index + 1;
+    // A re-store REPLACES the slot's contents. parse_patch_string_to_queue
+    // appends to whatever list is standing, so without this a second store
+    // to the same number merged two patches into one slot.
+    if (memory_patch_deltas[patch_index] != NULL || memory_patch_oscs[patch_index])
+        patches_reset_patch(e->patch_number);
+    memory_patch_auto[patch_index] = auto_assigned ? 1 : 0;
     // Store the patch as deltas and find out how many oscs this message uses
     parse_patch_string_to_queue(patch_string, 0, &memory_patch_deltas[patch_index], e->synth, e->time, true);
     update_num_oscs_for_patch_number(patch_index + _PATCHES_FIRST_USER_PATCH);
@@ -981,6 +1024,14 @@ uint8_t patches_voices_for_event(amy_event *e, uint16_t voices[]) {
     // Convert an event that may specify a synth into a number of specific voices.
     uint8_t num_voices = 0;
     uint32_t synth_flags = 0;
+    // The synth may have been CONSUMED earlier in this event's processing:
+    // releasing an instrument (num_voices=0) unsets e->synth precisely so
+    // the rest of the event is not forwarded to it
+    // (patches_voices_for_load_synth). Without this guard the unset
+    // sentinel (255) reached instrument_get_num_voices below and printed
+    // "instrument_number 255 is out of range" once per released synth —
+    // and on a device stderr is a blocking UART line in the audio path.
+    if (AMY_IS_UNSET(e->synth)) return 0;
     // We have an instrument specified - decide which of its voices are actually to be used.
         if (AMY_IS_SET(e->pedal)) {
         // Pedal events are a special case
@@ -1180,6 +1231,17 @@ uint8_t patches_voices_for_load_synth(amy_event *e, uint16_t voices[]) {
             // Clear all the midi mappings.
             int type = MIDI_MAP_TYPE_ANY;
             midi_clear_channel_mappings(e->synth, type);
+            // Free the instrument's AUTO-ASSIGNED memory patch: its number
+            // was invented in patches_store_patch, so nothing can ask for
+            // it again, and leaving it pinned leaked a slot per
+            // configure/release cycle until the pool ran dry. A patch the
+            // caller numbered explicitly is left alone — it may be loaded
+            // again by anyone who knows the number.
+            int prev = instrument_get_patch_number(e->synth);
+            int prev_index = prev - _PATCHES_FIRST_USER_PATCH;
+            if (prev_index >= 0 && prev_index < (int)max_num_memory_patches
+                && memory_patch_auto[prev_index])
+                patches_reset_patch(prev);
             // Delete the instrument
             instrument_release(e->synth);
             // Delete the instrument number so we don't forward the 'rest' of the event to it.
@@ -1267,6 +1329,18 @@ void patches_load_patch(amy_event *e) {
         } else {
             // User-defined patch
             int32_t patch_index = patch_number - _PATCHES_FIRST_USER_PATCH;
+            // Range-check before indexing. patches_store_patch refuses a
+            // number past the pool, but the event still carries it and
+            // arrives here — and indexing the tables with it read past
+            // their ends and walked a garbage delta pointer (a segfault
+            // on the desktop, a Guru Meditation on the device).
+            if (patch_index >= (int32_t)max_num_memory_patches) {
+                fprintf(stderr, "load patch_number %" PRIu16 " is out of range (%" PRId32 " .. %" PRId32 ") (synth %" PRId32 "), ignored\n",
+                        patch_number, (int32_t)_PATCHES_FIRST_USER_PATCH,
+                        (int32_t)(_PATCHES_FIRST_USER_PATCH + (int32_t)max_num_memory_patches - 1),
+                        (int32_t)e->synth);
+                return;
+            }
             oscs_per_voice = memory_patch_oscs[patch_index];
             if(oscs_per_voice > 0){
                 deltas = memory_patch_deltas[patch_index];

--- a/tests/test_patch_slots.c
+++ b/tests/test_patch_slots.c
@@ -1,0 +1,179 @@
+// Tests for the memory-patch slot lifecycle (patch_string storage).
+//
+// Every patch_string without an explicit patch_number used to burn a
+// fresh slot (next_user_patch_index only ever grew), so
+// max_memory_patches sends — 32 reconfigures of one synth, or a few
+// configure/release cycles of a multi-channel app — emptied the pool
+// for the rest of the session. And once it was empty the refusal was
+// not the end of it: patches_store_patch dropped the store but the
+// event still carried the refused number into patches_load_patch,
+// which indexed the 32-slot tables with it unchecked and walked a
+// garbage delta pointer — a segfault on the desktop, a Guru Meditation
+// on the device.
+//
+// Also pins the release-path spam: deleting an instrument
+// (num_voices=0) unsets e->synth so the rest of the event is not
+// forwarded, and patches_voices_for_event then read the unset sentinel
+// into instrument_get_num_voices — "instrument_number 255 is out of
+// range" once per released synth, and on a device stderr is a blocking
+// UART line inside the audio path.
+//
+// Build/run with `make ctest`.
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include "amy.h"
+
+static int failures = 0;
+
+#define CHECK(cond, fmt, ...) do {                                        \
+    if (cond) { printf("  ok   " fmt "\n", ##__VA_ARGS__); }              \
+    else { printf("  FAIL " fmt "\n", ##__VA_ARGS__); failures++; }       \
+} while (0)
+
+extern uint32_t max_num_memory_patches;
+extern struct delta **memory_patch_deltas;
+extern uint16_t *memory_patch_oscs;
+extern int instrument_get_patch_number(int instrument_number);
+extern int instrument_get_num_voices(int instrument_number, uint16_t *amy_voices);
+
+#define FIRST_USER 1024
+
+static void render_a_bit(void) {
+    for (int i = 0; i < 16; ++i) amy_simple_fill_buffer();
+}
+
+static void send(const char *m) {
+    amy_add_message((char *)m);
+    render_a_bit();
+}
+
+static int used_slots(void) {
+    int n = 0;
+    for (uint32_t i = 0; i < max_num_memory_patches; ++i)
+        if (memory_patch_deltas[i] != NULL || memory_patch_oscs[i] != 0) ++n;
+    return n;
+}
+
+static void test_reconfigure_reuses_slot(void) {
+    printf("a reconfigure reuses the instrument's own slot\n");
+    send("i17iv1uv0w7p3Z");
+    int first = instrument_get_patch_number(17);
+    CHECK(first >= FIRST_USER && first < FIRST_USER + (int)max_num_memory_patches,
+          "first store lands in the user range (%d)", first);
+    int before = used_slots();
+    for (int i = 0; i < 40; ++i) {
+        char m[64];
+        snprintf(m, sizeof(m), "i17iv1uv0w7p%dZ", i % 5);
+        send(m);
+    }
+    CHECK(instrument_get_patch_number(17) == first,
+          "40 reconfigures still on patch %d", first);
+    CHECK(used_slots() == before, "and no extra slots burned (%d used)",
+          used_slots());
+}
+
+static void test_release_frees_auto_slot(void) {
+    printf("releasing an instrument frees its auto-assigned slot\n");
+    send("i17iv0Z");          // release the previous test's holding first
+    int before = used_slots();
+    send("i18iv1uv0w7p3Z");
+    CHECK(used_slots() == before + 1, "config took one slot");
+    send("i18iv0Z");
+    CHECK(used_slots() == before, "release gave it back");
+    // 40 configure/release cycles across synths: the pool never runs dry.
+    for (int i = 0; i < 40; ++i) {
+        char m[64];
+        int s = 17 + (i % 8);
+        snprintf(m, sizeof(m), "i%div1uv0w7p%dZ", s, i % 5);
+        send(m);
+        int p = instrument_get_patch_number(s);
+        if (!(p >= FIRST_USER && p < FIRST_USER + (int)max_num_memory_patches)) {
+            CHECK(0, "cycle %d: synth %d got patch %d", i, s, p);
+            return;
+        }
+        snprintf(m, sizeof(m), "i%div0Z", s);
+        send(m);
+    }
+    CHECK(used_slots() == before, "40 configure/release cycles leaked nothing");
+}
+
+static void test_explicit_slot_survives_release(void) {
+    printf("an explicitly numbered patch is not freed behind the caller\n");
+    send("K1030uv0w7p3Zv1w7p4Z");            // store 2-osc patch as 1030
+    CHECK(memory_patch_oscs[1030 - FIRST_USER] == 2, "stored 2 oscs at 1030");
+    send("K1030i19iv1Z");                    // load it on synth 19
+    CHECK(instrument_get_patch_number(19) == 1030, "synth 19 loaded 1030");
+    send("i19iv0Z");                         // release the instrument
+    CHECK(memory_patch_oscs[1030 - FIRST_USER] == 2,
+          "slot 1030 still stored after release");
+    // A re-store REPLACES rather than appends.
+    send("K1030uv0w7p3Z");                   // now a 1-osc patch
+    CHECK(memory_patch_oscs[1030 - FIRST_USER] == 1,
+          "re-store replaced the slot (1 osc, not 3)");
+}
+
+static void test_pool_dry_is_safe(void) {
+    printf("a dry pool refuses the store and the load does not crash\n");
+    // Fill every slot with explicit stores.
+    for (uint32_t i = 0; i < max_num_memory_patches; ++i) {
+        char m[64];
+        snprintf(m, sizeof(m), "K%duv0w7p3Z", FIRST_USER + i);
+        send(m);
+    }
+    CHECK(used_slots() == (int)max_num_memory_patches, "pool full (%d slots)",
+          used_slots());
+    // An auto-assign now has nowhere to go: the store is refused and the
+    // load of the refused number must be IGNORED, not a wild index.
+    send("i20iv1uv0w7p3Z");
+    CHECK(instrument_get_num_voices(20, NULL) == 0,
+          "synth 20 not configured, and no crash");
+}
+
+static void test_release_is_quiet(void) {
+    printf("releasing a synth prints nothing (the 255 spam)\n");
+    // The spam went to stderr; point stderr at a file and look.
+    fflush(stderr);
+    FILE *redir = freopen("test_patch_slots.stderr.tmp", "w", stderr);
+    send("K7i21if8iv2y1Z");   // ROM patch config, the tulip5 shape
+    send("n60l0.8i21Z");
+    send("n0l0i21Z");
+    send("i21iv0Z");          // the release that used to print
+    fflush(stderr);
+    char buf[4096] = {0};
+    int found = 0;
+    if (redir) {
+        FILE *f = fopen("test_patch_slots.stderr.tmp", "r");
+        if (f) {
+            size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+            buf[n] = 0;
+            fclose(f);
+        }
+        found = strstr(buf, "out of range") != NULL;
+    }
+    freopen("/dev/stderr", "w", stderr);
+    remove("test_patch_slots.stderr.tmp");
+    CHECK(!found, "no 'out of range' on release%s%s",
+          found ? ": " : "", found ? buf : "");
+}
+
+// examples.o wants this from amy-example.c; every ctest stubs it.
+void delay_ms(uint32_t ms) { (void)ms; }
+
+int main(void) {
+    amy_config_t c = amy_default_config();
+    c.features.startup_bleep = 0;
+    amy_start(c);
+    render_a_bit();
+
+    test_reconfigure_reuses_slot();
+    test_release_frees_auto_slot();
+    test_explicit_slot_survives_release();
+    test_release_is_quiet();
+    test_pool_dry_is_safe();
+
+    if (failures) { printf("%d FAILURES\n", failures); return 1; }
+    printf("all ok\n");
+    return 0;
+}


### PR DESCRIPTION
Four faults in the `patch_string` slot lifecycle, found from tulip where every gamma9001 / exported-beat channel is a `patch_string` instrument. Reported from the bench as a micropython segfault after `patch number 1056 is out of range (1024 .. 1056)`, plus `instrument_number 255 is out of range 0..64 (get_num_voices)` spam on every app quit — with no patch changing involved at all.

## The leak

Every auto-assigned store burned a fresh slot (`next_user_patch_index` only ever grew), so `max_memory_patches` sends — 32 reconfigures of one synth, or a few configure/release cycles of an 8-channel app — emptied the pool for the rest of the session.

Now:
- a store **reuses the addressed instrument's own auto-assigned slot** (a reconfigure — a sample change, a re-sent config — stays on one slot),
- then any **free slot**,
- and **releasing an instrument** (`num_voices=0`) frees its auto-assigned slot.

An **explicitly numbered** patch is never recycled behind the caller — it may be loaded again by anyone who knows the number. Tracked by a per-slot auto flag carried in the `patches_init` block.

## The crash

Once the pool was dry, the refusal was not the end of it: `patches_store_patch` dropped the store, but the event still carried the refused number into `patches_load_patch`, which indexed the 32-slot tables with it **unchecked** and walked a garbage delta pointer — a segfault on the desktop, a Guru Meditation on a device. The user-patch branch range-checks before indexing now.

## Replace, not append

A re-store to the same number appended to the standing delta list (`parse_patch_string_to_queue` appends), silently merging two patches into one slot. A re-store resets the slot first.

## The 255 print

Releasing an instrument printed `instrument_number 255 is out of range 0..64 (get_num_voices)`: the release path unsets `e->synth` on purpose so the rest of the event is not forwarded, and `patches_voices_for_event` then read the unset sentinel into `instrument_get_num_voices`. On a device stderr is a blocking UART line inside the audio path, once per released synth. Guarded.

## Tests

`tests/test_patch_slots.c`, wired into `make ctest`, pins all four: 40 reconfigures stay on one slot, 40 configure/release cycles leak nothing, an explicit slot survives its instrument's release, a re-store replaces, a release prints nothing, and the dry-pool store+load survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)