### PR TITLE
Join the second-core render with a dedicated semaphore

### DIFF
--- a/src/i2s.c
+++ b/src/i2s.c
@@ -13,6 +13,7 @@
 
 #ifdef ESP_PLATFORM
 #include <esp_task.h>
+#include "freertos/semphr.h"
 
 ///////////////////////////////////////////////////////////////
 // ESP32, S3, P4 (maybe others)
@@ -30,7 +31,7 @@
 //   * esp_render_task (the task that runs on the second core):
 //      - Waits for notification (from main fill_audio thread)
 //      - renders half the oscs
-//      - notifies either fill_buffer (multithread) or amy_update (single thread) when done.
+//      - gives esp_render_done_sem when done, releasing whichever task ran esp_render_on_cores.
 //      - loop
 //   * esp_fill_audio_buffer_task (launched as one parallel task):
 //      - if not using I2S, waits for notification (from amy_update task)
@@ -38,7 +39,7 @@
 //      - execute AMY command updates (deltas)
 //      - Notify esp_render_task
 //      - render the other half of oscs
-//      - Wait for notification (indicating that esp_render_task is done)
+//      - Wait for esp_render_done_sem (indicating that esp_render_task is done)
 //      - call amy_fill_buffer (to combine the rendered oscs into output samples)
 //      - Notify amy_update_handle that the new block is ready
 //      - If I2S enabled, write samples to I2S.
@@ -52,7 +53,7 @@
 //      - If not I2S, Notify fill_buffer
 //      - If not multithread
 //        - If multicore, Notify amy_render_handle to get task on second core to render
-//          - wait for Notification indicating esp_render_task is done
+//          - wait for esp_render_done_sem indicating esp_render_task is done
 //        - else render all oscs
 //        - call amy_fill_buffer
 
@@ -254,30 +255,33 @@ TaskHandle_t amy_fill_buffer_handle;
 // Task to notify when amy_update is waiting for a completed buffer
 TaskHandle_t amy_update_handle = NULL;
 
-// Who esp_render_task tells that it is done.
-TaskHandle_t amy_render_task_done_handle = NULL;
+// Signals completion from esp_render_task back to esp_render_on_cores.  A
+// dedicated semaphore, not a task notification: the joining task can be any app
+// task (e.g. the one running amy_update()), and apps commonly pace such a task
+// with task notifications of their own.  A join on the shared default-index
+// notification counter can be released early by an unrelated notify, making the
+// caller combine the worker's half-written buffer.
+static SemaphoreHandle_t esp_render_done_sem = NULL;
 
 // Render the second core
 void esp_render_task( void * pvParameters) {
     while(1) {
         ulTaskNotifyTake(pdTRUE, portMAX_DELAY);  // from esp_render_on_cores
         amy_render(0, AMY_OSCS/2, 1);
-        // Tell (someone) we're done.
-        xTaskNotifyGive(amy_render_task_done_handle);  // to esp_render_on_cores
+        // Tell the caller we're done.
+        xSemaphoreGive(esp_render_done_sem);  // to esp_render_on_cores
     }
 }
 
 void esp_render_on_cores() {
     // Call amy_render on all the oscs, using multicore if available.
     if (amy_global.config.platform.multicore) {
-        // Tell the esp_render_task to inform *us* when it's done.
-        amy_render_task_done_handle = xTaskGetCurrentTaskHandle();
         // Tell the other core to start rendering.
         xTaskNotifyGive(amy_render_handle);  // to esp_render_task
         // Render me
         amy_render(AMY_OSCS/2, AMY_OSCS, 0);
         // Wait for the other core to finish
-        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);  // from esp_render_task
+        xSemaphoreTake(esp_render_done_sem, portMAX_DELAY);  // from esp_render_task
     } else {
         // We render everything on this core.
         amy_render(0, AMY_OSCS, 0);
@@ -409,7 +413,8 @@ void amy_platform_init() {
     }
     if (amy_global.config.platform.multicore) {
         // On ESP, multicore starts a second thread even if multithread is not requested.
-        // Create the second core rendering task
+        // Create the second core rendering task and its completion semaphore
+        esp_render_done_sem = xSemaphoreCreateBinary();
         xTaskCreatePinnedToCore(&esp_render_task, AMY_RENDER_TASK_NAME, AMY_RENDER_TASK_STACK_SIZE, NULL, AMY_RENDER_TASK_PRIORITY, &amy_render_handle, AMY_RENDER_TASK_COREID);
     }
     if (amy_global.config.platform.multithread) {
@@ -428,6 +433,8 @@ void amy_platform_deinit() {
     }
     if (amy_global.config.platform.multicore) {
         vTaskDelete(amy_render_handle);
+        vSemaphoreDelete(esp_render_done_sem);
+        esp_render_done_sem = NULL;
     }
     if (amy_global.config.platform.multithread) {
         vTaskDelete(amy_fill_buffer_handle);


### PR DESCRIPTION
`esp_render_on_cores()` joins the second-core worker with a plain task
notification on the calling task's default notification index. That counter is
not private to the join: the calling task belongs to the app (with
`multithread = 0` it is whatever task runs `amy_update()`), and pacing such a
task with task notifications is idiomatic FreeRTOS - a timer ISR giving one
notification per audio block, for example. When a tick lands inside the join
window, the join returns on the tick instead of the worker: the caller runs
`amy_fill_buffer()` while the worker is still writing `fbl[1]` and combines a
half-written buffer. The worker's real "done" give then miscounts the app's
next wait, desyncing its clock. It presents as intermittent, load-dependent
garbling that only appears in multicore configs.

This replaces the caller-side join with a dedicated binary semaphore, which
nothing else can signal, and retires `amy_render_task_done_handle`. The worker
kick keeps its notification: the worker task is AMY-internal and nothing else
notifies it.

Indexed notifications (`xTaskNotifyGiveIndexed` on a non-zero index) would
also work but require `configTASK_NOTIFICATION_ARRAY_ENTRIES > 1`, which the
supported cores don't all guarantee; the semaphore is portable.

## Verification

A/B on ESP32-P4 (ESP-IDF 6.1, `multicore=1`, `multithread=0`), with the
`amy_update()` task paced by a GPTimer ISR giving one default-index task
notification per block - the pacing shape described above. To make the
overlap deterministic, the second-core render window was stretched past the
5.33 ms block period so every join spans a tick; a worker-busy flag checked
at join return counts early releases.

- Unpatched join: 23,929 early releases in a 2-minute run (~180/s,
  essentially every block), the first within 3 s of boot, with the expected
  knock-on desync as the join consumes the app's pacing ticks.
- With this patch: zero early releases; a separate 17-minute soak
  (194,000 joins) ran with no deadlock and no missed completion.

Originally observed on ESP32-S3 with the same GPTimer pacing: intermittent,
load-dependent dual-core corruption that stopped once the join no longer
shared the task's notification counter. Compile-verified on ESP32-S3
(ESP-IDF 6.0.2) as well.
