### PR TITLE
Add portable local service transport and Godot lifecycle signals

### DIFF
--- a/.github/workflows/android-unix-socket.yml
+++ b/.github/workflows/android-unix-socket.yml
@@ -1,0 +1,21 @@
+name: Android Unix socket transport
+
+on:
+  pull_request:
+    paths:
+      - 'src/amy_unix_socket.c'
+      - 'src/amy_unix_socket.h'
+      - 'tests/test_amy_unix_socket.c'
+      - 'tests/run_amy_unix_socket_test.sh'
+      - '.github/workflows/android-unix-socket.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  linux-socket-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Compile and run private Unix socket transport test
+        run: bash tests/run_amy_unix_socket_test.sh

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -87,6 +87,9 @@ jobs:
     - name: Validate GDScript parses
       run: gdparse godot/amy.gd
 
+    - name: Test Godot backend lifecycle signals
+      run: python tests/test_godot_backend_signals.py
+
     - name: Check godot/amy.gd is in sync with amy/__init__.py
       run: |
         if ! git diff --quiet -- godot/amy.gd; then

--- a/.github/workflows/unix-socket.yml
+++ b/.github/workflows/unix-socket.yml
@@ -1,4 +1,4 @@
-name: Android Unix socket transport
+name: Unix socket transport
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
       - 'src/amy_unix_socket.h'
       - 'tests/test_amy_unix_socket.c'
       - 'tests/run_amy_unix_socket_test.sh'
-      - '.github/workflows/android-unix-socket.yml'
+      - '.github/workflows/unix-socket.yml'
 
 permissions:
   contents: read
@@ -17,5 +17,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Compile and run private Unix socket transport test
+      - name: Compile and run Unix socket transport test
         run: bash tests/run_amy_unix_socket_test.sh

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ AMY was built by [DAn Ellis](https://research.google/people/DanEllis/) and [Bria
  * [**Distortion in AMY**](docs/distortions.md)
  * [**AMY's MIDI specification**](docs/midi.md)
  * [**AMY in Arduino Getting Started**](docs/arduino.md)
+ * [**Porting AMY and local-service transports**](docs/porting.md)
  * [**Other AMY web demos**](https://shorepine.github.io/amy/)
 
 AMY supports
@@ -175,6 +176,7 @@ It's good to understand what wire messages are but you don't need to construct t
  * [**AMY's MIDI specification**](docs/midi.md)
  * [**AMY in Arduino Getting Started**](docs/arduino.md)
  * [**AMY in Godot**](docs/godot.md)
+ * [**Porting AMY and local-service transports**](docs/porting.md)
  * [**AMY on Windows**](windows/README.md)
  * [**Other AMY web demos**](https://shorepine.github.io/amy/)
 

--- a/docs/godot.md
+++ b/docs/godot.md
@@ -52,8 +52,12 @@ var amy: Amy
 
 func _ready():
     amy = Amy.new()
+    amy.backend_ready.connect(_on_amy_ready)
+    amy.backend_error.connect(_on_amy_error)
     add_child(amy)
-    await get_tree().process_frame  # let AMY initialize
+
+func _on_amy_ready():
+    # The selected backend can now accept messages.
 
     # Play a 440 Hz sine wave
     amy.send({"osc": 0, "wave": Amy.SINE, "freq": 440, "vel": 1.0})
@@ -69,7 +73,15 @@ func _ready():
 
     # Or use wire protocol directly
     amy.send_raw("v3w0f880l0.5")
+
+func _on_amy_error(message: String):
+    push_error(message)
 ```
+
+Connect the signals before `add_child(amy)`: the native backend can become
+ready synchronously during `_ready()`. `backend_ready` is emitted once the
+native or web backend accepts messages. `backend_error(message)` reports a
+missing native extension or a web-backend startup timeout.
 
 ### 4. Configure AMY (optional)
 
@@ -136,6 +148,16 @@ Or run locally: `python3 -m http.server` from your `dist`  folder and go to `loc
 
 - **Web:** AMY runs as its own WASM module with Web Audio API AudioWorklets. The `Amy` GDScript class detects `OS.get_name() == "Web"` and sends wire messages via `JavaScriptBridge` instead of the native extension.
 
+### Android reference implementation
+
+Android is not built or maintained in this repository. A complete external
+[Godot Android service integration](https://github.com/linuxificator/amy/tree/upstream/godot-android)
+demonstrates the same `Amy` Dictionary-to-wire API with AMY running in a
+separate Oboe service process. The lower-level
+[Android Oboe reference](https://github.com/linuxificator/amy/tree/upstream/android-oboe)
+contains the service and private Unix-socket transport. See
+[porting notes](porting.md) for the reusable boundary and verified build flags.
+
 
 ## API Reference
 
@@ -179,6 +201,11 @@ Send a raw AMY wire-protocol message (e.g. `"v0w0f440l1"`).
 ### `amy.panic()`
 
 Stop all sound immediately.
+
+### Signals
+
+- `backend_ready`: the selected backend is ready to accept AMY messages.
+- `backend_error(message)`: backend initialization failed.
 
 ### Constants
 

--- a/docs/porting.md
+++ b/docs/porting.md
@@ -1,0 +1,170 @@
+# Porting AMY and local-service transports
+
+AMY's C engine can run inside an application or in a separate local process.
+The second form is useful when a framework or language should remain a
+wire-protocol client and a small native service should own AMY and the audio
+device.
+
+This page records portable pieces and verified porting results. The complete
+Android, Godot Android, and Windows applications linked below are external
+reference implementations; their platform-specific build trees are not part
+of the core AMY repository.
+
+## Embedding boundary
+
+A native host normally:
+
+1. creates an `amy_config_t` with `amy_default_config()`;
+2. selects the host's audio and MIDI ownership before calling `amy_start()`;
+3. delivers complete AMY wire messages through `amy_add_message()` at a safe
+   control or render boundary;
+4. obtains audio with `amy_simple_fill_buffer()` when the host owns rendering;
+5. calls `amy_stop()` during shutdown.
+
+Keep blocking IPC away from the realtime audio callback. If a receiver thread
+accepts commands, move them through a bounded queue and let the AMY/audio owner
+drain that queue between render blocks.
+
+## Linux/Android packet transport
+
+`src/amy_unix_socket.[ch]` implements a local pathname `AF_UNIX` /
+`SOCK_SEQPACKET` server for Linux and Android. It is transport-only: its thread
+does not call AMY.
+
+The server provides:
+
+- one logical request per packet, up to `MAX_MESSAGE_LEN - 1` bytes;
+- a fixed 64-packet single-producer/single-consumer queue;
+- one connected client at a time;
+- pathname mode `0600` and same-effective-UID peer checks with `SO_PEERCRED`;
+- refusal to replace a live listener or remove a non-socket/reused pathname;
+- non-blocking dequeue and reply calls;
+- counters for queue overruns, oversized packets, and rejected clients.
+
+The render owner can drain commands immediately before a new AMY block:
+
+```c
+char message[MAX_MESSAGE_LEN];
+for (;;) {
+    int length = amy_unix_socket_receive(server, message, sizeof(message));
+    if (length <= 0) break;
+    amy_add_message(message);
+}
+```
+
+`amy_unix_socket_send()` supports replies from a non-realtime control/status
+path. It must not be called from the audio callback.
+
+Run the AddressSanitizer/UndefinedBehaviorSanitizer host regression on Linux:
+
+```bash
+bash tests/run_amy_unix_socket_test.sh
+```
+
+The test covers maximum and oversized packets, non-consuming `EMSGSIZE`, queue
+ordering/overrun behavior, connection replacement/rejection, reconnects,
+permissions, active/stale paths, and safe shutdown cleanup.
+
+On unsupported platforms these functions return `-ENOTSUP`. A stream or
+platform-native IPC adapter can preserve the same higher-level rule: one
+complete AMY wire request is delivered to the AMY owner at a safe boundary.
+
+## Verified Android NDK recipe
+
+The external [Android Oboe service reference][android-oboe] demonstrates that
+the AMY core compiles for Android NDK without changes to its synthesis sources.
+That build uses:
+
+```text
+AMY_DAISY=1
+AMY_HOST_MIDI=1
+AMY_NO_MINIAUDIO=1
+AMY_WAVETABLE=1
+```
+
+`AMY_DAISY` selects AMY's existing 48 kHz / 128-frame profile.
+`AMY_NO_MINIAUDIO` lets Oboe own audio, and `AMY_HOST_MIDI` lets the service
+supply the MIDI lifecycle hooks. The Oboe callback calls
+`amy_simple_fill_buffer()` only when it needs another AMY block and drains the
+socket queue before that block.
+
+One declaration-only compatibility header is force-included in the C
+translation units so `pcm.c` sees allocators already supplied by `delay.c`
+under `AMY_DAISY`:
+
+```c
+#include <stddef.h>
+
+void *qspi_malloc(size_t size);
+void qspi_free(void *ptr);
+```
+
+Do not link a second allocator implementation.
+
+The Android audio-level regression also caught an important gain detail:
+AMY's `V` bus/master control is a `0..10` scale, and final mixdown multiplies
+it by `0.1`. Therefore `V2.0` is 20% linear gain, while `V10.0` is full master
+gain. This differs from oscillator velocity/amplitude and per-synth `iV`.
+
+The reference branch includes the Gradle AAR, private `:amy` service, Oboe
+adapter, transport-only Java client, emulator tests, and captured AMY-to-Oboe
+audio comparison. Those framework-specific files remain outside the core AMY
+tree.
+
+## Godot lifecycle and Android reference
+
+The shared `godot/amy.gd` wrapper exposes two platform-independent signals:
+
+- `backend_ready`, emitted after the selected native or web backend can accept
+  messages;
+- `backend_error(message)`, emitted if backend initialization fails.
+
+Connect them before adding the `Amy` node to the scene tree, because a native
+backend may become ready synchronously:
+
+```gdscript
+var amy := Amy.new()
+amy.backend_ready.connect(func(): amy.send({"osc": 0, "note": 60, "vel": 1}))
+amy.backend_error.connect(func(message: String): push_error(message))
+add_child(amy)
+```
+
+The external [Godot Android reference][godot-android] uses the same signals and
+Dictionary-to-wire encoder while keeping AMY in the separate Android service.
+It contains the AAR packaging example and Android emulator validation. The
+Android backend itself is not part of the core Godot addon.
+
+## Verified Windows named-pipe adapter
+
+Windows local IPC did not require changes to AMY. The native
+[LB Omnichord Windows service][windows-service] compiles the normal AMY C
+sources and implements the transport entirely in its host wrapper:
+
+- `CreateNamedPipeA()` creates one private byte-mode pipe instance with
+  `PIPE_REJECT_REMOTE_CLIENTS`;
+- the [launcher][windows-launcher] supplies a unique per-run pipe name and
+  publishes readiness only after the pipe and AMY exist;
+- the [Qt client][windows-client] uses `QLocalSocket` and writes LF-framed
+  records because a Windows named pipe is a byte stream rather than a
+  `SOCK_SEQPACKET` endpoint;
+- the service buffers partial/multiple `ReadFile()` results, requires each
+  completed request to end in `Z`, then calls `amy_add_message()`;
+- AMY remains in a separate native service process and owns miniaudio output.
+
+The [Windows build target][windows-cmake], [packaging regression][windows-test],
+and [Windows Server 2025 release test][windows-ci] compile the service, run an
+offline `amy_simple_fill_buffer()` self-test, and exercise the packaged
+Qt-to-pipe-to-AMY boundary. These hosted tests prove compilation, command
+delivery, non-silent offline rendering, and process cleanup; they do not prove
+physical audio, MIDI, latency, or dropout behavior. See the [full Windows
+design and validation notes][windows-doc] for those limits.
+
+[android-oboe]: https://github.com/linuxificator/amy/tree/upstream/android-oboe
+[godot-android]: https://github.com/linuxificator/amy/tree/upstream/godot-android
+[windows-service]: https://github.com/linuxificator/LB_Omnichord/blob/387776cffad7394c1fcf6add1ced5d3e69a8d382/amysynth_version/qt_frontend/packaging/windows/amy_service.c
+[windows-launcher]: https://github.com/linuxificator/LB_Omnichord/blob/387776cffad7394c1fcf6add1ced5d3e69a8d382/amysynth_version/qt_frontend/packaging/windows/run_windows.ps1
+[windows-client]: https://github.com/linuxificator/LB_Omnichord/blob/387776cffad7394c1fcf6add1ced5d3e69a8d382/amysynth_version/qt_frontend/code/amy_transport.py
+[windows-cmake]: https://github.com/linuxificator/LB_Omnichord/blob/387776cffad7394c1fcf6add1ced5d3e69a8d382/amysynth_version/qt_frontend/packaging/windows/CMakeLists.txt
+[windows-test]: https://github.com/linuxificator/LB_Omnichord/blob/387776cffad7394c1fcf6add1ced5d3e69a8d382/amysynth_version/qt_frontend/tests/test_packaging.py
+[windows-ci]: https://github.com/linuxificator/LB_Omnichord/blob/387776cffad7394c1fcf6add1ced5d3e69a8d382/.github/workflows/desktop-release.yml
+[windows-doc]: https://github.com/linuxificator/LB_Omnichord/blob/387776cffad7394c1fcf6add1ced5d3e69a8d382/amysynth_version/qt_frontend/docs/WINDOWS_NATIVE.md

--- a/docs/porting.md
+++ b/docs/porting.md
@@ -25,6 +25,14 @@ Keep blocking IPC away from the realtime audio callback. If a receiver thread
 accepts commands, move them through a bounded queue and let the AMY/audio owner
 drain that queue between render blocks.
 
+Do not assume that a platform audio callback requests exactly one AMY render
+block. A host adapter should retain a cursor into the current AMY block, copy
+only the number of frames requested by the platform, and call
+`amy_simple_fill_buffer()` only after that block has been consumed. Drain
+queued control messages immediately before rendering the next AMY block so a
+command is never applied halfway through one block. This needs no additional
+full-block output ring.
+
 ## Linux/Android packet transport
 
 `src/amy_unix_socket.[ch]` implements a local pathname `AF_UNIX` /
@@ -88,6 +96,14 @@ supply the MIDI lifecycle hooks. The Oboe callback calls
 `amy_simple_fill_buffer()` only when it needs another AMY block and drains the
 socket queue before that block.
 
+An Android service and its client can remain separate processes while sharing
+one application UID. Put the pathname below the actual application-private
+`Context.getFilesDir()` and have the client discover that directory at runtime;
+do not hard-code `/data/user/...` or an Android user number. If the service
+publishes the socket only after audio has started, retrying `connect()` provides
+a readiness boundary without a fixed startup sleep. Clients should also
+reconnect after their application lifecycle restarts them.
+
 One declaration-only compatibility header is force-included in the C
 translation units so `pcm.c` sees allocators already supplied by `delay.c`
 under `AMY_DAISY`:
@@ -104,12 +120,30 @@ Do not link a second allocator implementation.
 The Android audio-level regression also caught an important gain detail:
 AMY's `V` bus/master control is a `0..10` scale, and final mixdown multiplies
 it by `0.1`. Therefore `V2.0` is 20% linear gain, while `V10.0` is full master
-gain. This differs from oscillator velocity/amplitude and per-synth `iV`.
+gain. This differs from oscillator velocity/amplitude and per-synth `iV`. A
+non-silence threshold must therefore be derived from the messages and patch
+used by that application rather than treated as a universal AMY dBFS value.
+
+For an end-to-end audio regression, a successful application launch or host
+audio log is not enough. A Linux-hosted Android emulator can mention its own
+PulseAudio device even while the guest service uses Oboe/AAudio. Check the
+guest output route, capture both the samples rendered by AMY and those handed
+to the platform callback, and compare them while independently rejecting
+silence and clipping. Emulator coverage proves build, packaging, process
+isolation, wire delivery, and digital audio flow; physical-device latency,
+xruns, speakers, suspend/resume, and audio-route changes still need hardware
+tests.
 
 The reference branch includes the Gradle AAR, private `:amy` service, Oboe
 adapter, transport-only Java client, emulator tests, and captured AMY-to-Oboe
 audio comparison. Those framework-specific files remain outside the core AMY
 tree.
+
+The same external boundary is exercised by the fork's current
+[Android integration branch][android-integration] and by a released
+[PySide6/Qt application package][qt-android-package]. The Qt deployment,
+Buildozer/python-for-android workarounds, first-run extraction warm-up, and APK
+signing remain downstream packaging concerns rather than AMY requirements.
 
 ## Godot lifecycle and Android reference
 
@@ -160,7 +194,9 @@ physical audio, MIDI, latency, or dropout behavior. See the [full Windows
 design and validation notes][windows-doc] for those limits.
 
 [android-oboe]: https://github.com/linuxificator/amy/tree/upstream/android-oboe
+[android-integration]: https://github.com/linuxificator/amy/tree/integration/amy_android
 [godot-android]: https://github.com/linuxificator/amy/tree/upstream/godot-android
+[qt-android-package]: https://github.com/linuxificator/LB_Omnichord/blob/f8724328b2e679533c7f3b97cee939e009b7eba7/amysynth_version/qt_frontend/packaging/android/README.md
 [windows-service]: https://github.com/linuxificator/LB_Omnichord/blob/387776cffad7394c1fcf6add1ced5d3e69a8d382/amysynth_version/qt_frontend/packaging/windows/amy_service.c
 [windows-launcher]: https://github.com/linuxificator/LB_Omnichord/blob/387776cffad7394c1fcf6add1ced5d3e69a8d382/amysynth_version/qt_frontend/packaging/windows/run_windows.ps1
 [windows-client]: https://github.com/linuxificator/LB_Omnichord/blob/387776cffad7394c1fcf6add1ced5d3e69a8d382/amysynth_version/qt_frontend/code/amy_transport.py

--- a/godot/amy.gd
+++ b/godot/amy.gd
@@ -14,6 +14,11 @@ extends Node
 ## Or use wire protocol directly:
 ##   amy.send_raw("v0w0f440l1")
 
+## Emitted after the selected native or web backend is ready for messages.
+signal backend_ready
+## Emitted when the selected backend cannot initialize.
+signal backend_error(message: String)
+
 # ============================================================
 #  Wave types
 # ============================================================
@@ -103,7 +108,9 @@ func _init_native() -> void:
 		_synth = ClassDB.instantiate(&"AmySynth")
 		add_child(_synth)
 	else:
-		push_warning("AmySynth GDExtension not loaded — audio disabled")
+		var message := "AmySynth GDExtension not loaded — audio disabled"
+		push_warning(message)
+		backend_error.emit(message)
 		return
 
 	# Apply config before starting
@@ -132,6 +139,7 @@ func _init_native() -> void:
 	_stream_player.play()
 	_playback = _stream_player.get_stream_playback() as AudioStreamGeneratorPlayback
 	_started = true
+	backend_ready.emit()
 
 func _init_web() -> void:
 	# Pass config to JS bridge before AMY starts
@@ -144,9 +152,12 @@ func _init_web() -> void:
 		if ready:
 			_started = true
 			print("AMY web synth ready")
+			backend_ready.emit()
 			return
 		await get_tree().create_timer(0.1).timeout
-	push_warning("AMY web module failed to load after 10 s")
+	var message := "AMY web module failed to load after 10 s"
+	push_warning(message)
+	backend_error.emit(message)
 
 func _process(_delta: float) -> void:
 	if _started and not _is_web:

--- a/src/amy_unix_socket.c
+++ b/src/amy_unix_socket.c
@@ -1,0 +1,447 @@
+#define _GNU_SOURCE
+
+#include "amy_unix_socket.h"
+
+#if defined(__linux__) || defined(__ANDROID__)
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
+#define AMY_UNIX_SOCKET_POLL_MS 50
+
+struct amy_unix_socket_packet {
+    uint16_t len;
+    char data[MAX_MESSAGE_LEN];
+};
+
+struct amy_unix_socket_server {
+    int listen_fd;
+    int client_fd;
+    pthread_t thread;
+    pthread_mutex_t client_lock;
+    bool thread_started;
+    volatile uint32_t running;
+
+    char path[sizeof(((struct sockaddr_un *)0)->sun_path)];
+
+    struct amy_unix_socket_packet queue[AMY_UNIX_SOCKET_QUEUE_CAPACITY];
+    volatile uint32_t write_index;
+    volatile uint32_t read_index;
+
+    volatile uint32_t queue_overruns;
+    volatile uint32_t oversize_packets;
+    volatile uint32_t rejected_peers;
+};
+
+static uint32_t load_u32(const volatile uint32_t *value) {
+    return __atomic_load_n(value, __ATOMIC_ACQUIRE);
+}
+
+static void store_u32(volatile uint32_t *value, uint32_t new_value) {
+    __atomic_store_n(value, new_value, __ATOMIC_RELEASE);
+}
+
+static void increment_u32(volatile uint32_t *value) {
+    __atomic_add_fetch(value, 1u, __ATOMIC_RELAXED);
+}
+
+static int set_nonblocking_cloexec(int fd) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0) return -errno;
+    if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) return -errno;
+
+    flags = fcntl(fd, F_GETFD, 0);
+    if (flags < 0) return -errno;
+    if (fcntl(fd, F_SETFD, flags | FD_CLOEXEC) < 0) return -errno;
+    return 0;
+}
+
+static int remove_owned_stale_socket(const char *path) {
+    struct stat st;
+    if (lstat(path, &st) < 0) {
+        return errno == ENOENT ? 0 : -errno;
+    }
+
+    if (!S_ISSOCK(st.st_mode)) return -EEXIST;
+    if (st.st_uid != geteuid()) return -EPERM;
+    if (unlink(path) < 0) return -errno;
+    return 0;
+}
+
+static bool peer_has_same_uid(int fd) {
+    struct ucred cred;
+    socklen_t len = sizeof(cred);
+    if (getsockopt(fd, SOL_SOCKET, SO_PEERCRED, &cred, &len) < 0) {
+        return false;
+    }
+    return cred.uid == geteuid();
+}
+
+static void close_client_locked(amy_unix_socket_server_t *server) {
+    if (server->client_fd >= 0) {
+        shutdown(server->client_fd, SHUT_RDWR);
+        close(server->client_fd);
+        server->client_fd = -1;
+    }
+}
+
+static void close_client(amy_unix_socket_server_t *server) {
+    pthread_mutex_lock(&server->client_lock);
+    close_client_locked(server);
+    pthread_mutex_unlock(&server->client_lock);
+}
+
+static void queue_packet(amy_unix_socket_server_t *server,
+                         const char *data,
+                         size_t len) {
+    if (len == 0) return;
+    if (len > AMY_UNIX_SOCKET_MAX_PACKET) {
+        increment_u32(&server->oversize_packets);
+        return;
+    }
+
+    uint32_t write_index = load_u32(&server->write_index);
+    uint32_t read_index = load_u32(&server->read_index);
+    if ((uint32_t)(write_index - read_index) >=
+        AMY_UNIX_SOCKET_QUEUE_CAPACITY) {
+        increment_u32(&server->queue_overruns);
+        return;
+    }
+
+    struct amy_unix_socket_packet *slot =
+        &server->queue[write_index % AMY_UNIX_SOCKET_QUEUE_CAPACITY];
+    memcpy(slot->data, data, len);
+    slot->data[len] = '\0';
+    slot->len = (uint16_t)len;
+
+    store_u32(&server->write_index, write_index + 1u);
+}
+
+static void receive_client_packets(amy_unix_socket_server_t *server,
+                                   int client_fd) {
+    for (;;) {
+        char packet[MAX_MESSAGE_LEN];
+        ssize_t received = recv(client_fd,
+                                packet,
+                                sizeof(packet),
+                                MSG_DONTWAIT | MSG_TRUNC);
+        if (received > 0) {
+            if ((size_t)received > AMY_UNIX_SOCKET_MAX_PACKET) {
+                increment_u32(&server->oversize_packets);
+            } else {
+                queue_packet(server, packet, (size_t)received);
+            }
+            continue;
+        }
+
+        if (received == 0) {
+            close_client(server);
+            return;
+        }
+
+        if (errno == EAGAIN || errno == EWOULDBLOCK) return;
+        if (errno == EINTR) continue;
+
+        close_client(server);
+        return;
+    }
+}
+
+static void accept_clients(amy_unix_socket_server_t *server) {
+    for (;;) {
+        int fd = accept(server->listen_fd, NULL, NULL);
+        if (fd < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) return;
+            if (errno == EINTR) continue;
+            return;
+        }
+
+        if (set_nonblocking_cloexec(fd) < 0 || !peer_has_same_uid(fd)) {
+            increment_u32(&server->rejected_peers);
+            close(fd);
+            continue;
+        }
+
+        pthread_mutex_lock(&server->client_lock);
+        if (server->client_fd >= 0) {
+            increment_u32(&server->rejected_peers);
+            close(fd);
+        } else {
+            server->client_fd = fd;
+        }
+        pthread_mutex_unlock(&server->client_lock);
+    }
+}
+
+static int current_client_fd(amy_unix_socket_server_t *server) {
+    int fd;
+    pthread_mutex_lock(&server->client_lock);
+    fd = server->client_fd;
+    pthread_mutex_unlock(&server->client_lock);
+    return fd;
+}
+
+static void *socket_thread(void *arg) {
+    amy_unix_socket_server_t *server =
+        (amy_unix_socket_server_t *)arg;
+
+    while (load_u32(&server->running)) {
+        struct pollfd fds[2];
+        nfds_t count = 1;
+
+        fds[0].fd = server->listen_fd;
+        fds[0].events = POLLIN;
+        fds[0].revents = 0;
+
+        int client_fd = current_client_fd(server);
+        if (client_fd >= 0) {
+            fds[1].fd = client_fd;
+            fds[1].events = POLLIN;
+            fds[1].revents = 0;
+            count = 2;
+        }
+
+        int ready = poll(fds, count, AMY_UNIX_SOCKET_POLL_MS);
+        if (ready < 0) {
+            if (errno == EINTR) continue;
+            break;
+        }
+        if (ready == 0) continue;
+
+        if (fds[0].revents & POLLIN) accept_clients(server);
+
+        if (count == 2) {
+            if (fds[1].revents & POLLIN) {
+                receive_client_packets(server, client_fd);
+            }
+            if (fds[1].revents & (POLLERR | POLLHUP | POLLNVAL)) {
+                close_client(server);
+            }
+        }
+    }
+
+    close_client(server);
+    return NULL;
+}
+
+int amy_unix_socket_start(amy_unix_socket_server_t **out_server,
+                          const char *path) {
+    if (out_server == NULL || path == NULL || path[0] == '\0') return -EINVAL;
+    *out_server = NULL;
+
+    size_t path_len = strlen(path);
+    if (path_len >= sizeof(((struct sockaddr_un *)0)->sun_path)) {
+        return -ENAMETOOLONG;
+    }
+
+    int rc = remove_owned_stale_socket(path);
+    if (rc < 0) return rc;
+
+    amy_unix_socket_server_t *server = calloc(1, sizeof(*server));
+    if (server == NULL) return -ENOMEM;
+
+    server->listen_fd = -1;
+    server->client_fd = -1;
+    memcpy(server->path, path, path_len + 1u);
+
+    int mutex_rc = pthread_mutex_init(&server->client_lock, NULL);
+    if (mutex_rc != 0) {
+        free(server);
+        return -mutex_rc;
+    }
+
+    int fd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    if (fd < 0) {
+        rc = -errno;
+        goto fail;
+    }
+    server->listen_fd = fd;
+
+    rc = set_nonblocking_cloexec(fd);
+    if (rc < 0) goto fail;
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    memcpy(addr.sun_path, path, path_len + 1u);
+
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        rc = -errno;
+        goto fail;
+    }
+
+    // The Android app-data parent directory is already sandboxed. Mode 0600
+    // additionally makes filesystem pathname access same-UID only.
+    if (chmod(path, S_IRUSR | S_IWUSR) < 0) {
+        rc = -errno;
+        goto fail;
+    }
+
+    if (listen(fd, 1) < 0) {
+        rc = -errno;
+        goto fail;
+    }
+
+    store_u32(&server->running, 1u);
+    int thread_rc = pthread_create(&server->thread, NULL,
+                                   socket_thread, server);
+    if (thread_rc != 0) {
+        rc = -thread_rc;
+        store_u32(&server->running, 0u);
+        goto fail;
+    }
+    server->thread_started = true;
+
+    *out_server = server;
+    return 0;
+
+fail:
+    if (server->listen_fd >= 0) close(server->listen_fd);
+    if (server->path[0] != '\0') unlink(server->path);
+    pthread_mutex_destroy(&server->client_lock);
+    free(server);
+    return rc;
+}
+
+void amy_unix_socket_stop(amy_unix_socket_server_t *server) {
+    if (server == NULL) return;
+
+    store_u32(&server->running, 0u);
+    if (server->thread_started) {
+        pthread_join(server->thread, NULL);
+    }
+
+    if (server->listen_fd >= 0) {
+        close(server->listen_fd);
+        server->listen_fd = -1;
+    }
+
+    if (server->path[0] != '\0') unlink(server->path);
+    pthread_mutex_destroy(&server->client_lock);
+    free(server);
+}
+
+int amy_unix_socket_receive(amy_unix_socket_server_t *server,
+                            char *out,
+                            size_t out_len) {
+    if (server == NULL || out == NULL) return -EINVAL;
+
+    uint32_t read_index = load_u32(&server->read_index);
+    uint32_t write_index = load_u32(&server->write_index);
+    if (read_index == write_index) return 0;
+
+    const struct amy_unix_socket_packet *slot =
+        &server->queue[read_index % AMY_UNIX_SOCKET_QUEUE_CAPACITY];
+    size_t len = slot->len;
+    if (out_len <= len) return -EMSGSIZE;
+
+    memcpy(out, slot->data, len);
+    out[len] = '\0';
+    store_u32(&server->read_index, read_index + 1u);
+    return (int)len;
+}
+
+int amy_unix_socket_send(amy_unix_socket_server_t *server,
+                         const void *data,
+                         size_t len) {
+    if (server == NULL || (data == NULL && len != 0)) return -EINVAL;
+    if (len > AMY_UNIX_SOCKET_MAX_PACKET) return -EMSGSIZE;
+
+    pthread_mutex_lock(&server->client_lock);
+    int fd = server->client_fd;
+    if (fd < 0) {
+        pthread_mutex_unlock(&server->client_lock);
+        return -ENOTCONN;
+    }
+
+    ssize_t sent = send(fd, data, len,
+                        MSG_DONTWAIT | MSG_NOSIGNAL);
+    int saved_errno = errno;
+    pthread_mutex_unlock(&server->client_lock);
+
+    if (sent < 0) return -saved_errno;
+    return (int)sent;
+}
+
+uint32_t amy_unix_socket_queue_overruns(
+    const amy_unix_socket_server_t *server) {
+    return server == NULL ? 0u : load_u32(&server->queue_overruns);
+}
+
+uint32_t amy_unix_socket_oversize_packets(
+    const amy_unix_socket_server_t *server) {
+    return server == NULL ? 0u : load_u32(&server->oversize_packets);
+}
+
+uint32_t amy_unix_socket_rejected_peers(
+    const amy_unix_socket_server_t *server) {
+    return server == NULL ? 0u : load_u32(&server->rejected_peers);
+}
+
+#else
+
+#include <errno.h>
+
+int amy_unix_socket_start(amy_unix_socket_server_t **out_server,
+                          const char *path) {
+    (void)out_server;
+    (void)path;
+    return -ENOTSUP;
+}
+
+void amy_unix_socket_stop(amy_unix_socket_server_t *server) {
+    (void)server;
+}
+
+int amy_unix_socket_receive(amy_unix_socket_server_t *server,
+                            char *out,
+                            size_t out_len) {
+    (void)server;
+    (void)out;
+    (void)out_len;
+    return -ENOTSUP;
+}
+
+int amy_unix_socket_send(amy_unix_socket_server_t *server,
+                         const void *data,
+                         size_t len) {
+    (void)server;
+    (void)data;
+    (void)len;
+    return -ENOTSUP;
+}
+
+uint32_t amy_unix_socket_queue_overruns(
+    const amy_unix_socket_server_t *server) {
+    (void)server;
+    return 0u;
+}
+
+uint32_t amy_unix_socket_oversize_packets(
+    const amy_unix_socket_server_t *server) {
+    (void)server;
+    return 0u;
+}
+
+uint32_t amy_unix_socket_rejected_peers(
+    const amy_unix_socket_server_t *server) {
+    (void)server;
+    return 0u;
+}
+
+#endif

--- a/src/amy_unix_socket.c
+++ b/src/amy_unix_socket.c
@@ -38,6 +38,9 @@ struct amy_unix_socket_server {
     volatile uint32_t running;
 
     char path[sizeof(((struct sockaddr_un *)0)->sun_path)];
+    dev_t path_device;
+    ino_t path_inode;
+    bool path_bound;
 
     struct amy_unix_socket_packet queue[AMY_UNIX_SOCKET_QUEUE_CAPACITY];
     volatile uint32_t write_index;
@@ -71,6 +74,13 @@ static int set_nonblocking_cloexec(int fd) {
     return 0;
 }
 
+static void fill_socket_address(struct sockaddr_un *addr, const char *path) {
+    size_t path_len = strlen(path);
+    memset(addr, 0, sizeof(*addr));
+    addr->sun_family = AF_UNIX;
+    memcpy(addr->sun_path, path, path_len + 1u);
+}
+
 static int remove_owned_stale_socket(const char *path) {
     struct stat st;
     if (lstat(path, &st) < 0) {
@@ -79,8 +89,54 @@ static int remove_owned_stale_socket(const char *path) {
 
     if (!S_ISSOCK(st.st_mode)) return -EEXIST;
     if (st.st_uid != geteuid()) return -EPERM;
+
+    // Do not steal the pathname from a live same-UID server. A pathname socket
+    // left behind after a crash refuses a connection; a listening server
+    // accepts it. The short-lived probe may be accepted and immediately see
+    // EOF, but it cannot replace or interrupt an existing client.
+    int probe_fd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    if (probe_fd < 0) return -errno;
+
+    struct sockaddr_un addr;
+    fill_socket_address(&addr, path);
+    int connect_rc = connect(probe_fd, (struct sockaddr *)&addr, sizeof(addr));
+    int connect_errno = errno;
+    close(probe_fd);
+
+    if (connect_rc == 0) return -EADDRINUSE;
+    if (connect_errno == ENOENT) return 0;
+    if (connect_errno != ECONNREFUSED) return -connect_errno;
+
     if (unlink(path) < 0) return -errno;
     return 0;
+}
+
+static int remember_bound_socket(amy_unix_socket_server_t *server) {
+    struct stat st;
+    if (lstat(server->path, &st) < 0) return -errno;
+    if (!S_ISSOCK(st.st_mode) || st.st_uid != geteuid()) return -EPERM;
+
+    server->path_device = st.st_dev;
+    server->path_inode = st.st_ino;
+    server->path_bound = true;
+    return 0;
+}
+
+static void remove_bound_socket(amy_unix_socket_server_t *server) {
+    if (!server->path_bound) return;
+
+    // Only unlink the exact filesystem node created by this server. This
+    // avoids deleting a regular file or a replacement socket if the pathname
+    // was removed and reused while the server was running.
+    struct stat st;
+    if (lstat(server->path, &st) == 0 &&
+        S_ISSOCK(st.st_mode) &&
+        st.st_uid == geteuid() &&
+        st.st_dev == server->path_device &&
+        st.st_ino == server->path_inode) {
+        unlink(server->path);
+    }
+    server->path_bound = false;
 }
 
 static bool peer_has_same_uid(int fd) {
@@ -276,14 +332,15 @@ int amy_unix_socket_start(amy_unix_socket_server_t **out_server,
     if (rc < 0) goto fail;
 
     struct sockaddr_un addr;
-    memset(&addr, 0, sizeof(addr));
-    addr.sun_family = AF_UNIX;
-    memcpy(addr.sun_path, path, path_len + 1u);
+    fill_socket_address(&addr, path);
 
     if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
         rc = -errno;
         goto fail;
     }
+
+    rc = remember_bound_socket(server);
+    if (rc < 0) goto fail;
 
     // The Android app-data parent directory is already sandboxed. Mode 0600
     // additionally makes filesystem pathname access same-UID only.
@@ -312,7 +369,7 @@ int amy_unix_socket_start(amy_unix_socket_server_t **out_server,
 
 fail:
     if (server->listen_fd >= 0) close(server->listen_fd);
-    if (server->path[0] != '\0') unlink(server->path);
+    remove_bound_socket(server);
     pthread_mutex_destroy(&server->client_lock);
     free(server);
     return rc;
@@ -331,7 +388,7 @@ void amy_unix_socket_stop(amy_unix_socket_server_t *server) {
         server->listen_fd = -1;
     }
 
-    if (server->path[0] != '\0') unlink(server->path);
+    remove_bound_socket(server);
     pthread_mutex_destroy(&server->client_lock);
     free(server);
 }

--- a/src/amy_unix_socket.h
+++ b/src/amy_unix_socket.h
@@ -1,0 +1,70 @@
+#ifndef AMY_UNIX_SOCKET_H
+#define AMY_UNIX_SOCKET_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "amy.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Private pathname AF_UNIX transport for local AMY control.
+//
+// Intended Android topology:
+//   Qt/Python process <-> amy.sock <-> native AMY/Oboe process
+//
+// The socket thread never calls AMY. It only copies complete SOCK_SEQPACKET
+// packets into this fixed SPSC queue. The audio/control owner drains packets
+// explicitly at a safe point (for example, immediately before rendering the
+// next AMY block) and may then pass them to amy_add_message().
+//
+// One connected client is supported at a time. On Linux/Android, accepted
+// peers must have the same effective UID as the server process. The pathname
+// is created mode 0600 and a stale socket is removed only when it is owned by
+// the same UID; an existing non-socket path is never removed.
+
+#define AMY_UNIX_SOCKET_QUEUE_CAPACITY 64u
+#define AMY_UNIX_SOCKET_MAX_PACKET ((size_t)MAX_MESSAGE_LEN - 1u)
+
+typedef struct amy_unix_socket_server amy_unix_socket_server_t;
+
+// Start a server at path. Returns 0 on success or -errno on failure.
+// out_server is set only on success.
+int amy_unix_socket_start(amy_unix_socket_server_t **out_server,
+                          const char *path);
+
+// Stop the receiver thread, close any client, unlink the socket pathname and
+// free the server. Safe to call with NULL.
+void amy_unix_socket_stop(amy_unix_socket_server_t *server);
+
+// Non-blocking dequeue for the AMY/control owner.
+// Returns payload length (>0), 0 when no packet is queued, or -errno.
+// On success out is NUL-terminated; packet payloads themselves need not carry
+// a trailing NUL. If out_len is too small, returns -EMSGSIZE and leaves the
+// packet queued.
+int amy_unix_socket_receive(amy_unix_socket_server_t *server,
+                            char *out,
+                            size_t out_len);
+
+// Send one reply packet to the currently connected client. This is intended
+// for non-realtime status/introspection replies, not the audio callback.
+// Returns bytes sent or -errno. The accepted client socket is non-blocking.
+int amy_unix_socket_send(amy_unix_socket_server_t *server,
+                         const void *data,
+                         size_t len);
+
+// Diagnostic counters. They are monotonic until the server is stopped.
+uint32_t amy_unix_socket_queue_overruns(
+    const amy_unix_socket_server_t *server);
+uint32_t amy_unix_socket_oversize_packets(
+    const amy_unix_socket_server_t *server);
+uint32_t amy_unix_socket_rejected_peers(
+    const amy_unix_socket_server_t *server);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // AMY_UNIX_SOCKET_H

--- a/src/amy_unix_socket.h
+++ b/src/amy_unix_socket.h
@@ -12,8 +12,8 @@ extern "C" {
 
 // Private pathname AF_UNIX transport for local AMY control.
 //
-// Intended Android topology:
-//   Qt/Python process <-> amy.sock <-> native AMY/Oboe process
+// Typical service topology:
+//   application process <-> amy.sock <-> native AMY/audio process
 //
 // The socket thread never calls AMY. It only copies complete SOCK_SEQPACKET
 // packets into this fixed SPSC queue. The audio/control owner drains packets
@@ -22,8 +22,9 @@ extern "C" {
 //
 // One connected client is supported at a time. On Linux/Android, accepted
 // peers must have the same effective UID as the server process. The pathname
-// is created mode 0600 and a stale socket is removed only when it is owned by
-// the same UID; an existing non-socket path is never removed.
+// is created mode 0600. A stale socket is removed only when it is owned by the
+// same UID and refuses a connection; a live listener, an existing non-socket
+// path, and any pathname that replaces the running server's node are preserved.
 
 #define AMY_UNIX_SOCKET_QUEUE_CAPACITY 64u
 #define AMY_UNIX_SOCKET_MAX_PACKET ((size_t)MAX_MESSAGE_LEN - 1u)

--- a/tests/run_amy_unix_socket_test.sh
+++ b/tests/run_amy_unix_socket_test.sh
@@ -2,19 +2,24 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
-out="${TMPDIR:-/tmp}/test_amy_unix_socket"
+out="$(mktemp "${TMPDIR:-/tmp}/amy-unix-socket-test.XXXXXX")"
+trap 'rm -f "$out"' EXIT
 
 cc \
   -std=c11 \
-  -O2 \
+  -O1 \
+  -g \
   -Wall \
   -Wextra \
   -Werror \
   -pthread \
+  -fsanitize=address,undefined \
+  -fno-omit-frame-pointer \
   -I"$repo_root/src" \
   "$repo_root/src/amy_unix_socket.c" \
   "$repo_root/tests/test_amy_unix_socket.c" \
   -o "$out"
 
-"$out"
-rm -f "$out"
+ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1 \
+  "$out"

--- a/tests/run_amy_unix_socket_test.sh
+++ b/tests/run_amy_unix_socket_test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+out="${TMPDIR:-/tmp}/test_amy_unix_socket"
+
+cc \
+  -std=c11 \
+  -O2 \
+  -Wall \
+  -Wextra \
+  -Werror \
+  -pthread \
+  -I"$repo_root/src" \
+  "$repo_root/src/amy_unix_socket.c" \
+  "$repo_root/tests/test_amy_unix_socket.c" \
+  -o "$out"
+
+"$out"
+rm -f "$out"

--- a/tests/test_amy_unix_socket.c
+++ b/tests/test_amy_unix_socket.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13,16 +14,28 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
+#define WAIT_STEPS 2000
+#define WAIT_US 1000
+
+typedef uint32_t (*counter_fn)(const amy_unix_socket_server_t *server);
+
+static void socket_address(struct sockaddr_un *addr, const char *path) {
+    memset(addr, 0, sizeof(*addr));
+    addr->sun_family = AF_UNIX;
+    assert(strlen(path) < sizeof(addr->sun_path));
+    strcpy(addr->sun_path, path);
+}
+
 static int connect_client(const char *path) {
     int fd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
     assert(fd >= 0);
 
     struct sockaddr_un addr;
-    memset(&addr, 0, sizeof(addr));
-    addr.sun_family = AF_UNIX;
-    assert(strlen(path) < sizeof(addr.sun_path));
-    strcpy(addr.sun_path, path);
-
+    socket_address(&addr, path);
     assert(connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
     return fd;
 }
@@ -30,35 +43,104 @@ static int connect_client(const char *path) {
 static int wait_receive(amy_unix_socket_server_t *server,
                         char *buffer,
                         size_t buffer_len) {
-    for (int i = 0; i < 1000; ++i) {
+    for (int i = 0; i < WAIT_STEPS; ++i) {
         int rc = amy_unix_socket_receive(server, buffer, buffer_len);
         if (rc != 0) return rc;
-        usleep(1000);
+        usleep(WAIT_US);
     }
     return -ETIMEDOUT;
 }
 
 static ssize_t wait_client_receive(int fd, void *buffer, size_t len) {
-    for (int i = 0; i < 1000; ++i) {
+    for (int i = 0; i < WAIT_STEPS; ++i) {
         ssize_t rc = recv(fd, buffer, len, MSG_DONTWAIT);
         if (rc >= 0) return rc;
         if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
             return -1;
         }
-        usleep(1000);
+        usleep(WAIT_US);
     }
     errno = ETIMEDOUT;
     return -1;
 }
 
-static void test_round_trip_and_permissions(void) {
-    char dir_template[] = "/tmp/amy-unix-socket-XXXXXX";
+static void wait_counter(counter_fn counter,
+                         amy_unix_socket_server_t *server,
+                         uint32_t expected) {
+    for (int i = 0; i < WAIT_STEPS; ++i) {
+        if (counter(server) >= expected) return;
+        usleep(WAIT_US);
+    }
+    assert(counter(server) >= expected);
+}
+
+static void wait_until_disconnected(amy_unix_socket_server_t *server) {
+    const char probe[] = "x";
+    for (int i = 0; i < WAIT_STEPS; ++i) {
+        int rc = amy_unix_socket_send(server, probe, sizeof(probe) - 1u);
+        if (rc == -ENOTCONN) return;
+        assert(rc == (int)(sizeof(probe) - 1u) || rc == -EPIPE ||
+               rc == -ECONNRESET);
+        usleep(WAIT_US);
+    }
+    assert(amy_unix_socket_send(server, probe, sizeof(probe) - 1u) ==
+           -ENOTCONN);
+}
+
+static void make_temp_path(char *dir_template,
+                           char *path,
+                           size_t path_len) {
     char *dir = mkdtemp(dir_template);
     assert(dir != NULL);
     assert(chmod(dir, 0700) == 0);
+    int written = snprintf(path, path_len, "%s/amy.sock", dir);
+    assert(written > 0 && (size_t)written < path_len);
+}
 
+static void remove_temp_dir(const char *path) {
+    char dir[256];
+    size_t len = strlen(path);
+    assert(len < sizeof(dir));
+    memcpy(dir, path, len + 1u);
+    char *slash = strrchr(dir, '/');
+    assert(slash != NULL);
+    *slash = '\0';
+    assert(rmdir(dir) == 0);
+}
+
+static void send_packet(int fd, const void *data, size_t len) {
+    assert(send(fd, data, len, MSG_NOSIGNAL) == (ssize_t)len);
+}
+
+static void test_invalid_arguments(void) {
+    char output[MAX_MESSAGE_LEN];
+    amy_unix_socket_server_t *server = NULL;
+
+    assert(amy_unix_socket_start(NULL, "/tmp/unused.sock") == -EINVAL);
+    assert(amy_unix_socket_start(&server, NULL) == -EINVAL);
+    assert(amy_unix_socket_start(&server, "") == -EINVAL);
+
+    char long_path[512];
+    memset(long_path, 'x', sizeof(long_path));
+    long_path[0] = '/';
+    long_path[sizeof(long_path) - 1u] = '\0';
+    assert(amy_unix_socket_start(&server, long_path) == -ENAMETOOLONG);
+    assert(server == NULL);
+
+    assert(amy_unix_socket_receive(NULL, output, sizeof(output)) == -EINVAL);
+    assert(amy_unix_socket_receive(NULL, NULL, 0) == -EINVAL);
+    assert(amy_unix_socket_send(NULL, "x", 1) == -EINVAL);
+    assert(amy_unix_socket_send(NULL, NULL, 0) == -EINVAL);
+    assert(amy_unix_socket_queue_overruns(NULL) == 0);
+    assert(amy_unix_socket_oversize_packets(NULL) == 0);
+    assert(amy_unix_socket_rejected_peers(NULL) == 0);
+    amy_unix_socket_stop(NULL);
+}
+
+static void test_round_trip_limits_and_permissions(void) {
+    char dir_template[] = "/tmp/amy-unix-roundtrip-XXXXXX";
     char path[256];
-    snprintf(path, sizeof(path), "%s/amy.sock", dir);
+    make_temp_path(dir_template, path, sizeof(path));
 
     amy_unix_socket_server_t *server = NULL;
     assert(amy_unix_socket_start(&server, path) == 0);
@@ -69,63 +151,58 @@ static void test_round_trip_and_permissions(void) {
     assert(S_ISSOCK(st.st_mode));
     assert((st.st_mode & 0777) == 0600);
     assert(st.st_uid == geteuid());
+    assert(amy_unix_socket_send(server, "x", 1) == -ENOTCONN);
 
     int client = connect_client(path);
-
     const char command[] = "n60l1i2Z";
-    assert(send(client, command, strlen(command), 0) ==
-           (ssize_t)strlen(command));
+    send_packet(client, command, strlen(command));
 
     char received[MAX_MESSAGE_LEN];
     int rc = wait_receive(server, received, sizeof(received));
     assert(rc == (int)strlen(command));
     assert(strcmp(received, command) == 0);
 
-    // Too-small destination must not consume the next queued packet.
+    // A too-small destination leaves the packet at the head of the queue.
     const char second[] = "K28i2Z";
-    assert(send(client, second, strlen(second), 0) ==
-           (ssize_t)strlen(second));
-    for (int i = 0; i < 1000; ++i) {
+    send_packet(client, second, strlen(second));
+    for (int i = 0; i < WAIT_STEPS; ++i) {
         rc = amy_unix_socket_receive(server, received, 4);
         if (rc != 0) break;
-        usleep(1000);
+        usleep(WAIT_US);
     }
     assert(rc == -EMSGSIZE);
     rc = amy_unix_socket_receive(server, received, sizeof(received));
     assert(rc == (int)strlen(second));
     assert(strcmp(received, second) == 0);
 
-    const char reply[] = "!iv1";
-    for (int i = 0; i < 1000; ++i) {
-        rc = amy_unix_socket_send(server, reply, strlen(reply));
-        if (rc != -ENOTCONN) break;
-        usleep(1000);
-    }
-    assert(rc == (int)strlen(reply));
+    char maximum[MAX_MESSAGE_LEN];
+    memset(maximum, 'm', AMY_UNIX_SOCKET_MAX_PACKET);
+    send_packet(client, maximum, AMY_UNIX_SOCKET_MAX_PACKET);
+    rc = wait_receive(server, received, sizeof(received));
+    assert(rc == (int)AMY_UNIX_SOCKET_MAX_PACKET);
+    assert(memcmp(received, maximum, AMY_UNIX_SOCKET_MAX_PACKET) == 0);
+    assert(received[AMY_UNIX_SOCKET_MAX_PACKET] == '\0');
 
-    char reply_buffer[32];
-    ssize_t reply_len = wait_client_receive(client,
-                                            reply_buffer,
-                                            sizeof(reply_buffer));
-    assert(reply_len == (ssize_t)strlen(reply));
-    assert(memcmp(reply_buffer, reply, strlen(reply)) == 0);
+    assert(amy_unix_socket_send(server, maximum, MAX_MESSAGE_LEN) ==
+           -EMSGSIZE);
+    rc = amy_unix_socket_send(server, maximum, AMY_UNIX_SOCKET_MAX_PACKET);
+    assert(rc == (int)AMY_UNIX_SOCKET_MAX_PACKET);
+
+    char reply[MAX_MESSAGE_LEN];
+    ssize_t reply_len = wait_client_receive(client, reply, sizeof(reply));
+    assert(reply_len == (ssize_t)AMY_UNIX_SOCKET_MAX_PACKET);
+    assert(memcmp(reply, maximum, AMY_UNIX_SOCKET_MAX_PACKET) == 0);
 
     close(client);
     amy_unix_socket_stop(server);
-
-    assert(lstat(path, &st) < 0);
-    assert(errno == ENOENT);
-    assert(rmdir(dir) == 0);
+    assert(lstat(path, &st) < 0 && errno == ENOENT);
+    remove_temp_dir(path);
 }
 
 static void test_oversize_packet_is_dropped(void) {
     char dir_template[] = "/tmp/amy-unix-oversize-XXXXXX";
-    char *dir = mkdtemp(dir_template);
-    assert(dir != NULL);
-    assert(chmod(dir, 0700) == 0);
-
     char path[256];
-    snprintf(path, sizeof(path), "%s/amy.sock", dir);
+    make_temp_path(dir_template, path, sizeof(path));
 
     amy_unix_socket_server_t *server = NULL;
     assert(amy_unix_socket_start(&server, path) == 0);
@@ -133,12 +210,8 @@ static void test_oversize_packet_is_dropped(void) {
 
     char packet[MAX_MESSAGE_LEN];
     memset(packet, 'x', sizeof(packet));
-    assert(send(client, packet, sizeof(packet), 0) == (ssize_t)sizeof(packet));
-
-    for (int i = 0; i < 1000; ++i) {
-        if (amy_unix_socket_oversize_packets(server) != 0) break;
-        usleep(1000);
-    }
+    send_packet(client, packet, sizeof(packet));
+    wait_counter(amy_unix_socket_oversize_packets, server, 1);
     assert(amy_unix_socket_oversize_packets(server) == 1);
 
     char received[MAX_MESSAGE_LEN];
@@ -146,17 +219,134 @@ static void test_oversize_packet_is_dropped(void) {
 
     close(client);
     amy_unix_socket_stop(server);
-    assert(rmdir(dir) == 0);
+    remove_temp_dir(path);
+}
+
+static void test_queue_is_bounded_and_ordered(void) {
+    char dir_template[] = "/tmp/amy-unix-queue-XXXXXX";
+    char path[256];
+    make_temp_path(dir_template, path, sizeof(path));
+
+    amy_unix_socket_server_t *server = NULL;
+    assert(amy_unix_socket_start(&server, path) == 0);
+    int client = connect_client(path);
+
+    const uint32_t extra = 8;
+    for (uint32_t i = 0; i < AMY_UNIX_SOCKET_QUEUE_CAPACITY + extra; ++i) {
+        char packet[32];
+        int len = snprintf(packet, sizeof(packet), "packet-%03u", i);
+        assert(len > 0 && (size_t)len < sizeof(packet));
+        send_packet(client, packet, (size_t)len);
+    }
+
+    wait_counter(amy_unix_socket_queue_overruns, server, extra);
+    assert(amy_unix_socket_queue_overruns(server) == extra);
+
+    for (uint32_t i = 0; i < AMY_UNIX_SOCKET_QUEUE_CAPACITY; ++i) {
+        char expected[32];
+        int expected_len = snprintf(expected, sizeof(expected),
+                                    "packet-%03u", i);
+        char received[MAX_MESSAGE_LEN];
+        int rc = amy_unix_socket_receive(server, received, sizeof(received));
+        assert(rc == expected_len);
+        assert(strcmp(received, expected) == 0);
+    }
+
+    char received[MAX_MESSAGE_LEN];
+    assert(amy_unix_socket_receive(server, received, sizeof(received)) == 0);
+    close(client);
+    amy_unix_socket_stop(server);
+    remove_temp_dir(path);
+}
+
+static void test_only_one_client_and_reconnect(void) {
+    char dir_template[] = "/tmp/amy-unix-clients-XXXXXX";
+    char path[256];
+    make_temp_path(dir_template, path, sizeof(path));
+
+    amy_unix_socket_server_t *server = NULL;
+    assert(amy_unix_socket_start(&server, path) == 0);
+    int first = connect_client(path);
+
+    char received[MAX_MESSAGE_LEN];
+    send_packet(first, "first", 5);
+    assert(wait_receive(server, received, sizeof(received)) == 5);
+    assert(strcmp(received, "first") == 0);
+
+    int rejected = connect_client(path);
+    wait_counter(amy_unix_socket_rejected_peers, server, 1);
+    assert(amy_unix_socket_rejected_peers(server) == 1);
+
+    // Rejecting a second connection must not disturb the established client.
+    send_packet(first, "still-first", 11);
+    assert(wait_receive(server, received, sizeof(received)) == 11);
+    assert(strcmp(received, "still-first") == 0);
+    close(rejected);
+
+    close(first);
+    wait_until_disconnected(server);
+
+    int second = connect_client(path);
+    send_packet(second, "second", 6);
+    assert(wait_receive(server, received, sizeof(received)) == 6);
+    assert(strcmp(received, "second") == 0);
+
+    close(second);
+    amy_unix_socket_stop(server);
+    remove_temp_dir(path);
+}
+
+static void test_live_socket_is_not_stolen(void) {
+    char dir_template[] = "/tmp/amy-unix-live-XXXXXX";
+    char path[256];
+    make_temp_path(dir_template, path, sizeof(path));
+
+    amy_unix_socket_server_t *first_server = NULL;
+    assert(amy_unix_socket_start(&first_server, path) == 0);
+    int client = connect_client(path);
+    send_packet(client, "before", 6);
+
+    char received[MAX_MESSAGE_LEN];
+    assert(wait_receive(first_server, received, sizeof(received)) == 6);
+
+    amy_unix_socket_server_t *second_server = NULL;
+    assert(amy_unix_socket_start(&second_server, path) == -EADDRINUSE);
+    assert(second_server == NULL);
+
+    send_packet(client, "after", 5);
+    assert(wait_receive(first_server, received, sizeof(received)) == 5);
+    assert(strcmp(received, "after") == 0);
+
+    close(client);
+    amy_unix_socket_stop(first_server);
+    remove_temp_dir(path);
+}
+
+static void test_owned_stale_socket_is_replaced(void) {
+    char dir_template[] = "/tmp/amy-unix-stale-XXXXXX";
+    char path[256];
+    make_temp_path(dir_template, path, sizeof(path));
+
+    int stale = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    assert(stale >= 0);
+    struct sockaddr_un addr;
+    socket_address(&addr, path);
+    assert(bind(stale, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    close(stale);
+
+    amy_unix_socket_server_t *server = NULL;
+    assert(amy_unix_socket_start(&server, path) == 0);
+    amy_unix_socket_stop(server);
+
+    struct stat st;
+    assert(lstat(path, &st) < 0 && errno == ENOENT);
+    remove_temp_dir(path);
 }
 
 static void test_existing_regular_file_is_never_removed(void) {
-    char dir_template[] = "/tmp/amy-unix-stale-XXXXXX";
-    char *dir = mkdtemp(dir_template);
-    assert(dir != NULL);
-    assert(chmod(dir, 0700) == 0);
-
+    char dir_template[] = "/tmp/amy-unix-file-XXXXXX";
     char path[256];
-    snprintf(path, sizeof(path), "%s/amy.sock", dir);
+    make_temp_path(dir_template, path, sizeof(path));
 
     int fd = open(path, O_CREAT | O_WRONLY | O_EXCL, 0600);
     assert(fd >= 0);
@@ -169,15 +359,42 @@ static void test_existing_regular_file_is_never_removed(void) {
     struct stat st;
     assert(lstat(path, &st) == 0);
     assert(S_ISREG(st.st_mode));
-
     assert(unlink(path) == 0);
-    assert(rmdir(dir) == 0);
+    remove_temp_dir(path);
+}
+
+static void test_stop_preserves_replacement_path(void) {
+    char dir_template[] = "/tmp/amy-unix-replaced-XXXXXX";
+    char path[256];
+    make_temp_path(dir_template, path, sizeof(path));
+
+    amy_unix_socket_server_t *server = NULL;
+    assert(amy_unix_socket_start(&server, path) == 0);
+    assert(unlink(path) == 0);
+
+    int fd = open(path, O_CREAT | O_WRONLY | O_EXCL, 0600);
+    assert(fd >= 0);
+    close(fd);
+
+    amy_unix_socket_stop(server);
+
+    struct stat st;
+    assert(lstat(path, &st) == 0);
+    assert(S_ISREG(st.st_mode));
+    assert(unlink(path) == 0);
+    remove_temp_dir(path);
 }
 
 int main(void) {
-    test_round_trip_and_permissions();
+    test_invalid_arguments();
+    test_round_trip_limits_and_permissions();
     test_oversize_packet_is_dropped();
+    test_queue_is_bounded_and_ordered();
+    test_only_one_client_and_reconnect();
+    test_live_socket_is_not_stolen();
+    test_owned_stale_socket_is_replaced();
     test_existing_regular_file_is_never_removed();
+    test_stop_preserves_replacement_path();
     puts("amy unix socket tests passed");
     return 0;
 }

--- a/tests/test_amy_unix_socket.c
+++ b/tests/test_amy_unix_socket.c
@@ -1,0 +1,183 @@
+#define _GNU_SOURCE
+
+#include "amy_unix_socket.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+static int connect_client(const char *path) {
+    int fd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    assert(fd >= 0);
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    assert(strlen(path) < sizeof(addr.sun_path));
+    strcpy(addr.sun_path, path);
+
+    assert(connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    return fd;
+}
+
+static int wait_receive(amy_unix_socket_server_t *server,
+                        char *buffer,
+                        size_t buffer_len) {
+    for (int i = 0; i < 1000; ++i) {
+        int rc = amy_unix_socket_receive(server, buffer, buffer_len);
+        if (rc != 0) return rc;
+        usleep(1000);
+    }
+    return -ETIMEDOUT;
+}
+
+static ssize_t wait_client_receive(int fd, void *buffer, size_t len) {
+    for (int i = 0; i < 1000; ++i) {
+        ssize_t rc = recv(fd, buffer, len, MSG_DONTWAIT);
+        if (rc >= 0) return rc;
+        if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
+            return -1;
+        }
+        usleep(1000);
+    }
+    errno = ETIMEDOUT;
+    return -1;
+}
+
+static void test_round_trip_and_permissions(void) {
+    char dir_template[] = "/tmp/amy-unix-socket-XXXXXX";
+    char *dir = mkdtemp(dir_template);
+    assert(dir != NULL);
+    assert(chmod(dir, 0700) == 0);
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/amy.sock", dir);
+
+    amy_unix_socket_server_t *server = NULL;
+    assert(amy_unix_socket_start(&server, path) == 0);
+    assert(server != NULL);
+
+    struct stat st;
+    assert(lstat(path, &st) == 0);
+    assert(S_ISSOCK(st.st_mode));
+    assert((st.st_mode & 0777) == 0600);
+    assert(st.st_uid == geteuid());
+
+    int client = connect_client(path);
+
+    const char command[] = "n60l1i2Z";
+    assert(send(client, command, strlen(command), 0) ==
+           (ssize_t)strlen(command));
+
+    char received[MAX_MESSAGE_LEN];
+    int rc = wait_receive(server, received, sizeof(received));
+    assert(rc == (int)strlen(command));
+    assert(strcmp(received, command) == 0);
+
+    // Too-small destination must not consume the next queued packet.
+    const char second[] = "K28i2Z";
+    assert(send(client, second, strlen(second), 0) ==
+           (ssize_t)strlen(second));
+    for (int i = 0; i < 1000; ++i) {
+        rc = amy_unix_socket_receive(server, received, 4);
+        if (rc != 0) break;
+        usleep(1000);
+    }
+    assert(rc == -EMSGSIZE);
+    rc = amy_unix_socket_receive(server, received, sizeof(received));
+    assert(rc == (int)strlen(second));
+    assert(strcmp(received, second) == 0);
+
+    const char reply[] = "!iv1";
+    for (int i = 0; i < 1000; ++i) {
+        rc = amy_unix_socket_send(server, reply, strlen(reply));
+        if (rc != -ENOTCONN) break;
+        usleep(1000);
+    }
+    assert(rc == (int)strlen(reply));
+
+    char reply_buffer[32];
+    ssize_t reply_len = wait_client_receive(client,
+                                            reply_buffer,
+                                            sizeof(reply_buffer));
+    assert(reply_len == (ssize_t)strlen(reply));
+    assert(memcmp(reply_buffer, reply, strlen(reply)) == 0);
+
+    close(client);
+    amy_unix_socket_stop(server);
+
+    assert(lstat(path, &st) < 0);
+    assert(errno == ENOENT);
+    assert(rmdir(dir) == 0);
+}
+
+static void test_oversize_packet_is_dropped(void) {
+    char dir_template[] = "/tmp/amy-unix-oversize-XXXXXX";
+    char *dir = mkdtemp(dir_template);
+    assert(dir != NULL);
+    assert(chmod(dir, 0700) == 0);
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/amy.sock", dir);
+
+    amy_unix_socket_server_t *server = NULL;
+    assert(amy_unix_socket_start(&server, path) == 0);
+    int client = connect_client(path);
+
+    char packet[MAX_MESSAGE_LEN];
+    memset(packet, 'x', sizeof(packet));
+    assert(send(client, packet, sizeof(packet), 0) == (ssize_t)sizeof(packet));
+
+    for (int i = 0; i < 1000; ++i) {
+        if (amy_unix_socket_oversize_packets(server) != 0) break;
+        usleep(1000);
+    }
+    assert(amy_unix_socket_oversize_packets(server) == 1);
+
+    char received[MAX_MESSAGE_LEN];
+    assert(amy_unix_socket_receive(server, received, sizeof(received)) == 0);
+
+    close(client);
+    amy_unix_socket_stop(server);
+    assert(rmdir(dir) == 0);
+}
+
+static void test_existing_regular_file_is_never_removed(void) {
+    char dir_template[] = "/tmp/amy-unix-stale-XXXXXX";
+    char *dir = mkdtemp(dir_template);
+    assert(dir != NULL);
+    assert(chmod(dir, 0700) == 0);
+
+    char path[256];
+    snprintf(path, sizeof(path), "%s/amy.sock", dir);
+
+    int fd = open(path, O_CREAT | O_WRONLY | O_EXCL, 0600);
+    assert(fd >= 0);
+    close(fd);
+
+    amy_unix_socket_server_t *server = NULL;
+    assert(amy_unix_socket_start(&server, path) == -EEXIST);
+    assert(server == NULL);
+
+    struct stat st;
+    assert(lstat(path, &st) == 0);
+    assert(S_ISREG(st.st_mode));
+
+    assert(unlink(path) == 0);
+    assert(rmdir(dir) == 0);
+}
+
+int main(void) {
+    test_round_trip_and_permissions();
+    test_oversize_packet_is_dropped();
+    test_existing_regular_file_is_never_removed();
+    puts("amy unix socket tests passed");
+    return 0;
+}

--- a/tests/test_godot_backend_signals.py
+++ b/tests/test_godot_backend_signals.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Static regression for Amy.gd's platform-independent backend lifecycle."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AMY_GD = ROOT / "godot" / "amy.gd"
+
+
+def function_body(source: str, name: str) -> str:
+    lines = source.splitlines()
+    signature = f"func {name}("
+    start = next(
+        index for index, line in enumerate(lines) if line.startswith(signature)
+    )
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if line and not line.startswith(("\t", " ")):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+class GodotBackendSignalContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = AMY_GD.read_text(encoding="utf-8")
+
+    def test_public_signal_signatures_are_stable(self) -> None:
+        self.assertEqual(self.source.count("signal backend_ready\n"), 1)
+        self.assertEqual(
+            self.source.count("signal backend_error(message: String)\n"), 1
+        )
+
+    def test_native_backend_reports_success_and_failure(self) -> None:
+        body = function_body(self.source, "_init_native")
+        self.assertIn('var message := "AmySynth GDExtension not loaded', body)
+        self.assertIn("backend_error.emit(message)", body)
+        self.assertIn("_started = true", body)
+        self.assertIn("backend_ready.emit()", body)
+        self.assertLess(
+            body.index("_started = true"), body.index("backend_ready.emit()")
+        )
+
+    def test_web_backend_reports_success_and_timeout(self) -> None:
+        body = function_body(self.source, "_init_web")
+        self.assertIn("_started = true", body)
+        self.assertIn("backend_ready.emit()", body)
+        self.assertIn('var message := "AMY web module failed to load', body)
+        self.assertIn("backend_error.emit(message)", body)
+        self.assertLess(
+            body.index("_started = true"), body.index("backend_ready.emit()")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This is the reduced, portable replacement requested in the review of #1136. It supersedes #1136 and #1138 without bringing their Android projects into AMY.

- add a Linux/Android `AF_UNIX` / `SOCK_SEQPACKET` transport that only moves complete wire messages through a bounded SPSC queue; it never calls AMY from its receiver thread
- expose platform-independent `backend_ready` and `backend_error(message)` signals in the existing Godot wrapper
- document the verified Android NDK build flags, declaration-only allocator header, and `V2.0` versus `V10.0` master-volume scale
- document service-host integration on Linux/Android and the external Windows named-pipe implementation
- link the complete Android Oboe and Godot Android implementations in the fork instead of adding framework-specific build trees here

Full reference implementations:

- https://github.com/linuxificator/amy/tree/upstream/android-oboe
- https://github.com/linuxificator/amy/tree/upstream/godot-android

## Deliberately excluded

No Android Gradle project, Oboe service, app example, Godot Android project, or emulator workflow is included. Those remain external references, as requested.

The Windows named-pipe transport also stays external because its native service uses AMY's existing public embedding calls without modifying AMY core. The porting guide links its exact service, launcher, Qt client, build target, regression, and release workflow revision.

## Validation

- `bash tests/run_amy_unix_socket_test.sh` (ASan + UBSan)
- `make ctest`
- `AMY_TEST_THRESHOLD_DB=-70.0 make test PYTHON=/tmp/amy-test-venv/bin/python` (133 tests, matching upstream CI threshold)
- `python3 tests/test_godot_backend_signals.py`
- `gdparse godot/amy.gd`
- `make godot-api`
- `make check-c-api`
- `git diff --check upstream/main...HEAD`

The socket regression covers packet boundaries and maximum size, oversize drops, non-consuming `EMSGSIZE`, bounded-queue ordering and overrun accounting, permissions, client rejection and reconnect, live/stale path handling, and safe pathname cleanup.
