### PR TITLE
Loop checks walk the osc graph without allocating it

### DIFF
--- a/src/amy.c
+++ b/src/amy.c
@@ -1372,8 +1372,10 @@ int chained_osc_would_cause_loop(uint16_t osc, uint16_t chained_osc) {
     // Check to see if chaining this osc would cause a loop.
     uint16_t next_osc = chained_osc;
     do {
-        // An osc we can't allocate can't be linked.
-        if (!ensure_osc_allocd(next_osc, NULL)) return true;
+        // Walk without allocating: an osc with no storage is at its defaults,
+        // so its chained_osc is unset and the chain ends here -- no loop. The
+        // link site allocates what it is about to write to.
+        if (synth[next_osc] == NULL) return false;
         if (next_osc == osc) {
             fprintf(stderr, "chaining osc %d to osc %d would cause loop.\n",
                     chained_osc, osc);
@@ -1393,8 +1395,9 @@ int chained_osc_would_cause_loop(uint16_t osc, uint16_t chained_osc) {
 static bool mod_osc_reaches(uint16_t from, uint16_t target, int *budget) {
     if (!AMY_IS_SET(from)) return false;
     if ((*budget)-- <= 0) return true;
-    // An osc we can't allocate can't be linked.
-    if (!ensure_osc_allocd(from, NULL)) return true;
+    // Walk without allocating (see chained_osc_would_cause_loop): an osc with
+    // no storage has no mod_sources, so it reaches nothing.
+    if (synth[from] == NULL) return false;
     if (from == target) return true;
     for (int i = 0; i < NUM_MOD_SOURCES; ++i)
         if (mod_osc_reaches(synth[from]->mod_source[i], target, budget)) return true;
@@ -1555,7 +1558,8 @@ void play_delta(struct delta *d) {
     if(d->param == CHAINED_OSC) {
         int chained_osc = d->data.i;
         if (chained_osc >=0 && chained_osc < AMY_OSCS &&
-            !chained_osc_would_cause_loop(d->osc, chained_osc)) {
+            !chained_osc_would_cause_loop(d->osc, chained_osc) &&
+            ensure_osc_allocd(chained_osc, NULL)) {
             synth[d->osc]->chained_osc = chained_osc;
             synth[chained_osc]->role = SYNTH_IS_CHAINED;
         } else {
@@ -1608,11 +1612,11 @@ void play_delta(struct delta *d) {
         // CHAINED_OSC above - a cycle must be rejected before it is stored or
         // the recursion never terminates.
         if (mod_osc >= 0 && mod_osc < AMY_OSCS &&
-            !mod_osc_would_cause_loop(d->osc, mod_osc)) {
+            !mod_osc_would_cause_loop(d->osc, mod_osc) &&
+            ensure_osc_allocd(mod_osc, NULL)) {
             synth[d->osc]->mod_source[which_source] = mod_osc;
             // NOTE: These are delta-only side effects.  A purist would strive to remove them.
             // When an oscillator is named as a modulator, we change its state.
-            ensure_osc_allocd(mod_osc, NULL);
             synth[mod_osc]->role = SYNTH_IS_MOD_SOURCE;
             // Remove default amplitude dependence on velocity when an oscillator is made a modulator.
             synth[mod_osc]->amp_coefs[COEF_VEL] = 0;


### PR DESCRIPTION
Follow-up to the review of #1106, which is about not materializing oscs that nothing is playing yet. Two functions were doing exactly that behind a predicate's back.

## What they did

`chained_osc_would_cause_loop()` and `mod_osc_reaches()` called `ensure_osc_allocd()` on every osc they walked past. Asking *"would this link close a cycle?"* allocated storage along the way — including for chains whose answer turned out to be no.

They're predicates now: they stop at an osc with no storage and report no loop. That's what an osc at its defaults means — `chained_osc` unset, no `mod_source`s — so the walk genuinely ends there.

## Where the allocation went

To the link sites, which are the code that actually writes:

- **`CHAINED_OSC`** wrote `synth[chained_osc]->role` behind nothing but a range check. It was safe only because the predicate happened to allocate on its way through — an unstated dependency that would break the first time someone moved that ensure. (Which is how this came up: #1106 moves an ensure off the ingest path, and the question was whether chaining still worked. It did, via this.)
- **`MOD_SOURCE`** did call `ensure_osc_allocd(mod_osc)`, but ignored the result and dereferenced regardless. The predicate's ensure was what actually covered OOM. Making the predicate pure would have exposed that, so it's fixed here too.

Both are conditions of the link now, so an osc that cannot be allocated is not linked — the same outcome the predicates used to produce by returning "would cause loop", just stated where it happens.

## Testing

Behavior is unchanged for anything that links. Verified against the C state directly:

```
chain to untouched osc 9: osc0->chained_osc=9, synth[9] allocated, role=3 (SYNTH_IS_CHAINED)
self-chain:               osc0->chained_osc=65535 (refused)
mod to untouched osc 7:   osc0->mod_source[0]=7, synth[7] role=1 (SYNTH_IS_MOD_SOURCE)
```

`make ctest` 9/9, `make test` 132/132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)