### PR TITLE
Recheck synth[] before following one osc's reference to another

### DIFF
--- a/src/algorithms.c
+++ b/src/algorithms.c
@@ -153,7 +153,8 @@ void note_on_mod(uint16_t osc, uint16_t algo_osc) {
 
 void algo_note_off(uint16_t osc) {
     for(uint8_t i=0;i<MAX_ALGO_OPS;i++) {
-        if(AMY_IS_SET(synth[osc]->algo_source[i])) {
+        if(AMY_IS_SET(synth[osc]->algo_source[i])
+           && synth[synth[osc]->algo_source[i]] != NULL) {
             uint16_t o = synth[osc]->algo_source[i];
             AMY_UNSET(synth[o]->note_on_clock);
             synth[o]->note_off_clock = amy_global.total_blocks * AMY_BLOCK_SIZE;
@@ -168,7 +169,8 @@ void algo_note_off(uint16_t osc) {
 void algo_note_on(uint16_t osc, float freq) {
     msynth[osc]->logfreq = logfreq_of_freq(freq);
     for(uint8_t i=0;i<MAX_ALGO_OPS;i++) {
-        if(AMY_IS_SET(synth[osc]->algo_source[i])) {
+        if(AMY_IS_SET(synth[osc]->algo_source[i])
+           && synth[synth[osc]->algo_source[i]] != NULL) {
             note_on_mod(synth[osc]->algo_source[i], osc);
         }
     }
@@ -244,7 +246,11 @@ SAMPLE render_algo(SAMPLE* buf, uint16_t osc, uint8_t core) {
         }
 
         SAMPLE value = 0;
+        // As with mod_source, an algo_source osc can have been freed since it
+        // was named, leaving synth[] NULL; render_algo is reached past
+        // amy_render's null skip.
         if(AMY_IS_SET(synth[osc]->algo_source[op])
+           && synth[synth[osc]->algo_source[op]] != NULL
            && synth[synth[osc]->algo_source[op]]->role == SYNTH_IS_ALGO_SOURCE) {
             value = render_mod(in_buf, out_buf, synth[osc]->algo_source[op], feedback_level, osc, mod_amp);
         } // If osc is not set, output has already been cleared.

--- a/src/amy.c
+++ b/src/amy.c
@@ -1479,7 +1479,7 @@ void play_delta(struct delta *d) {
               || synth[osc]->role == SYNTH_IS_ALGO_SOURCE
               || synth[osc]->role == SYNTH_IS_CHAINED
               || synth[osc]->wave == PARTIAL)) {
-            while(AMY_IS_SET(osc)) {
+            while(AMY_IS_SET(osc) && synth[osc] != NULL) {  // a freed link ends the chain
                 synth[osc]->midi_note = d->data.f;
                 osc = synth[osc]->chained_osc;
             }
@@ -1718,7 +1718,7 @@ void play_delta(struct delta *d) {
             // Loop through chained oscs
             uint16_t osc = d->osc;
             //fprintf(stderr, "t %.3f: delta note_on: osc %d vel %.3f\n\r", amy_global.time, osc, d->data.f);
-            while(AMY_IS_SET(osc)) {
+            while(AMY_IS_SET(osc) && synth[osc] != NULL) {  // a freed link ends the chain
                 //fprintf(stderr, "osc: %d wave %d role %d\n\r", osc, synth[osc]->wave, synth[osc]->role);
                 // Ignore velocity events for mod source / algo / partial notes.
                 if (!(synth[osc]->role == SYNTH_IS_MOD_SOURCE
@@ -1754,7 +1754,8 @@ void play_delta(struct delta *d) {
                     // trigger the mod sources, for however many we have
                     for (int m = 0; m < NUM_MOD_SOURCES; ++m) {
                         uint16_t mod_osc = synth[osc]->mod_source[m];
-                        if(AMY_IS_SET(mod_osc)) {
+                        // A modulator named by this osc may have been freed.
+                        if(AMY_IS_SET(mod_osc) && synth[mod_osc] != NULL) {
                             if (AMY_IS_SET(synth[mod_osc]->trigger_phase))
                                 synth[mod_osc]->phase = F2P(synth[mod_osc]->trigger_phase);
                             synth[mod_osc]->note_on_clock = amy_global.total_samples;  // Need a note_on_clock to have envelope work correctly.
@@ -1781,7 +1782,7 @@ void play_delta(struct delta *d) {
             }
         } else if(synth[d->osc]->velocity > 0 && d->data.f == 0) { // new note off
             uint16_t osc = d->osc;
-            while(AMY_IS_SET(osc)) {
+            while(AMY_IS_SET(osc) && synth[osc] != NULL) {  // a freed link ends the chain
                 if (!(synth[osc]->role == SYNTH_IS_MOD_SOURCE
                       || synth[osc]->role == SYNTH_IS_ALGO_SOURCE
                       || synth[osc]->wave == PARTIAL)) {
@@ -2073,7 +2074,7 @@ SAMPLE render_osc_wave(uint16_t osc, uint8_t core, SAMPLE* buf) {
             //printf("h&m: time %.3f osc %d OFF\n", amy_global.time, osc);
             // Oscillator has fallen silent, stop executing it.
             uint16_t osc_to_stop = osc;  // Type must match synthinfo.chained_osc
-            while (AMY_IS_SET(osc_to_stop)) {
+            while (AMY_IS_SET(osc_to_stop) && synth[osc_to_stop] != NULL) {  // a freed link ends the chain
                 synth[osc_to_stop]->status = SYNTH_INAUDIBLE;  // It *could* come back...
                 // 2026-03-22: It's necessary to reset these two fields in msynth to get OwBass to restart without click...
                 msynth[osc_to_stop]->filter_logfreq = 0;  // (a)

--- a/src/envelope.c
+++ b/src/envelope.c
@@ -41,7 +41,12 @@ AMY_IRAM_ATTR SAMPLE compute_mod_scale(uint16_t osc, uint16_t which_source) {
     // mod slots.
     uint16_t source = synth[osc]->mod_source[which_source];
     if(AMY_IS_SET(source)) {
-        if(source != osc) {  // belt-and-braces; assignment already rejects this
+        // synth[source] can be NULL: FREE_OSC returns a released voice's osc
+        // storage to the heap, while every osc that named it as a modulator
+        // still holds its number.  amy_render's own null skip doesn't cover
+        // this descent, so recheck here -- the same reason render_osc_wave
+        // rechecks before following chained_osc.
+        if(source != osc && synth[source] != NULL) {  // belt-and-braces; assignment already rejects self as source
             hold_and_modify(source);
             return compute_mod_value(source);
         }

--- a/tests/test_osc_free_on_release.c
+++ b/tests/test_osc_free_on_release.c
@@ -156,6 +156,98 @@ static void test_builtin_patch_release(void) {
     CHECK(all_null(owned, n), "and freed them on release");
 }
 
+// --- References held by OTHER oscs -------------------------------------
+//
+// Freeing an osc NULLs its synth[] slot, but nothing walks the rest of the
+// array to clear the references to it: mod_source, algo_source and
+// chained_osc are all stored as bare osc numbers. amy_render skips a NULL
+// osc at the top of its loop, so the referrer itself is safe -- but the
+// recursive descents past that skip (compute_mod_scale -> hold_and_modify,
+// render_algo -> render_mod) and the note-on mod trigger in play_delta all
+// dereferenced the referenced osc without rechecking, which is a segfault
+// on the render thread. render_osc_wave already rechecks before following
+// chained_osc, for exactly this reason.
+//
+// The dangling reference is built the way it arises in the field: a bare
+// osc names an osc that no voice owns yet, and the voice allocator -- which
+// only skips oscs with osc_to_voice set -- later hands that same osc to a
+// voice, whose release then frees it.
+
+// An osc currently owned by instrument `instr`, or AMY_UNSET_VALUE on none.
+static uint16_t an_owned_osc(int instr) {
+    uint16_t owned[MAX_OWNED];
+    int n = collect_owned(instr, owned);
+    return n ? owned[0] : (uint16_t)0xFFFF;
+}
+
+static void test_render_survives_freed_mod_source(void) {
+    printf("rendering an osc whose mod_source was freed does not crash\n");
+    send("i36iv1uv0w0f220Zv1w0f330Z");
+    uint16_t victim = an_owned_osc(36);
+    CHECK(victim != 0xFFFF, "found an osc owned by the synth (%d)", victim);
+    char m[64];
+    // A bare osc, modulated by an osc the synth owns.
+    snprintf(m, sizeof(m), "v0w0f220L%dZ", victim);
+    send(m);
+    send("v0f220l1Z");
+    CHECK(synth[0] != NULL && synth[0]->mod_source[0] == victim,
+          "bare osc 0 is modulated by osc %d", victim);
+    // Release the synth: the modulator goes away, osc 0 keeps its number.
+    send("i36iv0Z");   // <- rendered past a NULL modulator before the fix
+    CHECK(synth[victim] == NULL, "the modulator was freed");
+    CHECK(synth[0] != NULL, "the osc that named it is still here");
+    render_a_bit();
+    CHECK(1, "rendered with a dangling mod_source");
+    send("v0l0Z");
+}
+
+static void test_note_on_survives_freed_mod_source(void) {
+    printf("a note-on whose mod_source was freed does not crash\n");
+    send("i37iv1uv0w0f220Zv1w0f330Z");
+    uint16_t victim = an_owned_osc(37);
+    char m[64];
+    snprintf(m, sizeof(m), "v2w0f220L%dZ", victim);
+    send(m);
+    send("i37iv0Z");
+    CHECK(synth[victim] == NULL, "the modulator was freed");
+    // play_delta's note-on walks mod_source[] to trigger the modulators.
+    send("v2f220l1Z");
+    CHECK(1, "note-on with a dangling mod_source");
+    send("v2l0Z");
+}
+
+static void test_render_survives_freed_algo_source(void) {
+    printf("rendering an algo osc whose algo_source was freed does not crash\n");
+    send("i38iv1uv0w0f220Zv1w0f330Z");
+    uint16_t victim = an_owned_osc(38);
+    char m[64];
+    snprintf(m, sizeof(m), "v3w%do1O%dZ", ALGO, victim);
+    send(m);
+    send("v3l1Z");
+    send("i38iv0Z");
+    CHECK(synth[victim] == NULL, "the algo source was freed");
+    render_a_bit();
+    CHECK(1, "rendered with a dangling algo_source");
+    send("v3l0Z");
+}
+
+static void test_note_survives_freed_chained_osc(void) {
+    printf("a note on an osc whose chained_osc was freed does not crash\n");
+    send("i39iv1uv0w0f220Zv1w0f330Z");
+    uint16_t victim = an_owned_osc(39);
+    char m[64];
+    snprintf(m, sizeof(m), "v4w0f220c%dZ", victim);
+    send(m);
+    send("i39iv0Z");
+    CHECK(synth[victim] == NULL, "the chained osc was freed");
+    // play_delta walks the chain on note, velocity and note-off.
+    send("v4n60Z");
+    send("v4f220l1Z");
+    render_a_bit();
+    send("v4l0Z");
+    CHECK(1, "note on/off walked a chain ending in a freed osc");
+}
+
 // AMY calls these; the test binary has to provide them.
 void delay_ms(uint32_t ms) { (void)ms; }
 
@@ -170,6 +262,10 @@ int main(void) {
     test_freed_oscs_come_back();
     test_cycles_reach_steady_state();
     test_builtin_patch_release();
+    test_render_survives_freed_mod_source();
+    test_note_on_survives_freed_mod_source();
+    test_render_survives_freed_algo_source();
+    test_note_survives_freed_chained_osc();
 
     if (failures) { printf("%d FAILURES\n", failures); return 1; }
     printf("all ok\n");


### PR DESCRIPTION
Fixes a SIGSEGV on the audio thread introduced by osc-free-on-release (#1105 / #1107).

## What happens

Freeing an osc NULLs its `synth[]` slot, but nothing walks the rest of the array to clear the references **to** it. `mod_source`, `algo_source` and `chained_osc` are all stored as bare osc numbers, and there is no back-pointer to invalidate them. While `synth[osc]` stayed allocated for the whole session, a stale reference was at worst a wrong sound; now it is a null deref inside `amy_render`.

`amy_render()` skips a NULL osc at the top of its loop, so the *referrer* is safe. Each descent past that skip needs its own check — which `render_osc_wave()` already does before following `chained_osc`:

```c
if (synth[chained_osc] != NULL && synth[chained_osc]->status == SYNTH_AUDIBLE) {  // We have to recheck this since we're bypassing the skip in amy_render.
```

Seven other places did not:

| | |
|---|---|
| `envelope.c` `compute_mod_scale` | `hold_and_modify(source)` — **the reported crash** |
| `algorithms.c` `render_algo` | `synth[algo_source[op]]->role` |
| `algorithms.c` `algo_note_on` / `algo_note_off` | `algo_source[i]` |
| `amy.c` `play_delta` | the `mod_source[m]` note-on trigger loop |
| `amy.c` `play_delta` | three `chained_osc` walks (MIDI_NOTE, note-on, note-off) |
| `amy.c` `render_osc_wave` | the fall-silent `chained_osc` walk |

Each is a one-line recheck; none changes behaviour for an allocated osc.

## How it was found

A crash report from a desktop (macOS / miniaudio) build: `EXC_BAD_ACCESS` at `0xc` on `com.apple.audio.IOThread.client`. The binary was stripped, but the instruction bytes in the report identify it exactly —

```
ldr  x8, [x20]                  ; synth
ldr  x8, [x8, w0, uxtw #3]      ; synth[osc], osc = 0x76 = 118 -> NULL
ldp  s1, s2, [x8, #0xc]         ; ->midi_note, ->velocity     far = 0xc
```

`hold_and_modify+68`, reached by `amy_render → render_osc_wave → hold_and_modify → compute_mod_scale → hold_and_modify`. Worth noting that every Juno patch names osc 1 as the mod source of its other five oscs (`v0…L1Z v2…L1Z v3…L1Z v4…L1Z v5w5L1Z`), so a single Juno voice carries five references to one osc.

## Tests

Four cases added to `tests/test_osc_free_on_release.c`, one per reference kind. They build the dangling reference the way it arises in practice rather than by calling `free_osc()` directly: a bare osc names an osc that no voice owns yet, the voice allocator (which only skips oscs with `osc_to_voice` set) later hands that same osc to a voice, and the voice's release frees it.

Each case segfaults on `main` and passes here. `make ctest` green, `make qtest` 132/132 unchanged, `make check-c-api` clean.

## What this does not do

It stops the crash; it does not stop a reference going stale. A freed osc that is re-allocated for something else still leaves the referrer pointing at whatever now lives at that number — a wrong modulator rather than a crash. Actually fixing that means either clearing back-references when an osc is freed, or refusing to free an osc that is still named. Both are bigger changes than this, and neither is needed to stop the segfault.
