### PR TITLE
Ensure M_PI defined, don't track forgotten notes under IGNORE_NOTE_OFFS

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -206,7 +206,7 @@ amy_start(amy_config);
 | `max_sequencer_tags` | Int | 256 | How many sequencer items to handle |
 | `max_voices` | Int | 64 | How many voices |
 | `max_synths` | Int | 64 | How many synths |
-| `max_memory_patches` | Int | 32 | How many in memory patches to supprot |
+| `max_memory_patches` | Int | 32 | How many in memory patches to support |
 | `i2s_lrc`, `i2s_dout`, `i2s_din`, `i2s_bclk`, `i2s_mclk` | Int | -1 | Pin numbers for the I2S interface |
 | `midi_out`, `midi_in` | Int | -1 | Pin number for the MIDI UART pins |
 | `midi_uart` | 0,1,[2] | -1 | UART device index for MCU. Default 1 (`UART1`) on Pi Pico and ESP. Teensy is always `8` |

--- a/src/instrument.c
+++ b/src/instrument.c
@@ -223,6 +223,10 @@ void instrument_free(struct instrument_info *instrument) {
 }
 
 void _instrument_push_note_forgotten(struct instrument_info *instrument, uint16_t note) {
+    if (instrument->flags & SYNTH_FLAGS_IGNORE_NOTE_OFFS) {
+        // Don't track forgotten notes if we're ignoring note_offs anyway.
+        return;
+    }
     int available_index = -1;
     for (int i = 0; i < FORGOTTEN_POOL_SIZE; ++i) {
         if (instrument->forgotten_notes[i] == note) {
@@ -295,7 +299,8 @@ uint16_t instrument_note_off(struct instrument_info *instrument, uint16_t note) 
     uint16_t voice = _instrument_voice_for_note(instrument, note);
     if (voice == _INSTRUMENT_NO_VOICE) {
         // Don't report an unmatched note-off if it was a victim of stealing.
-        if (!_instrument_pop_note_forgotten(instrument, note)
+        if (!(instrument->flags & SYNTH_FLAGS_IGNORE_NOTE_OFFS)
+            && !_instrument_pop_note_forgotten(instrument, note)
             && !(instrument->flags & SYNTH_FLAGS_NO_NOTE_WARNINGS))
             fprintf(stderr, "note off for %d/%d does not match note on\n", note / 128, note & 0x7F);
         //instrument_debug(instrument);
@@ -551,6 +556,11 @@ uint32_t instrument_get_flags(int instrument_number) {
 void instrument_set_flags(int instrument_number, uint32_t flags) {
     if (!instrument_number_exists(instrument_number, "set_flags")) return;
     struct instrument_info *instrument = instruments[instrument_number];
+    if ((flags & SYNTH_FLAGS_IGNORE_NOTE_OFFS)
+        && !(instrument->flags & SYNTH_FLAGS_IGNORE_NOTE_OFFS)) {
+        // Forgotten pool is not used, make sure it's empty.
+        _instrument_reset_forgotten_pool(instrument);
+    }
     instrument->flags = flags;
 }
 

--- a/src/pcm.c
+++ b/src/pcm.c
@@ -3,6 +3,10 @@
 #include "amy.h"
 #include "transfer.h"
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 #ifdef __EMSCRIPTEN__
 #include "emscripten.h"
 #endif


### PR DESCRIPTION
Two minor problems reported by @linuxificator:
 - `M_PI` is not defined for some Windows builds, define it conditionally.
 - the `note_forgotten` pool tended to overflow in `SYNTH_FLAGS_IGNORE_NOTE_OFFS` contexts; disable it then.
