### PR TITLE
Let amy_render_audio register amy_update_handle itself

### DIFF
--- a/src/i2s.c
+++ b/src/i2s.c
@@ -44,9 +44,10 @@
 //      - If I2S enabled, write samples to I2S.
 //      - loop
 //   * ESP's amy_platform_init
+//      - if the app renders via amy_update() (Arduino, or audio without built-in
+//        I2S), register the calling task as amy_update_handle
 //      - if multicore, launch esp_render_task
 //      - if multithread, launch esp_fill_audio_buffer_task
-//      - if not I2S, Notify fill_buffer to get it started
 //   * ESP's amy_render_audio
 //      - If multithread, wait for Notification (from fill_audio_buffer)
 //      - If not I2S, Notify fill_buffer
@@ -400,8 +401,15 @@ void amy_platform_init() {
     // However, if we're not using amy_update (e.g., Tulip/AMYboard native), we don't
     // want to do this - the un-handled xTaskNotifyGives cause Tulip to crash when it
     // turns on WiFi.
+    // ARDUINO builds always render via amy_update().  Non-Arduino builds do too
+    // whenever the audio output is not the built-in I2S (nothing else consumes the
+    // rendered blocks), so there the gate is the audio config, not the platform.
+    // Registering at init requires amy_start() to be called from the task that
+    // will call amy_update() - already the (implicit) Arduino contract.
 #ifdef ARDUINO
     amy_update_handle = xTaskGetCurrentTaskHandle();
+#else
+    if (!AMY_HAS_I2S) amy_update_handle = xTaskGetCurrentTaskHandle();
 #endif
     if (AMY_HAS_I2S) {
         // Start i2s
@@ -450,7 +458,8 @@ void amy_update_tasks() {
 }
 
 int16_t *amy_render_audio() {
-    // Called by api.amy_update() to render the audio.  Not used for non-Arduino.
+    // Called by api.amy_update() to render the audio.  Not used by builds with
+    // their own audio loop (e.g. Tulip/AMYboard native).
     int16_t *buf = NULL;
     if (amy_global.config.platform.multithread) {
         // Wait for esp_fill_audio_buffer_task to indicate a buffer is ready.


### PR DESCRIPTION


> **Reworked 2026-08-24.** The branch was force-pushed with a single new
> commit and this description rewritten to match. The previous shape (lazy
> registration in `amy_render_audio()` plus a fill-task startup hold) is
> gone; registration now happens once at init, gated on the audio config.
> Comments below from before this date discuss the old diff.

## Problem

The use-case is a plain ESP-IDF app (no Arduino) whose audio output is not the
built-in I2S - ours renders into USB audio (UAC callbacks). The natural config
is `multithread = 1` with `config.audio = AMY_AUDIO_IS_NONE`:
`esp_fill_audio_buffer_task` renders in the background, and the app's audio
task pulls each finished block with `amy_update()`.

That config deadlocks on the first block. `amy_update_handle` is set only
under `#ifdef ARDUINO`, so on ESP-IDF it stays NULL and the notify pair never
starts:

- the fill task renders block 1, skips its ready-notify
  (`if (amy_update_handle)` fails), and parks in the `!AMY_HAS_I2S`
  update-sync wait - which only `amy_render_audio()` releases;
- `amy_render_audio()` sits in `ulTaskNotifyTake(portMAX_DELAY)` waiting for
  the ready-notify that was skipped.

Each task now waits on the other with no timeout. The I2S path never notices:
there the fill task paces on the DMA write and needs no handle. So in
practice, multithread rendering on plain ESP-IDF is routable only to the
built-in I2S output.

This bit me at the very start of an ESP32-S3 synth project with USB (UAC)
output: attempts to drive amy_update() with background rendering hung at the
first block. The fix removes that fork in the road for the next
non-I2S integration.

## Fix

`#ifdef ARDUINO` is a proxy for "this build runs amy_update()". A non-Arduino
build without built-in I2S must be running `amy_update()` too - nothing else
consumes the rendered blocks - so this gates the same init-time registration
on the audio config: register also when `!AMY_HAS_I2S`. Tulip/AMYboard native
run their own audio loop over I2S and stay unregistered, so the stray-notify
crash the guard protects them from is unaffected.

Registration stays at init - no per-block work, reworked from the previous
lazy-registration shape per review. The tradeoff is a stated contract rather
than a new init option: `amy_start()` must be called from the task that will
call `amy_update()`, the contract Arduino builds already rely on implicitly.
The audio config already says "no built-in consumer", so a separate init
option would restate it.

Registration lands before the fill task is created, so the block-1
ready-notify cannot be dropped and the first handoff needs no special
handling.

## Verification

Verification updated with an A/B bench:

On-target A/B on an ESP32-S3 (ESP-IDF 6.0.2): a minimal app starts AMY with
`multithread = 1` and `AMY_AUDIO_IS_NONE` and pulls blocks with
`amy_update()` from the task that called `amy_start()`. At main (9a8385f)
the first `amy_update()` never returns - a watchdog task reports 0 blocks
indefinitely. With this change, blocks free-run at ~4,100/s with nonzero
rendered audio, steady over the capture. Arduino builds compile the same
registration line under the same `#ifdef` as before.

