### PR TITLE
log2_lut: floor the argument instead of spinning on it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ dkms.conf
 godot/.sconsign.dblite
 godot/src/*.os
 tests/test_clone_on_grow
+tests/test_log2_lut

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ amy-message: $(OBJECTS) src/amy-message.o
 # rollovers 50 days out, which you can only hit by fast-forwarding the counters.
 CTESTS = tests/test_clock_wrap tests/test_sequencer_active tests/test_sequencer_bounds \
          tests/test_bus_config tests/test_patch_slots \
-         tests/test_synth_readout tests/test_clone_on_grow
+         tests/test_synth_readout tests/test_log2_lut tests/test_clone_on_grow
 
 # Static pattern rules, so these win over the generic %.o: %.c above (which
 # would compile without -Isrc and fail to find amy.h).

--- a/src/amy.c
+++ b/src/amy.c
@@ -652,9 +652,18 @@ void add_delta_to_queue(struct delta *d, struct delta **queue) {
 
 }
 
+// The smallest amplitude this maps rather than treating as silence. log2_lut
+// requires a strictly positive argument -- it normalizes by shifting, so zero
+// shifts to zero forever -- and `lin == 0` did not cover everything that
+// reaches it as zero or worse: a negative amplitude, a NaN, or (in fixed-point
+// builds, 23 fractional bits) any amplitude that underflows the conversion.
+// This is 60 dB below the quietest amplitude the mapping describes, so
+// nothing audible changes. Written as !(lin > MIN) so NaN takes the guard too.
+#define MAP_60DB_MIN_LIN 1e-6f
+
 float map_60dB_to_01f(float lin) {
     // Map .001 to 0, 1 to 1 logarithmically.
-    if (lin == 0) return -10.0f;
+    if (!(lin > MAP_60DB_MIN_LIN)) return -10.0f;
     // Use AMY's fast log2 LUT instead of libm log2f (called per-osc per-block).
     float result = 1.0f + 0.10034333188799373f * S2F(log2_lut(F2S(lin)));  // 0.100343 = 1 / (3 * log2(10))
     return result;

--- a/src/envelope.c
+++ b/src/envelope.c
@@ -171,8 +171,12 @@ AMY_IRAM_ATTR SAMPLE compute_breakpoint_scale(uint16_t osc, uint8_t bp_set, uint
 #define MIN_LEVEL_S 4.25f
 #define ATTACK_RANGE_S 9.375f
 #define MAP_ATTACK_LEVEL_S(level) (1 - MAX(level - MIN_LEVEL_S, 0) / ATTACK_RANGE_S)
-                SAMPLE mapped_current_level = F2S(MAP_ATTACK_LEVEL_S(LINEAR_SAMP_TO_DX7_LEVEL(v0)));
-                SAMPLE mapped_target_level = F2S(MAP_ATTACK_LEVEL_S(LINEAR_SAMP_TO_DX7_LEVEL(v1)));
+                // MAP_ATTACK_LEVEL_S reaches zero (and goes negative) once the
+                // DX7 level passes 13.625, which a breakpoint value above ~2.37
+                // does. log2_lut needs a positive argument, so floor these the
+                // same way v0/v1 are floored in the decay branch below.
+                SAMPLE mapped_current_level = MAX(F2S(MAP_ATTACK_LEVEL_S(LINEAR_SAMP_TO_DX7_LEVEL(v0))), F2S(BREAKPOINT_EPS));
+                SAMPLE mapped_target_level = MAX(F2S(MAP_ATTACK_LEVEL_S(LINEAR_SAMP_TO_DX7_LEVEL(v1))), F2S(BREAKPOINT_EPS));
                 float t_const = (t1 - t0) / S2F(log2_lut(mapped_current_level) - log2_lut(mapped_target_level));
                 float my_t0 = -t_const * S2F(log2_lut(mapped_current_level));
                 // This is the magic equation that shapes the DX7 attack envelopes.

--- a/src/log2_exp2.c
+++ b/src/log2_exp2.c
@@ -11,8 +11,17 @@ static inline SAMPLE lut_val(SAMPLE frac, const LUTSAMPLE *table, const int log2
 }
 
 
+// Smallest argument log2_lut will take. Anything at or below it -- zero, a
+// negative, a NaN, an amplitude that underflowed the conversion to SAMPLE --
+// is treated as this instead. log2 of it is -20, i.e. -120 dB, far below
+// anything audible, and the alternative is not returning at all: the
+// normalizing loop below shifts zero left forever.
+#define LOG2_LUT_MIN F2S(1.0f / (1 << 20))
+
 AMY_IRAM_ATTR SAMPLE log2_lut(SAMPLE x) {
-    // assert(x > 0);
+    // Branch-free floor rather than a test-and-return: this runs per-osc
+    // per-block. MAX takes the floor for NaN too, since NaN > y is false.
+    x = MAX(x, LOG2_LUT_MIN);
     int scale = 0;
     while (x < F2S(1.0f)) {
         x = SHIFTL(x, 1);

--- a/tests/test_log2_lut.c
+++ b/tests/test_log2_lut.c
@@ -1,0 +1,87 @@
+// log2_lut() normalizes its argument into [1, 2) by shifting, so it requires a
+// strictly positive one: shifting zero left leaves zero, forever. That is a
+// deliberate contract -- it runs per-osc per-block, and a guard inside it would
+// be paid on every sample -- so every caller must floor its argument. Two did
+// not:
+//
+//   map_60dB_to_01f() guarded `lin == 0`, which misses a negative amplitude, a
+//   NaN, and (in fixed-point builds) any amplitude too small to survive the
+//   conversion to a SAMPLE. Any of those wedged the render thread in an
+//   infinite loop: no crash, no message, just silence and a pegged core.
+//
+//   The DX7 attack branch in envelope.c fed log2_lut a level that reaches zero
+//   once a breakpoint value passes ~2.37, which a hand-written patch can ask
+//   for.
+//
+// Found by TestFuzzWireParser, which hung at its 92nd random message on x86 --
+// an amp coefficient landed on the wrong side of the underflow there while the
+// same message on arm64 did not.
+//
+// Build/run with `make ctest`.
+
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+#include <unistd.h>
+#include "amy.h"
+
+static int failures = 0;
+
+#define CHECK(cond, fmt, ...) do {                                        \
+    if (cond) { printf("  ok   " fmt "\n", ##__VA_ARGS__); }              \
+    else { printf("  FAIL " fmt "\n", ##__VA_ARGS__); failures++; }       \
+} while (0)
+
+extern float map_60dB_to_01f(float lin);
+extern float map_01_to_60dBf(float log);
+
+static void render_a_bit(void) {
+    for (int i = 0; i < 16; ++i) amy_simple_fill_buffer();
+}
+
+void delay_ms(uint32_t ms) { (void)ms; }
+
+int main(void) {
+    // Every check here hangs rather than fails if a guard goes missing, so
+    // bound the run: the alarm turns a wedged engine into a visible failure
+    // instead of a CI job that sits at "in progress" for six hours.
+    alarm(30);
+
+    amy_config_t c = amy_default_config();
+    c.features.startup_bleep = 0;
+    amy_start(c);
+    render_a_bit();
+
+    printf("map_60dB_to_01f survives everything that isn't safely positive\n");
+    CHECK(map_60dB_to_01f(0.0f) <= -10.0f, "0 -> %f", map_60dB_to_01f(0.0f));
+    CHECK(map_60dB_to_01f(-0.5f) <= -10.0f, "-0.5 -> %f", map_60dB_to_01f(-0.5f));
+    CHECK(map_60dB_to_01f(1e-9f) <= -10.0f, "1e-9 (underflows) -> %f", map_60dB_to_01f(1e-9f));
+    CHECK(map_60dB_to_01f(nanf("")) <= -10.0f, "NaN -> %f", map_60dB_to_01f(nanf("")));
+
+    printf("and still maps the range it documents\n");
+    float one = map_60dB_to_01f(1.0f), milli = map_60dB_to_01f(0.001f);
+    CHECK(one > 0.99f && one < 1.01f, "1.0 -> %f (want 1)", one);
+    CHECK(milli > -0.01f && milli < 0.01f, "0.001 -> %f (want 0)", milli);
+    CHECK(map_01_to_60dBf(map_60dB_to_01f(0.5f)) > 0.45f &&
+          map_01_to_60dBf(map_60dB_to_01f(0.5f)) < 0.55f,
+          "0.5 round-trips (%f)", map_01_to_60dBf(map_60dB_to_01f(0.5f)));
+
+    printf("an oscillator with a junk amplitude renders instead of wedging\n");
+    // The shape the fuzzer found: a negative ratio (logratio NaN) and an
+    // out-of-range amp, then a note-on to make the envelopes run.
+    amy_add_message((char *)"v0w0I-1a0.0000001l1n60Z");
+    render_a_bit();
+    CHECK(1, "negative ratio + tiny amp rendered");
+    amy_add_message((char *)"S8192Z");
+    render_a_bit();
+
+    printf("a DX7 attack past the mapping's ceiling renders too\n");
+    // Breakpoint values above ~2.37 drive MAP_ATTACK_LEVEL_S to zero.
+    amy_add_message((char *)"v1w0T2A0,3.0,100,4.0,200,0Zl1n60Z");
+    render_a_bit();
+    CHECK(1, "oversized DX7 breakpoints rendered");
+
+    if (failures) { printf("%d FAILURES\n", failures); return 1; }
+    printf("all ok\n");
+    return 0;
+}


### PR DESCRIPTION
## The hang

`log2_lut()` normalizes its argument into `[1, 2)` by shifting, so a non-positive one never returns — shifting zero left leaves zero. The precondition was a commented-out `// assert(x > 0);`, and two callers didn't meet it:

- **`map_60dB_to_01f`** guarded `lin == 0`, in *float*. That misses a negative amplitude, a NaN, and — in fixed-point builds, 23 fractional bits — any amplitude too small to survive `F2S`. Any of those wedges the render thread: no crash, no message, just silence and a pegged core.
- **The DX7 attack branch** in `envelope.c` feeds it `MAP_ATTACK_LEVEL_S`, which reaches zero once a breakpoint value passes ~2.37. A hand-written patch can ask for that; no fuzzing needed.

The other three call sites already guarantee a positive argument (`logfreq_of_freq` has `if (freq<=0) return 0;`, the envelope decay branch floors with `MAX(F2S(BREAKPOINT_EPS), …)`).

Backtrace from the wedged process:

```
#0  log2_lut (x=0) at src/log2_exp2.c:17     // while (x < F2S(1.0f))
#1  map_60dB_to_01f (lin=<optimized out>) at src/amy.c:660
#3  amp_combine_controls (...) at src/amy.c:1817
#4  hold_and_modify (osc=0) at src/amy.c:1886
#5  render_osc_wave (...) / amy_render / amy_simple_fill_buffer
```

## The fix, in three places deliberately

- **`log2_lut` floors its argument**, branch-free (`MAX`, which takes the floor for NaN too since `NaN > y` is false). This is the hot path, so it was measured — see below.
- **`map_60dB_to_01f` keeps its own guard**, now covering everything that isn't safely positive, so silence still returns the `-10` sentinel rather than a very negative number. Same single comparison it always had.
- **`envelope.c` floors the mapped attack levels** the way the decay branch below it already floors `v0`/`v1`. The `log2_lut` guard alone would leave both levels equal there and divide by zero computing `t_const`.

## Cost, measured on AMYboard

`tools/arduino_loadsweep`, 6-note chord, 20 s captures:

| | runs (final) |
|---|---|
| main | 2514 / 2515 / 2556 |
| this PR | 2520 / 2520 / 2521 |

**+5 to +6, about +0.2%**, and +284 bytes of flash. The rig's own run-to-run spread (that 2556, max 2841) is larger than the effect.

## How it was found, and why CI never caught it

`TestFuzzWireParser` hangs at its 92nd random message on x86 — an amp coefficient lands on the wrong side of the underflow there, while the same message on arm64 does not. That test arrived in #1089, whose CI run was **cancelled**, and no C/C++ CI run has completed on main since. So this has been sitting in main unnoticed, and it is what has been stalling every recent PR's Python jobs at 'in progress' for hours.

## Testing

- New `tests/test_log2_lut.c`: zero, negative, NaN, underflow, the DX7 ceiling, and that the documented mapping still holds (`1.0→1`, `0.001→0`, round-trip). It calls `alarm(30)`, so a missing guard fails in half a minute rather than leaving a job 'in progress' for six hours. **Verified it hangs (exit 142) with these changes reverted.**
- `make ctest` 8/8, `make test` 132/132 locally (arm64, where the fuzz test passed before too — x86 CI on this PR is the real check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)