### PR TITLE
An auto-assigned patch number is a courier, not a patch

### DIFF
--- a/src/amy_midi.c
+++ b/src/amy_midi.c
@@ -158,7 +158,17 @@ void amy_received_program_change(uint8_t channel, uint8_t program) {
     if (bank_number < 0) {
         // If the bank hasn't been set, stay within the block of 128 of the current patch
         // (so e.g. DX7 voices remain DX7).
-        bank_number = (instrument_get_patch_number(e.synth) & 0xFF80) >> 7;
+        int synth_patch = instrument_get_patch_number(e.synth);
+        // ...but only if there IS a current patch. A synth built from a
+        // patch_string carries no patch number (the auto-assigned one is an
+        // allocator artifact, released as soon as it is loaded), and a synth
+        // that doesn't exist reports -1. Both used to be masked and shifted
+        // into a nonsense bank -- 511 for the unset sentinel -- which put the
+        // program change hundreds of patches past anything defined, so a bare
+        // PC on such a channel did nothing at all. Default to bank 0 (Juno).
+        uint16_t synth_patch_u16 = (uint16_t)synth_patch;
+        if (synth_patch < 0 || AMY_IS_UNSET(synth_patch_u16))  synth_patch = 0;
+        bank_number = (synth_patch & 0xFF80) >> 7;
         // Banks 0 (Juno, patches 0-127) and 1 (DX7, 128-255) are full 128-patch
         // banks, and bank 3 (384+) is the Gamma9001 drum kit bank -- a synth
         // sitting on a drum kit patch should stay in the kit bank so a bare PC

--- a/src/patches.c
+++ b/src/patches.c
@@ -888,29 +888,16 @@ void patches_store_patch(amy_event *e, char * patch_string) {
     //fprintf(stderr, "store_patch: synth %d patch_num %d patch '%s'\n", e->synth, e->patch, patch_string);
     bool auto_assigned = !AMY_IS_SET(e->patch_number);
     if (auto_assigned) {
-        // We need a number. Recycle before extending, in this order:
-        // (a) the addressed instrument's own auto-assigned patch — a
-        //     reconfigure (a sample change, a re-sent config) sends a
-        //     fresh patch_string for the same synth, and burning a new
-        //     slot each time emptied the whole pool in
-        //     max_num_memory_patches sends;
-        // (b) any free slot (never used, or freed when its instrument
-        //     was released);
-        // (c) refusal — the deliberately out-of-range number falls to
-        //     the range check below, which prints and drops the store.
-        if (AMY_IS_SET(e->synth) && instrument_number_exists(e->synth, NULL)) {
-            int prev = instrument_get_patch_number(e->synth);
-            int prev_index = prev - _PATCHES_FIRST_USER_PATCH;
-            if (prev_index >= 0 && prev_index < (int)max_num_memory_patches
-                && memory_patch_auto[prev_index])
-                e->patch_number = prev;
-        }
-        if (!AMY_IS_SET(e->patch_number)) {
-            for (uint32_t i = 0; i < max_num_memory_patches; ++i) {
-                if (memory_patch_deltas[i] == NULL && memory_patch_oscs[i] == 0) {
-                    e->patch_number = i + _PATCHES_FIRST_USER_PATCH;
-                    break;
-                }
+        // We need a number, and it only has to live long enough to carry this
+        // patch_string into patches_load_patch, which frees the slot as soon as
+        // it has loaded it. So: take any free slot (never used, or handed back
+        // by an earlier load), else refuse — the deliberately out-of-range
+        // number falls to the range check below, which prints and drops the
+        // store.
+        for (uint32_t i = 0; i < max_num_memory_patches; ++i) {
+            if (memory_patch_deltas[i] == NULL && memory_patch_oscs[i] == 0) {
+                e->patch_number = i + _PATCHES_FIRST_USER_PATCH;
+                break;
             }
         }
         if (!AMY_IS_SET(e->patch_number))
@@ -1266,17 +1253,10 @@ uint8_t patches_voices_for_load_synth(amy_event *e, uint16_t voices[]) {
             // Clear all the midi mappings.
             int type = MIDI_MAP_TYPE_ANY;
             midi_clear_channel_mappings(e->synth, type);
-            // Free the instrument's AUTO-ASSIGNED memory patch: its number
-            // was invented in patches_store_patch, so nothing can ask for
-            // it again, and leaving it pinned leaked a slot per
-            // configure/release cycle until the pool ran dry. A patch the
-            // caller numbered explicitly is left alone — it may be loaded
-            // again by anyone who knows the number.
-            int prev = instrument_get_patch_number(e->synth);
-            int prev_index = prev - _PATCHES_FIRST_USER_PATCH;
-            if (prev_index >= 0 && prev_index < (int)max_num_memory_patches
-                && memory_patch_auto[prev_index])
-                patches_reset_patch(prev);
+            // No memory patch to free here: an auto-assigned slot is released
+            // by patches_load_patch as soon as it has been loaded, so an
+            // instrument never holds one, and a patch the caller numbered
+            // explicitly is never freed behind their back.
             // Delete the instrument
             instrument_release(e->synth);
             // Delete the instrument number so we don't forward the 'rest' of the event to it.
@@ -1329,15 +1309,27 @@ void patches_load_patch(amy_event *e) {
     if (AMY_IS_UNSET(patch_number) && AMY_IS_UNSET(e->oscs_per_voice)
         && AMY_IS_SET(e->synth) && instrument_number_exists(e->synth, NULL))
         clone_oscs_per_voice = snapshot_voice_config(e->synth, &clone_deltas, e->time);
+    // An AUTO-ASSIGNED memory patch is a courier, not a patch. Its number was
+    // invented by patches_store_patch so a patch_string could be handed to this
+    // load; the caller never saw it and can never ask for it again. So it is
+    // consumed here: the number is not stored on the instrument (the voices
+    // themselves are the synth's config now that growth clones them), and the
+    // slot goes back to the pool on the way out, whether this load worked or
+    // not.
+    bool auto_patch = false;
+    if (AMY_IS_SET(patch_number)) {
+        int patch_index = (int)patch_number - _PATCHES_FIRST_USER_PATCH;
+        auto_patch = (patch_index >= 0 && patch_index < (int)max_num_memory_patches
+                      && memory_patch_auto[patch_index]);
+    }
     num_voices = patches_voices_for_load_synth(e, voices);
     if (num_voices == 0) {
-        if (clone_deltas)  delta_release_list(clone_deltas);
         if (AMY_IS_UNSET(e->num_voices)) {
             // Print a warning unless we deliberately set the voices to zero to release the synth.
             fprintf(stderr, "synth %" PRId32 ": no voices selected, ignored (e->num_voices %" PRId32 "...)\n",
                     (int32_t)e->synth, (int32_t)e->num_voices);
         }
-        return;
+        goto done;
     } else {
         // Reset every osc belonging to each voice so stale state doesn't persist
         // before we reallocate and reinitialize them below.
@@ -1380,7 +1372,7 @@ void patches_load_patch(amy_event *e) {
             if (patch_number >= _PATCHES_NUM_BUILTIN || patch_commands[patch_number] == NULL) {
                 fprintf(stderr, "patch_number %" PRIu16 " is not a defined built-in patch (synth %" PRId32 "), ignored\n",
                         patch_number, (int32_t)e->synth);
-                return;
+                goto done;
             }
             message = (char*)patch_commands[patch_number];
             oscs_per_voice = patch_oscs[patch_number];
@@ -1397,7 +1389,7 @@ void patches_load_patch(amy_event *e) {
                         patch_number, (int32_t)_PATCHES_FIRST_USER_PATCH,
                         (int32_t)(_PATCHES_FIRST_USER_PATCH + (int32_t)max_num_memory_patches - 1),
                         (int32_t)e->synth);
-                return;
+                goto done;
             }
             oscs_per_voice = memory_patch_oscs[patch_index];
             if(oscs_per_voice > 0){
@@ -1406,7 +1398,7 @@ void patches_load_patch(amy_event *e) {
                 fprintf(stderr, "patch_number %" PRIu16 " has %" PRIu16 " num_deltas %" PRIi32 " (synth %" PRId32 " num_voices %" PRId32 "), ignored\n",
                         patch_number, oscs_per_voice, delta_list_len(memory_patch_deltas[patch_index]),
                         (int32_t)e->synth, (int32_t)e->num_voices);
-                return;
+                goto done;
             }
         }
     }
@@ -1464,7 +1456,11 @@ void patches_load_patch(amy_event *e) {
         if (AMY_IS_SET(e->synth_flags)) flags = e->synth_flags;
         uint16_t bus = 0;
         if (AMY_IS_SET(e->bus)) bus = e->bus;
-        instrument_add_new(e->synth, num_voices, voices, patch_number, oscs_per_voice, bus, flags);
+        // An auto-assigned number is an allocator artifact, so the instrument
+        // records no patch at all rather than a number nobody can use.
+        uint16_t stored_patch_number = patch_number;
+        if (auto_patch)  AMY_UNSET(stored_patch_number);
+        instrument_add_new(e->synth, num_voices, voices, stored_patch_number, oscs_per_voice, bus, flags);
     }
     // Now actually initialize the newly-allocated osc blocks with the patch
     bool is_first_voice = true;  // flag for once-only messages.
@@ -1479,6 +1475,10 @@ void patches_load_patch(amy_event *e) {
             is_first_voice = false;
         }
     }
+done:
     // add_deltas_to_queue_with_baseosc copies, so the snapshot is ours to free.
     if (clone_deltas)  delta_release_list(clone_deltas);
+    // Likewise the courier slot: its deltas have been copied into the queue (or
+    // this load failed), and nothing can ask for it by number, so hand it back.
+    if (auto_patch)  patches_reset_patch(e->patch_number);
 }

--- a/tests/test_patch_slots.c
+++ b/tests/test_patch_slots.c
@@ -37,6 +37,8 @@ extern struct delta **memory_patch_deltas;
 extern uint16_t *memory_patch_oscs;
 extern int instrument_get_patch_number(int instrument_number);
 extern int instrument_get_num_voices(int instrument_number, uint16_t *amy_voices);
+extern void patches_reset_patch(int patch_number);
+extern void amy_received_program_change(uint8_t channel, uint8_t program);
 
 #define FIRST_USER 1024
 
@@ -56,47 +58,75 @@ static int used_slots(void) {
     return n;
 }
 
-static void test_reconfigure_reuses_slot(void) {
-    printf("a reconfigure reuses the instrument's own slot\n");
-    send("i17iv1uv0w7p3Z");
-    int first = instrument_get_patch_number(17);
-    CHECK(first >= FIRST_USER && first < FIRST_USER + (int)max_num_memory_patches,
-          "first store lands in the user range (%d)", first);
+static void test_auto_slot_is_released_on_load(void) {
+    printf("an auto-assigned slot is a courier: it is gone once it is loaded\n");
     int before = used_slots();
+    send("i17iv1uv0w7p3Z");
+    CHECK(used_slots() == before, "the config left no slot standing (%d used)",
+          used_slots());
+    uint16_t p = (uint16_t)instrument_get_patch_number(17);
+    CHECK(AMY_IS_UNSET(p),
+          "and the synth records no patch number (%d)", (int)p);
     for (int i = 0; i < 40; ++i) {
         char m[64];
         snprintf(m, sizeof(m), "i17iv1uv0w7p%dZ", i % 5);
         send(m);
     }
-    CHECK(instrument_get_patch_number(17) == first,
-          "40 reconfigures still on patch %d", first);
-    CHECK(used_slots() == before, "and no extra slots burned (%d used)",
+    CHECK(used_slots() == before, "40 reconfigures burned nothing (%d used)",
           used_slots());
 }
 
-static void test_release_frees_auto_slot(void) {
-    printf("releasing an instrument frees its auto-assigned slot\n");
-    send("i17iv0Z");          // release the previous test's holding first
+static void test_configure_release_cycles_leak_nothing(void) {
+    printf("configure/release cycles never run the pool dry\n");
+    send("i17iv0Z");          // release the previous test's synth first
     int before = used_slots();
     send("i18iv1uv0w7p3Z");
-    CHECK(used_slots() == before + 1, "config took one slot");
     send("i18iv0Z");
-    CHECK(used_slots() == before, "release gave it back");
-    // 40 configure/release cycles across synths: the pool never runs dry.
+    CHECK(used_slots() == before, "a configure/release round trip is neutral");
+    // 40 cycles across synths: the pool never runs dry, and every config
+    // actually takes (a refused store would leave the synth with no voices).
     for (int i = 0; i < 40; ++i) {
         char m[64];
         int s = 17 + (i % 8);
         snprintf(m, sizeof(m), "i%div1uv0w7p%dZ", s, i % 5);
         send(m);
-        int p = instrument_get_patch_number(s);
-        if (!(p >= FIRST_USER && p < FIRST_USER + (int)max_num_memory_patches)) {
-            CHECK(0, "cycle %d: synth %d got patch %d", i, s, p);
+        if (instrument_get_num_voices(s, NULL) != 1) {
+            CHECK(0, "cycle %d: synth %d did not configure", i, s);
             return;
         }
         snprintf(m, sizeof(m), "i%div0Z", s);
         send(m);
     }
     CHECK(used_slots() == before, "40 configure/release cycles leaked nothing");
+}
+
+static void test_program_change_without_a_patch_number(void) {
+    printf("a bare program change on a patch_string synth lands in bank 0\n");
+    // A synth built from a patch_string has no patch number to infer a bank
+    // from. That used to be masked and shifted anyway -- the unset sentinel
+    // gives bank 511 -- putting the program change 65408 patches past anything
+    // defined, so the PC silently did nothing.
+    send("i9iv1uv0w7p3Z");
+    CHECK(instrument_get_num_voices(9, NULL) == 1, "synth 9 configured");
+    amy_received_program_change(9, 3);
+    render_a_bit();
+    CHECK(instrument_get_patch_number(9) == 3,
+          "PC 3 loaded built-in patch 3 (got %d)", instrument_get_patch_number(9));
+    // An explicitly numbered patch DOES carry a bank, and that still works:
+    // 1030 is bank 8, so PC 5 there means patch 8*128 + 5 = 1029.
+    send("K1029uv0w7p3Z");
+    send("K1030uv0w7p4Z");
+    send("K1030i10iv1Z");
+    CHECK(instrument_get_patch_number(10) == 1030, "synth 10 sits on patch 1030");
+    amy_received_program_change(10, 5);
+    render_a_bit();
+    CHECK(instrument_get_patch_number(10) == 1029,
+          "PC 5 stayed in the synth's own bank (got %d)",
+          instrument_get_patch_number(10));
+    send("i9iv0Z");
+    send("i10iv0Z");
+    patches_reset_patch(1029);
+    patches_reset_patch(1030);
 }
 
 static void test_explicit_slot_survives_release(void) {
@@ -167,8 +197,9 @@ int main(void) {
     amy_start(c);
     render_a_bit();
 
-    test_reconfigure_reuses_slot();
-    test_release_frees_auto_slot();
+    test_auto_slot_is_released_on_load();
+    test_configure_release_cycles_leak_nothing();
+    test_program_change_without_a_patch_number();
     test_explicit_slot_survives_release();
     test_release_is_quiet();
     test_pool_dry_is_safe();


### PR DESCRIPTION
**Stacked on #1100** — base is `clone_on_grow`, so review that one first; this PR's own diff is the second commit. GitHub will retarget it to `main` when #1100 merges.

Steps 2b and 3 of the memory-patch thread, which #1100 unblocked.

## An auto-assigned patch number is a courier, not a patch

A `patch_string` with no `patch_number` gets one invented for it by `patches_store_patch`, purely so the deltas have somewhere to live until `patches_load_patch` reads them. The caller never sees that number and can never ask for it again — but the instrument stored it, and everything downstream then treated an allocator artifact as if it meant something.

Now that growing a synth clones its live voice (#1100), nothing needs the number after the load, so it is consumed there:

- the instrument records **no** patch number (UNSET) rather than one nobody can use;
- the slot goes **back to the pool on the way out**, whether the load worked or not (all exits share one cleanup path).

A slot is now held for exactly the span of one load instead of the lifetime of a synth, so the pool contains only what callers explicitly numbered.

## This deletes the #1096 machinery for auto slots

Both halves become unreachable and go:

- `patches_store_patch` no longer reaches into the addressed instrument to recycle its slot — there is nothing to recycle, the slot was freed at load;
- releasing an instrument no longer hunts for an auto slot to free — an instrument never holds one.

Explicitly numbered patches are untouched throughout: stored, kept on the instrument, never freed behind the caller's back.

## The `amy_midi` bank guard

`amy_received_program_change` masked and shifted whatever `instrument_get_patch_number()` returned. A synth with no patch number computes `(65535 & 0xFF80) >> 7` = **bank 511**, putting a bare program change 65408 patches past anything defined — so the PC did nothing at all. (A synth that doesn't exist reports `-1`, same story.) It now defaults to bank 0 (Juno) in both cases.

Per your call on the last thread, an **explicit** user patch number keeps its bank logic: 1030 is bank 8, and a bare PC there still walks that bank. Only the machine-generated case is guarded.

## Testing

- `tests/test_patch_slots.c` rewritten to the new contract: a config leaves no slot standing, the synth records no patch number, 40 reconfigures burn nothing, 40 configure/release cycles leak nothing. The explicit-number, dry-pool and release-is-quiet tests are unchanged and still pass.
- New program-change test in the same file — it **fails without the `amy_midi` guard** (`PC 3 loaded built-in patch 3 (got 65535)`), and pins that an explicitly numbered patch still resolves its own bank.
- `make ctest` 7/7, `make test` 131/131.
- `tulipcc` (`tulip/macos/build.sh`) builds clean against this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
