### PR TITLE
Rename amy.release to amy.version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ name: Release
 # manual claude/bump-* flow that produced every release to date.
 #
 # WHAT THE BUMP TOUCHES: library.properties (the Arduino version, and the source
-# this workflow reads to compute the next one), amy/__init__.py's `release`
-# string, so `import amy; amy.release` reports the tag that copy shipped in, and
+# this workflow reads to compute the next one), amy/__init__.py's `version`
+# string, so `import amy; amy.version` reports the tag that copy shipped in, and
 # pyproject.toml's `version`, so a pip install reports the same number.
 #
 # WHY THIS DOESN'T LOOP: the bump branch, PR, and merge are all done with the
@@ -132,12 +132,12 @@ jobs:
           branch="bump-$NEXT"
           git switch -c "$branch"
           sed -i -E "s/^version=.*/version=$NEXT/" library.properties
-          # Keep the Python package's amy.release string in lockstep with
-          # library.properties, so `import amy; amy.release` reports the release
+          # Keep the Python package's amy.version string in lockstep with
+          # library.properties, so `import amy; amy.version` reports the release
           # tag this copy shipped in.
-          sed -i -E "s/^release = .*/release = '$NEXT'/" amy/__init__.py
-          grep -q "^release = '$NEXT'\$" amy/__init__.py \
-            || { echo "::error::Failed to bump amy.release in amy/__init__.py" >&2; exit 1; }
+          sed -i -E "s/^version = .*/version = '$NEXT'/" amy/__init__.py
+          grep -q "^version = '$NEXT'\$" amy/__init__.py \
+            || { echo "::error::Failed to bump amy.version in amy/__init__.py" >&2; exit 1; }
           # ...and the version pip reports for the installed package.
           sed -i -E "s/^version = .*/version = \"$NEXT\"/" pyproject.toml
           grep -q "^version = \"$NEXT\"\$" pyproject.toml \

--- a/amy/__init__.py
+++ b/amy/__init__.py
@@ -11,9 +11,9 @@ except ImportError:
 
 # The AMY release this package came from. Kept in sync with library.properties by
 # .github/workflows/release.yml, which rewrites the line below in the same commit
-# it tags -- so amy.release always matches the release tag it shipped in. Edit
+# it tags -- so amy.version always matches the release tag it shipped in. Edit
 # with the workflow, not by hand.
-release = '1.2.161'
+version = '1.2.161'
 
 # BEGIN GENERATED - scripts/gen_amy_c_api.py
 # One backend resolver per C API function: prefer the CPython c_amy


### PR DESCRIPTION
## What

Renames the attribute added in #1143 from `amy.release` to `amy.version`, and moves the release workflow's `sed`/`grep` anchor to match.

```python
>>> import amy; amy.version
'1.2.161'
```

## Why

`amy.release` was the wrong name. `version` is what the other two strings the release workflow bumps already call it — `library.properties`' `version=` and `pyproject.toml`'s `version =` — so all three are now one concept under one name.

## Notes for a reviewer

- **This is a breaking rename, but nothing depends on it yet.** `amy.release` existed only in the release that came out of #1143; there are no in-repo references (checked). `hasattr(amy, 'release')` is now `False`.
- **The attribute and the workflow anchor must move together,** and do: the workflow now seds `^version = ` in `amy/__init__.py` instead of `^release = `. Renaming only the attribute would leave the `sed` matching nothing — caught by its `grep` guard, but as a failed release.
- **The literal stays at `1.2.161`**, the version currently on main, so this doesn't disturb the numbering.
- **All three version anchors are one-per-file** and each `sed` names its own file. An unaddressed substitution rewrites every match, so a future second `version = ` line in `amy/__init__.py` or `pyproject.toml` would get rewritten too.

## Testing

- `python3 -c "import amy; print(amy.version)"` → `1.2.161`
- Ran the renamed `sed` + `grep` pair against a scratch copy with the next version; it rewrote, passed its guard, and the result still parses via `ast`.
- `release.yml` parses via `yaml.safe_load`; no `amy.release` references remain anywhere in the repo.
- The workflow's real behavior was confirmed by the #1143 merge itself, which cut `1.2.161` and correctly bumped all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
