### PR TITLE
esp32: only yield past-overload when rendering actually can't keep up

### DIFF
--- a/src/i2s.c
+++ b/src/i2s.c
@@ -379,11 +379,18 @@ void esp_fill_audio_buffer_task() {
         // i2s DMA write (or the update-sync wait) above, which is when lower-priority
         // tasks on this core get to run.
         amy_overload_check(busy_us);
-        // If the audio output didn't block at all, we're past overloaded, and this
-        // max-priority task would starve everything else on this core (USB, MIDI,
-        // the host app).  Audio is already breaking up, so give the rest of the
-        // system a tick.
-        if (blocked_us < 150) vTaskDelay(1);
+        // If rendering genuinely can't keep up (a block costs at least its own
+        // real-time budget) AND the audio output didn't block, we're past
+        // overloaded, and this max-priority task would starve everything else
+        // on this core (USB, MIDI, the host app).  Audio is already breaking
+        // up, so give the rest of the system a tick.
+        //
+        // Both conditions matter: with a small DMA ring a healthy just-in-time
+        // iteration can also see blocked_us == 0, and one tick here (10 ms at
+        // a 100 Hz tick rate) can be bigger than the whole ring -- a single
+        // spurious delay underruns it, the drained ring makes the next write
+        // not block either, and the delay re-arms forever (#1118).
+        if (busy_us >= AMY_BLOCK_US && blocked_us < 150) vTaskDelay(1);
     }
 }
 


### PR DESCRIPTION
Fixes #1118.

The `vTaskDelay(1)` added with the overload failsafe (#791) fires on any iteration where the i2s write didn't block (`blocked_us < 150`). That's the right signal with a large DMA ring: past overload the write never blocks, and a max-priority task that never blocks starves USB CDC / MIDI / the host app on its core — the delay is what keeps the board from wedging.

But with a DMA ring shrunk for low latency (as in #1118: 2 descriptors × 32 frames ≈ 1.5 ms against a 2.9 ms block), a perfectly **healthy** just-in-time iteration can also legitimately see `blocked_us ≈ 0`. One tick of delay — 10 ms at a 100 Hz RTOS tick — is then bigger than the entire ring, so a single spurious trigger underruns it; the drained ring makes the *next* write return immediately too, and the delay re-arms on every iteration forever. That's the self-sustaining "it keeps creating its own overloads" behavior reported, and it's why low-latency DMA configurations were unusable without commenting the line out.

The fix gates the yield on genuine overload as well:

```c
if (busy_us >= AMY_BLOCK_US && blocked_us < 150) vTaskDelay(1);
```

- **Starvation protection is fully preserved.** In real overload, rendering one block costs at least the block's real-time budget by definition, so `busy_us >= AMY_BLOCK_US` always holds there — including when the failsafe threshold is disabled (`overload_threshold = 0`), which is why gating on the failsafe's own smoothed counter wouldn't be enough.
- **A healthy loop can never trigger it**, no matter how small the DMA ring or how coarse the tick, because `busy_us` stays under the block budget whenever rendering keeps up. No new config knob, no tick-rate coupling.
- **The death spiral becomes impossible**: a just-in-time write on its own can't start it.

This is the same class of fix as #960 (the MIDI UART timeout that was integer-zero at a 100 Hz tick): tick-rate-dependent behavior replaced by a condition that's only true when it should be.

Simply removing the delay (suggested in the issue) would reintroduce the wedge #791 fixed: the "FreeRTOS already yields when the task blocks" argument is correct for the healthy case, but in genuine overload the task never blocks, so the scheduler never runs anything lower-priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)