### PR TITLE
speedtest: run measure.py with ${PYTHON}, like every other target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,13 +149,13 @@ speedtest:
 	echo "Compiling LoadTestChord.ino..."
 	arduino-cli compile --fqbn esp32:esp32:amyboard --build-path ./build --build-property "compiler.c.extra_flags=-DARDUINO_SPEEDTEST" tools/arduino_loadsweep/LoadTestChord
 	echo 'Running measure.py.  Press RESET on board after seeing "[flash] ok (attempt 1)"'
-	python tools/arduino_loadsweep/measure.py --out ./load --port ${USBSERIAL} ./build
+	${PYTHON} tools/arduino_loadsweep/measure.py --out ./load --port ${USBSERIAL} ./build
 
 speedtest-piano:
 	echo "Compiling LoadTestChord.ino..."
 	arduino-cli compile --fqbn esp32:esp32:amyboard --build-path ./build --build-property "compiler.c.extra_flags=-DARDUINO_SPEEDTEST" --build-property "compiler.cpp.extra_flags=-DSPEEDTEST_PATCH=256 -DSPEEDTEST_NUM_NOTES=6" tools/arduino_loadsweep/LoadTestChord
 	echo 'Running measure.py.  Press RESET on board after seeing "[flash] ok (attempt 1)"'
-	python tools/arduino_loadsweep/measure.py --out ./load --port ${USBSERIAL} ./build
+	${PYTHON} tools/arduino_loadsweep/measure.py --out ./load --port ${USBSERIAL} ./build
 
 valgrind: amy-example
 	valgrind --leak-check=full --show-reachable=yes --suppressions=valgrind.suppressions ./amy-example


### PR DESCRIPTION
The two `speedtest` recipes called a bare `python`. Inside the project venv (`amy/venv`) that resolves fine — which is why this has never bitten — but outside it there may be no `python` at all, and the target dies *after* a successful two-minute compile:

```
make: python: No such file or directory
make: *** [speedtest] Error 1
```

Every other Python-invoking target in the Makefile already uses `${PYTHON}`, which defaults to `python3` at line 46. This makes these two match.

Note `measure.py` also imports pyserial, so running outside the venv needs an interpreter that has it — e.g. `make speedtest PYTHON=~/.espressif/python_env/idf5.4_py3.14_env/bin/python`. The venv has both, so `make speedtest` from there is unchanged.

Makefile-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)