### PR TITLE
examples/AMY_MIDI_Synth: Sequencer is controlled by e.ticks[].

### DIFF
--- a/examples/AMY_MIDI_Synth/AMY_MIDI_Synth.ino
+++ b/examples/AMY_MIDI_Synth/AMY_MIDI_Synth.ino
@@ -27,9 +27,9 @@ void test_polyphony() {
 
 void test_sequencer() {
   amy_event e = amy_default_event();
-  e.sequence[0] = 0;
-  e.sequence[1] = 48;
-  e.sequence[2] = 1;
+  e.ticks[0] = 0;
+  e.ticks[1] = 48;
+  e.ticks[2] = 1;
   e.velocity = 1;
   e.midi_note = 60;
   e.synth = 1;


### PR DESCRIPTION
Somehow this got left behind when we changed the name from sequence[].